### PR TITLE
Update asdf requirement to >= 2.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf @ git+https://github.com/asdf-format/asdf.git
+    asdf >= 2.8.0
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
asdf 2.8.0 is released, so we can use a real requirement here now.  Huzzah!