### PR TITLE
Updated remaining Nonreference RomanCal Schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@
 
 - Added misc. required db keyword attributes. [JIRA RAD-7]
 
+- Updated aperture, basic, ephemeris, exposure, guidestar, observation, pixelarea, and visit schemas. [#46]
+  
   
 0.1.0 (unreleased)
 ==================

--- a/src/rad/resources/schemas/aperture-1.0.0.yaml
+++ b/src/rad/resources/schemas/aperture-1.0.0.yaml
@@ -16,16 +16,6 @@ properties:
     archive_catalog:
       datatype: nvarchar(40)
       destination: [ScienceCommon.aperture_name]
-  pss_name:
-    title: Original AperName supplied by PSS
-    type: string
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-      archive_catalog:
-        datatype: nvarchar(40)
-        destination: [ScienceCommon.pps_aperture_name]
   position_angle:
     title: "[deg] Position angle of aperture used"
     type: number
@@ -36,7 +26,7 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.position_angle]
-propertyOrder: [name, pss_name, position_angle]
+propertyOrder: [name, position_angle]
 flowStyle: block
-required: [name, pss_name, position_angle]
+required: [name, position_angle]
 ...

--- a/src/rad/resources/schemas/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/basic-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
 
-title: Common level metadata keywords
+title: Common metadata keywords
 
 type: object
 properties:

--- a/src/rad/resources/schemas/ephemeris-1.0.0.yaml
+++ b/src/rad/resources/schemas/ephemeris-1.0.0.yaml
@@ -7,7 +7,7 @@ title: Ephemeris data information
 type: object
 properties:
   earth_angle:
-    title: "Earth Angle [radians]"
+    title: "[radians] Earth Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -17,7 +17,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.earth_angle]
   moon_angle:
-    title: "Moon Angle [radians]"
+    title: "[radians] Moon Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -37,7 +37,7 @@ properties:
       datatype: nvarchar(10)
       destination: [ScienceCommon.ephemeris_reference_frame]
   sun_angle:
-    title: "Sun Angle [radians]"
+    title: "[radians] Sun Angle"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -265,26 +265,6 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.exposure_duration]
-  nresets_at_start:
-    title: Number of resets at start of exposure
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [ScienceCommon.exposure_nresets_at_start]
-  datamode:
-    title: post-processing method used in FPAP
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [ScienceCommon.exposure_datamode]
 propertyOrder: [id, type,
            start_time, mid_time, end_time,
            start_time_mjd, mid_time_mjd, end_time_mjd,
@@ -293,8 +273,7 @@ propertyOrder: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, nresets_at_start,
-           datamode]
+           effective_exposure_time, duration]
 flowStyle: block
 required: [id, type,
            start_time, mid_time, end_time,
@@ -304,6 +283,5 @@ required: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, nresets_at_start,
-           datamode]
+           effective_exposure_time, duration]
 ...

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -150,7 +150,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.data_end]
   gw_acq_exec_stat:
-    title: Guide star acquisition execution status
+    title: Guide star window acquisition execution status
     type: string
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -178,15 +178,22 @@ properties:
     archive_catalog:
       datatype: nvarchar(50)
       destination: [ScienceCommon.ma_table_name]
+  survey:
+    title: Flat Field Step
+    type: string
+    enum: [HLS, EMS, SN, N/A]
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceCommon.survey]
 propertyOrder: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name]
+           observation_label, ma_table_name, survey]
 flowStyle: block
 required: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name]
+           observation_label, ma_table_name, survey]
 ...

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -179,7 +179,7 @@ properties:
       datatype: nvarchar(50)
       destination: [ScienceCommon.ma_table_name]
   survey:
-    title: Flat Field Step
+    title: Observation Survey
     type: string
     enum: [HLS, EMS, SN, N/A]
     archive_catalog:

--- a/src/rad/resources/schemas/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/pixelarea-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 type: object
 properties:
   area:
+    title: Pixel area array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: float32
     ndim: 2

--- a/src/rad/resources/schemas/visit-1.0.0.yaml
+++ b/src/rad/resources/schemas/visit-1.0.0.yaml
@@ -88,9 +88,19 @@ properties:
     archive_catalog:
       datatype: bit
       destination: [ScienceCommon.visit_internal_target]
+  target_of_opportunity:
+    title: Visit scheduled as target of opportunity
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: bit
+      destination: [ScienceCommon.target_of_opportunity]
 propertyOrder: [engineering_quality, pointing_engdb_quality, type,
-           start_time, end_time, status, total_exposures, internal_target]
+           start_time, end_time, status, total_exposures, internal_target, target_of_opportunity]
 flowStyle: block
 required: [engineering_quality, pointing_engdb_quality, type,
-           start_time, end_time, status, total_exposures, internal_target]
+           start_time, end_time, status, total_exposures, internal_target, target_of_opportunity]
 ...


### PR DESCRIPTION
This PR is to update the remaining schemas to the latest in RomanCAL. The affected schemas are: aperture, basic, ephemeris, exposure, guidestar, observation, pixelarea, and visit

Tests: Passes standard tests

Docs: Unneeded

Ticket: [#46]