### PR TITLE
Import roman cal schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@
 
 - Added misc. required db keyword attributes. [JIRA RAD-7]
 
+- Imported all remaining schema files from romancal [JIRA RCAL-144, RCAL-245]
+
+- Updated optical element to add new filter and remove engineering. [#6]
+
+- Removed misc. unneeded keywords and added survey attribute. [JIRA RAD-8]
+
   
 0.1.0 (unreleased)
 ==================

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -9,6 +9,21 @@ asdf_standard_requirement:
   gte: 1.1.0
 tags:
 # Object Modules
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/gls_rampfit-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/gls_rampfit-1.0.0
+  title: Optional output for GLS ramp fitting
+  description: |-
+    Optional output for GLS ramp fitting
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.0.0
+  title: Ramp schema
+  description: |-
+    Ramp schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/rampfitoutput-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/rampfitoutput-1.0.0
+  title: Ramp fit output schema
+  description: |-
+    Ramp fit output schema
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.0.0
   title: Roman WFI Raw Science Data datamodel
@@ -24,57 +39,78 @@ tags:
   title: Roman WFI Instrument Mode
   description: |-
     Roman WFI Instrument
+# Helper Object Modules
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/dq_def-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/dq_def-1.0.0
+  title: DQ Flag definition schema
+  description: |-
+    DQ Flag definition schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/group-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/group-1.0.0
+  title: Group parameter schema
+  description: |-
+    Group parameter schema
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/pixelarea-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/pixelarea-1.0.0
   title: Pixel area array
   description: |-
     The schema for the pixel area array
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/variance-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/variance-1.0.0
+  title: An object that is required to include the variance arrays.
+  description: |-
+    An object that is required to include the variance arrays.
 # Metadata Modules
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0
-  title: Exposure information
-  description: |-
-    Exposure information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/program-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/program-1.0.0
-  title: Xprogram information
-  description: |-
-    Xprogram information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
-  title: Observation information
-  description: |-
-    Observation information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ephemeris-1.0.0
-  title: Ephemeris information
-  description: |-
-    Ephemeris information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.0.0
-  title: Visit information
-  description: |-
-    Visit information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/photometry-1.0.0
-  title: Photometry information
-  description: |-
-    Photometry information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/coordinates-1.0.0
-  title: Coordinate frame information
-  description: |-
-    Coordinate frame information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/aperture-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/aperture-1.0.0
   title: Aperture information
   description: |-
     Aperture information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/cal_step-1.0.0
+  title: Calibration Step status information
+  description: |-
+    Calibration Step status information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/coordinates-1.0.0
+  title: Coordinate frame information
+  description: |-
+    Coordinate frame information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ephemeris-1.0.0
+  title: Ephemeris information
+  description: |-
+    Ephemeris information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0
+  title: Exposure information
+  description: |-
+    Exposure information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.0.0
+  title: Guidestar information
+  description: |-
+    Guidestar information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
+  title: Observation information
+  description: |-
+    Observation information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/photometry-1.0.0
+  title: Photometry information
+  description: |-
+    Photometry information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/pointing-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/pointing-1.0.0
   title: Spacecraft Pointing information
   description: |-
     Spacecraft Pointing information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/program-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/program-1.0.0
+  title: Program information
+  description: |-
+    Program information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/target-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/target-1.0.0
   title: Target information
@@ -85,25 +121,51 @@ tags:
   title: Velocity aberration information
   description: |-
     Velocity aberration information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.0.0
+  title: Visit information
+  description: |-
+    Visit information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wcsinfo-1.0.0
   title: Wcsinfo information
   description: |-
     Wcsinfo information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.0.0
-  title: Guidestar information
+# Reference Metadata Module
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ref_common-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+  title: Common reference metadata properties
   description: |-
-    Guidestar information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/cal_step-1.0.0
-  title: Calibration Step status information
-  description: |-
-    Calibration Step status information
+    Common reference metadata properties
 # Reference Modules
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
+  title: Dark reference schema
+  description: |-
+    Dark reference schema
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.0.0
-  title: flat field information
+  title: Flat reference schema
   description: |-
-    flat field information
+    Flat reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+  title: Gain reference schema
+  description: |-
+    Gain reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+  title: DQ Mask reference schema
+  description: |-
+    DQ Mask reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+  title: Read noise reference schema
+  description: |-
+    Read noise reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0.0
+  title: WFI imaging photometric flux conversion data model
+  description: |-
+    WFI imaging photometric flux conversion data model
 ...

--- a/src/rad/resources/schemas/aperture-1.0.0.yaml
+++ b/src/rad/resources/schemas/aperture-1.0.0.yaml
@@ -16,16 +16,6 @@ properties:
     archive_catalog:
       datatype: nvarchar(40)
       destination: [ScienceCommon.aperture_name]
-  pss_name:
-    title: Original AperName supplied by PSS
-    type: string
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-      archive_catalog:
-        datatype: nvarchar(40)
-        destination: [ScienceCommon.pps_aperture_name]
   position_angle:
     title: "[deg] Position angle of aperture used"
     type: number
@@ -36,7 +26,7 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.position_angle]
-propertyOrder: [name, pss_name, position_angle]
+propertyOrder: [name, position_angle]
 flowStyle: block
-required: [name, pss_name, position_angle]
+required: [name, position_angle]
 ...

--- a/src/rad/resources/schemas/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/basic-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
 
-title: Common level metadata keywords
+title: Common metadata keywords
 
 type: object
 properties:

--- a/src/rad/resources/schemas/dq_def-1.0.0.yaml
+++ b/src/rad/resources/schemas/dq_def-1.0.0.yaml
@@ -1,0 +1,25 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/dq_def-1.0.0
+
+title: DQ Flag definition schema
+
+
+type: object
+properties:
+  dq_def:
+    title: DQ flag definitions
+    # Should this be an Astropy Table?
+    datatype:
+      - name: BIT
+        datatype: int32
+      - name: VALUE
+        datatype: uint32
+      - name: NAME
+        datatype: [ascii, 40]
+      - name: DESCRIPTION
+        datatype: [ascii, 80]
+flowStyle: block
+required: [dq_def]
+...

--- a/src/rad/resources/schemas/ephemeris-1.0.0.yaml
+++ b/src/rad/resources/schemas/ephemeris-1.0.0.yaml
@@ -7,7 +7,7 @@ title: Ephemeris data information
 type: object
 properties:
   earth_angle:
-    title: "Earth Angle [radians]"
+    title: "[radians] Earth Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -17,7 +17,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.earth_angle]
   moon_angle:
-    title: "Moon Angle [radians]"
+    title: "[radians] Moon Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -37,7 +37,7 @@ properties:
       datatype: nvarchar(10)
       destination: [ScienceCommon.ephemeris_reference_frame]
   sun_angle:
-    title: "Sun Angle [radians]"
+    title: "[radians] Sun Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -265,26 +265,6 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.exposure_duration]
-  nresets_at_start:
-    title: Number of resets at start of exposure
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [ScienceCommon.exposure_nresets_at_start]
-  datamode:
-    title: post-processing method used in FPAP
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [ScienceCommon.exposure_datamode]
 propertyOrder: [id, type,
            start_time, mid_time, end_time,
            start_time_mjd, mid_time_mjd, end_time_mjd,
@@ -293,8 +273,7 @@ propertyOrder: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, nresets_at_start,
-           datamode]
+           effective_exposure_time, duration]
 flowStyle: block
 required: [id, type,
            start_time, mid_time, end_time,
@@ -304,6 +283,5 @@ required: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, nresets_at_start,
-           datamode]
+           effective_exposure_time, duration]
 ...

--- a/src/rad/resources/schemas/gls_rampfit-1.0.0.yaml
+++ b/src/rad/resources/schemas/gls_rampfit-1.0.0.yaml
@@ -1,0 +1,41 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/gls_rampfit-1.0.0
+
+title: Optional output for GLS ramp fitting
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: common-1.0.0
+  yint:
+    title: Y-intercept
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 2
+    datatype: float32
+  sigyint:
+    title: Sigma for Y-intercept
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 2
+    datatype: float32
+  pedestal:
+    title: Pedestal
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 2
+    datatype: float32
+  crmag:
+    title: CR magnitudes
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 3
+    datatype: float32
+  sigcrmag:
+    title: Sigma for CR magnitudes
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 3
+    datatype: float32
+required: [meta, yint, sigyint, pedestal, crmag, sigcrmag]
+flowStyle: block
+propertyOrder: [meta, yint, sigyint, pedestal, crmag, sigcrmag]
+...

--- a/src/rad/resources/schemas/group-1.0.0.yaml
+++ b/src/rad/resources/schemas/group-1.0.0.yaml
@@ -1,0 +1,48 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/group-1.0.0
+
+title: Group parameter schema
+
+allOf:
+- type: object
+  properties:
+    group:
+      title: Group parameters table
+      # Astropy Tables not presently supported -  need to better define structure
+      #tag: tag:astropy.org:astropy/table/table-1.0.0
+      #colnames: [ integration_number, group_number, end_day, end_milliseconds, end_submilliseconds,
+      #            group_end_time, number_of_columns, number_of_rows, number_of_gaps,
+      #            completion_code_number, completion_code_text, bary_end_time, helio_end_time ]
+      #columns:
+      datatype:
+        - name: integration_number
+          datatype: int16
+        - name: group_number
+          datatype: int16
+        - name: end_day
+          datatype: int16
+        - name: end_milliseconds
+          datatype: int32
+        - name: end_submilliseconds
+          datatype: int16
+        - name: group_end_time
+          datatype: [ ascii, 26 ]
+        - name: number_of_columns
+          datatype: int16
+        - name: number_of_rows
+          datatype: int16
+        - name: number_of_gaps
+          datatype: int16
+        - name: completion_code_number
+          datatype: int16
+        - name: completion_code_text
+          datatype: [ ascii, 36 ]
+        - name: bary_end_time
+          datatype: float64
+        - name: helio_end_time
+          datatype: float64
+  flowStyle: block
+  required: [group]
+...

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -150,7 +150,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.data_end]
   gw_acq_exec_stat:
-    title: Guide star acquisition execution status
+    title: Guide star window acquisition execution status
     type: string
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -184,7 +184,7 @@ properties:
     enum: [HLS, EMS, SN, N/A]
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.survey]
+      destination: [ScienceCommon.survey]
 propertyOrder: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -178,15 +178,22 @@ properties:
     archive_catalog:
       datatype: nvarchar(50)
       destination: [ScienceCommon.ma_table_name]
+  survey:
+    title: Flat Field Step
+    type: string
+    enum: [HLS, EMS, SN, N/A]
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.survey]
 propertyOrder: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name]
+           observation_label, ma_table_name, survey]
 flowStyle: block
 required: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name]
+           observation_label, ma_table_name, survey]
 ...

--- a/src/rad/resources/schemas/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/pixelarea-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 type: object
 properties:
   area:
+    title: Pixel area array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: float32
     ndim: 2

--- a/src/rad/resources/schemas/program-1.0.0.yaml
+++ b/src/rad/resources/schemas/program-1.0.0.yaml
@@ -4,6 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/program-1.0.0
 
 title: Program information
+
 type: object
 properties:
   title:
@@ -22,8 +23,9 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        # There are a number of ways to get the pi_name.  Here is one
-        # of them: "= apt('./ProposalInformation/PrincipalInvestigator/InvestigatorAddress/LastName') + ', ' + apt('./ProposalInformation/PrincipalInvestigator/InvestigatorAddress/FirstName')"
+        # There are a number of ways to get the pi_name.  Here is one of them:
+        # "= apt('./ProposalInformation/PrincipalInvestigator/InvestigatorAddress/LastName') +
+        # ', ' + apt('./ProposalInformation/PrincipalInvestigator/InvestigatorAddress/FirstName')"
         origin: TBD
     archive_catalog:
       datatype: nvarchar(100)

--- a/src/rad/resources/schemas/rad_schema-1.0.0.yaml
+++ b/src/rad/resources/schemas/rad_schema-1.0.0.yaml
@@ -68,41 +68,41 @@ allOf:
       additionalItems:
         anyOf:
           - type: boolean
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+          - $ref: "#"
       items:
         anyOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-          - $ref: "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0#/definitions/schemaArray"
+          - $ref: "#"
+          - $ref: "#/definitions/schemaArray"
       additionalProperties:
         anyOf:
           - type: boolean
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+          - $ref: "#"
       definitions:
         type: object
         additionalProperties:
-          $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+          $ref: "#"
       properties:
         type: object
         additionalProperties:
-          $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+          $ref: "#"
       patternProperties:
         type: object
         additionalProperties:
-          $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+          $ref: "#"
       dependencies:
         type: object
         additionalProperties:
           anyOf:
-            - $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+            - $ref: "#"
             - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
       allOf:
-        $ref: "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0#/definitions/schemaArray"
+        $ref: "#/definitions/schemaArray"
       anyOf:
-        $ref: "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0#/definitions/schemaArray"
+        $ref: "#/definitions/schemaArray"
       oneOf:
-        $ref: "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0#/definitions/schemaArray"
+        $ref: "#/definitions/schemaArray"
       not:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+        $ref: "#"
 
 # Needed to cause the validator to check sdf and archive_catalog
 # in object properties.
@@ -111,5 +111,5 @@ definitions:
     type: array
     minItems: 1
     items:
-      $ref: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+      $ref: "#"
 ...

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.0.0
+
+title: Ramp schema
+
+allOf:
+- type: object
+  properties:
+    meta:
+      allOf:
+        - $ref: common-1.0.0
+    data:
+      title: The science data
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    pixeldq:
+      title: 2-D data quality array for all planes
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 2
+      datatype: uint32
+    groupdq:
+      title: 3-D data quality array for each plane
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: uint8
+    err:
+      title: Error array
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 2
+      datatype: float32
+    refout:
+      title: Reference Output
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+  required: [meta, data, pixeldq, groupdq, err, refout]
+  propertyOrder: [meta, data, pixeldq, groupdq, err, refout]
+- $ref: group-1.0.0
+flowStyle: block
+...

--- a/src/rad/resources/schemas/rampfitoutput-1.0.0.yaml
+++ b/src/rad/resources/schemas/rampfitoutput-1.0.0.yaml
@@ -1,0 +1,53 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/rampfitoutput-1.0.0
+
+title: Ramp fit output schema
+
+allOf:
+- type: object
+  properties:
+    meta:
+      allOf:
+        - $ref: common-1.0.0
+    slope:
+      title: Segment-specific slope
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    sigslope:
+      title: Sigma for segment-specific slope
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    yint:
+      title: Segment-specific y-intercept
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    sigyint:
+      title: Sigma for segment-specific y-intercept
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    pedestal:
+      title: Pedestal array
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 2
+      datatype: float32
+    weights:
+      title: Weights for segment-specific fits
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+    crmag:
+      title: Approximate CR magnitudes
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      ndim: 3
+      datatype: float32
+  required: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag]
+  propertyOrder: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag]
+- $ref: variance-1.0.0
+flowStyle: block
+...

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
 
-title: Flat reference schema
+title: Dark reference schema
 
 type: object
 properties:
@@ -11,12 +11,12 @@ properties:
     allOf:
       - $ref: ref_common-1.0.0
   data:
-    title: Flat data array
+    title: Dark current array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: float32
-    ndim: 2
+    ndim: 3
   dq:
-    title: Data quality array
+    title: 2-D data quality array for all planes
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: uint16
     ndim: 2
@@ -24,7 +24,7 @@ properties:
     title: Error array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: float32
-    ndim: 2
+    ndim: 3
 required: [meta, data, dq, err]
 flowStyle: block
 propertyOrder: [meta, data, dq, err]

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+
+title: Gain reference schema
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  data:
+    title: The detector gain map
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]
+...

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+
+title: DQ Mask reference schema
+
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  dq:
+    title: Data quality mask array
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint16
+    ndim: 2
+required: [meta, dq]
+flowStyle: block
+propertyOrder: [meta, dq]
+...

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+
+title: Read noise reference schema
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  data:
+    title: Read noise data array
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]
+...

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -21,7 +21,7 @@ allOf:
           origin: TBD
         archive_catalog:
           datatype: nvarchar(120)
-          destination: [ReferenceCommon.reftype]
+          destination: [ScienceRefData.reftype]
     pedigree:
       title: The pedigree of the reference file
       type: string
@@ -31,7 +31,7 @@ allOf:
           origin: TBD
         archive_catalog:
           datatype: nvarchar(120)
-          destination: [ReferenceCommon.pedigree]
+          destination: [ScienceRefData.pedigree]
     description:
       title: Description of the reference file
       type: string
@@ -41,7 +41,7 @@ allOf:
           origin: TBD
         archive_catalog:
           datatype: nvarchar(120)
-          destination: [ReferenceCommon.description]
+          destination: [ScienceRefData.description]
     author:
       title: Author of the reference file
       type: string
@@ -51,7 +51,7 @@ allOf:
           origin: TBD
       archive_catalog:
         datatype: nvarchar(120)
-        destination: [ReferenceCommon.author]
+        destination: [ScienceRefData.author]
     useafter:
       title: Use after date of the reference file
       tag: tag:stsci.edu:asdf/time/time-1.1.0
@@ -61,7 +61,7 @@ allOf:
           origin: TBD
       archive_catalog:
         datatype: datetime2
-        destination: [ReferenceCommon.useafter]
+        destination: [ScienceRefData.useafter]
   propertyOrder: [author, description, pedigree, useafter, reftype]
   flowStyle: block
   required: [author, description, pedigree, useafter, reftype]

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -5,45 +5,64 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
 
 title: Common reference metadata properties
 
-type: object
-properties:
-  telescope:
-    title: Telescope used
-    type: string
-    enum: [ROMAN]
-  instrument:
-    type: object
-    properties:
-      name:
-        title: Instrument used to acquire the data
-        type: string
-        enum: [WFI]
-      detector:
-        title: Detector used to acquire the data
-        type: string
-        enum: [WFI01, WFI02, WFI03, WFI04, WFI05, WFI06, WFI07, WFI08, WFI09,
-               WFI10, WFI11, WFI12, WFI13, WFI14, WFI15, WFI16, WFI17, WFI18]
-      optical_element:
-        title: Name of the filter or optical element used
-        type: string
-        enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, DARK, ENGINEERING]
-    required: [name, detector, optical_element]
-  reftype:
-    title: Reference file type
-    type: string
-    enum: [AREA, DARK, FLAT, GAIN, IPC, LINEARITY, PERSAT, PHOTOM, READNOISE, REFPIX,
-           SATURATION, SUPERBIAS, TRAPDENSITY, TRAPPARS]
-  pedigree:
-    title: The pedigree of the reference file
-    type: string
-  description:
-    title: Description of the reference file
-    type: string
-  author:
-    title: Author of the reference file
-    type: string
-  useafter:
-    title: Use after date of the reference file
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
-required: [telescope, instrument, reftype, pedigree, description, author, useafter]
+allOf:
+- $ref: ../common-1.0.0
+- $ref: ../dq_def-1.0.0
+- type: object
+  properties:
+    reftype:
+      title: Reference file type
+      type: string
+      enum: [AREA, DARK, FLAT, GAIN, LINEARITY, MASK, PERSAT, PHOTOM, READNOISE, REFPIX,
+             SATURATION, SUPERBIAS, TRAPDENSITY, TRAPPARS]
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ReferenceCommon.reftype]
+    pedigree:
+      title: The pedigree of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ReferenceCommon.pedigree]
+    description:
+      title: Description of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ReferenceCommon.description]
+    author:
+      title: Author of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+      archive_catalog:
+        datatype: nvarchar(120)
+        destination: [ReferenceCommon.author]
+    useafter:
+      title: Use after date of the reference file
+      tag: tag:stsci.edu:asdf/time/time-1.1.0
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+      archive_catalog:
+        datatype: datetime2
+        destination: [ReferenceCommon.useafter]
+  propertyOrder: [author, description, pedigree, useafter, reftype]
+  flowStyle: block
+  required: [author, description, pedigree, useafter, reftype]
 ...

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0.0
+
+title: WFI imaging photometric flux conversion data model
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  phot_table:
+    title: Photometric flux conversion factors table
+    # Should this be an Astropy Table?
+    datatype:
+      - name: optical_element
+        datatype: [ascii, 12]
+      - name: photmjsr
+        title: surface brightness, in MJy/steradian
+        datatype: float32
+      - name: uncertainty
+        title: uncertainty of surface brightness, in MJy/steradian
+        datatype: float32
+required: [meta, phot_table]
+flowStyle: block
+propertyOrder: [meta, phot_table]
+...

--- a/src/rad/resources/schemas/variance-1.0.0.yaml
+++ b/src/rad/resources/schemas/variance-1.0.0.yaml
@@ -1,0 +1,30 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/variance-1.0.0
+
+title: |
+  An object that is required to include the variance arrays.
+
+
+type: object
+properties:
+  var_poisson:
+    title: variance due to poisson noise
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  var_rnoise:
+    title: variance due to read noise
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  var_flat:
+    title: variance due to flat field
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+propertyOrder: [var_poisson, var_rnoise, var_flat]
+flowStyle: block
+required: [var_poisson, var_rnoise, var_flat]
+...

--- a/src/rad/resources/schemas/visit-1.0.0.yaml
+++ b/src/rad/resources/schemas/visit-1.0.0.yaml
@@ -88,9 +88,19 @@ properties:
     archive_catalog:
       datatype: bit
       destination: [ScienceCommon.visit_internal_target]
+  target_of_opportunity:
+    title: Visit scheduled as target of opportunity
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: bit
+      destination: [ScienceCommon.target_of_opportunity]
 propertyOrder: [engineering_quality, pointing_engdb_quality, type,
-           start_time, end_time, status, total_exposures, internal_target]
+           start_time, end_time, status, total_exposures, internal_target, target_of_opportunity]
 flowStyle: block
 required: [engineering_quality, pointing_engdb_quality, type,
-           start_time, end_time, status, total_exposures, internal_target]
+           start_time, end_time, status, total_exposures, internal_target, target_of_opportunity]
 ...

--- a/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
@@ -34,7 +34,7 @@ properties:
   optical_element:
     title: Name of the filter element used
     type: string
-    enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, DARK, ENGINEERING]
+    enum: [F062, F087, F106, F129, W146, F158, F184, F213, GRISM, PRISM, DARK]
     sdf:
       special_processing: VALUE_REQUIRED
       source:


### PR DESCRIPTION
Import of all romancal schema yaml files to RAD. These files all pass the RAD tests. This is starting as a draft PR, in order to tackle the following issues before full PR:

1. @perrygreenfield @dmggh - I left all the ramp* files and the wfi* data yaml files. Could you guys clarify which is which, and which we should be using?
2. @eslavich - Are my table-like structures in group and reference_files/wfi_img_photom okay? Do we need to do something else structurally?
3. @gardner358 - Did I get the db hooks in correctly (where appropriate)? 