### PR TITLE
Fix tag URIs in metadata schemas and add test coverage

### DIFF
--- a/src/rad/resources/schemas/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/common-1.0.0.yaml
@@ -79,34 +79,33 @@ properties:
       destination: [ScienceCommon.telescope]
   # Meta Objects
   aperture:
-    tag: "tag:stsci.edu:datamodels/roman/aperture-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/aperture-1.0.0
   cal_step:
-    tag: "tag:stsci.edu:datamodels/roman/cal_step-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
   coordinates:
-    tag: "tag:stsci.edu:datamodels/roman/coordinates-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
   ephemeris:
-    tag: "tag:stsci.edu:datamodels/roman/ephemeris-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.0.0
   exposure:
-    tag: "tag:stsci.edu:datamodels/roman/exposure-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
   instrument:
-    tag: "tag:stsci.edu:datamodels/roman/wfi_mode-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
   observation:
-    tag: "tag:stsci.edu:datamodels/roman/observation-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
   photometry:
-    tag: "tag:stsci.edu:datamodels/roman/photometry-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
   pointing:
-    tag: "tag:stsci.edu:datamodels/roman/pointing-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.0.0
   program:
-   tag: "tag:stsci.edu:datamodels/roman/program-1.0.0"
+   tag: asdf://stsci.edu/datamodels/roman/tags/program-1.0.0
   target:
-    tag: "tag:stsci.edu:datamodels/roman/target-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/target-1.0.0
   velocity_aberration:
-    tag: "tag:stsci.edu:datamodels/roman/velocity_aberration-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
   visit:
-    tag: "tag:stsci.edu:datamodels/roman/visit-1.0.0"
+    tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.0.0
   wcsinfo:
-    tag: "tag:stsci.edu:datamodels/roman/wcsinfo-1.0.0"
-flowStyle: block
+    tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.0.0
 required: [calibration_software_version, filename, file_date,
            model_type, origin, prd_software_version, telescope,
            aperture, cal_step, coordinates, ephemeris, exposure,

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -27,8 +27,6 @@ properties:
         title: Name of the filter or optical element used
         type: string
         enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, DARK, ENGINEERING]
-    # propertyOrder: [name, detector, optical_element]
-    flowStyle: block
     required: [name, detector, optical_element]
   reftype:
     title: Reference file type
@@ -47,7 +45,5 @@ properties:
   useafter:
     title: Use after date of the reference file
     tag: tag:stsci.edu:asdf/time/time-1.1.0
-# propertyOrder: [telescope, instrument, reftype, pedigree, description, author, useafter]
-flowStyle: block
 required: [telescope, instrument, reftype, pedigree, description, author, useafter]
 ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import asdf
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="session")
+def manifest():
+    return yaml.safe_load(
+        asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"]
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,15 +3,6 @@ Test that the manifest file is correctly structured and refers
 to schemas that exist.
 """
 import asdf
-import pytest
-import yaml
-
-
-@pytest.fixture
-def manifest():
-    return yaml.safe_load(
-        asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"]
-    )
 
 
 def test_manifest_valid(manifest):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands=
 deps=
     flake8
 commands=
-    flake8 --count src
+    flake8 --count src tests
 
 [testenv:bandit]
 deps=


### PR DESCRIPTION
I discovered some bugs (and corresponding gaps in test coverage) when testing latest rad with roman_datamodels.  This PR fixes both.