### PR TITLE
Added remaining romancal reference modules

### DIFF
--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -100,10 +100,31 @@ tags:
   title: Calibration Step status information
   description: |-
     Calibration Step status information
+# Reference Metadata Module
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ref_common-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+  title: Common reference metadata properties
+  description: |-
+    Common reference metadata properties
 # Reference Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.0.0
   title: flat field information
   description: |-
     flat field information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+  title: Gain reference schema
+  description: |-
+    Gain reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+  title: DQ Mask reference schema
+  description: |-
+    DQ Mask reference schema
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+  title: Read noise reference schema
+  description: |-
+    Read noise reference schema
 ...

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+
+title: Gain reference schema
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  data:
+    title: The detector gain map
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]
+...

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+
+title: DQ Mask reference schema
+
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  dq:
+    title: Data quality mask array
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint16
+    ndim: 2
+required: [meta, dq]
+flowStyle: block
+propertyOrder: [meta, dq]
+...

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+
+title: Read noise reference schema
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: ref_common-1.0.0
+  data:
+    title: Read noise data array
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]
+...

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -5,45 +5,64 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
 
 title: Common reference metadata properties
 
-type: object
-properties:
-  telescope:
-    title: Telescope used
-    type: string
-    enum: [ROMAN]
-  instrument:
-    type: object
-    properties:
-      name:
-        title: Instrument used to acquire the data
-        type: string
-        enum: [WFI]
-      detector:
-        title: Detector used to acquire the data
-        type: string
-        enum: [WFI01, WFI02, WFI03, WFI04, WFI05, WFI06, WFI07, WFI08, WFI09,
-               WFI10, WFI11, WFI12, WFI13, WFI14, WFI15, WFI16, WFI17, WFI18]
-      optical_element:
-        title: Name of the filter or optical element used
-        type: string
-        enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, DARK, ENGINEERING]
-    required: [name, detector, optical_element]
-  reftype:
-    title: Reference file type
-    type: string
-    enum: [AREA, DARK, FLAT, GAIN, IPC, LINEARITY, PERSAT, PHOTOM, READNOISE, REFPIX,
-           SATURATION, SUPERBIAS, TRAPDENSITY, TRAPPARS]
-  pedigree:
-    title: The pedigree of the reference file
-    type: string
-  description:
-    title: Description of the reference file
-    type: string
-  author:
-    title: Author of the reference file
-    type: string
-  useafter:
-    title: Use after date of the reference file
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
-required: [telescope, instrument, reftype, pedigree, description, author, useafter]
+allOf:
+- $ref: ../basic-1.0.0
+- $ref: ../dq_def-1.0.0
+- type: object
+  properties:
+    reftype:
+      title: Reference file type
+      type: string
+      enum: [AREA, DARK, FLAT, GAIN, LINEARITY, MASK, PERSAT, PHOTOM, READNOISE, REFPIX,
+             SATURATION, SUPERBIAS, TRAPDENSITY, TRAPPARS]
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ScienceRefData.reftype]
+    pedigree:
+      title: The pedigree of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ScienceRefData.pedigree]
+    description:
+      title: Description of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ScienceRefData.description]
+    author:
+      title: Author of the reference file
+      type: string
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+      archive_catalog:
+        datatype: nvarchar(120)
+        destination: [ScienceRefData.author]
+    useafter:
+      title: Use after date of the reference file
+      tag: tag:stsci.edu:asdf/time/time-1.1.0
+      sdf:
+        special_processing: VALUE_REQUIRED
+        source:
+          origin: TBD
+      archive_catalog:
+        datatype: datetime2
+        destination: [ScienceRefData.useafter]
+  propertyOrder: [author, description, pedigree, useafter, reftype]
+  flowStyle: block
+  required: [author, description, pedigree, useafter, reftype]
 ...


### PR DESCRIPTION
This PR is to add the remaining romancal reference modules: gain, mask, readnoise, and ref_common.

Tests: Fails due to dependency on dq support

Docs: Unneeded

Ticket: [#37]