### PR TITLE
Validate each reference's specific reftype

### DIFF
--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -10,6 +10,11 @@ properties:
   meta:
     allOf:
       - $ref: ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [DARK]
   data:
     title: Dark current array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
@@ -10,6 +10,11 @@ properties:
   meta:
     allOf:
       - $ref: ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [FLAT]
   data:
     title: Flat data array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -10,6 +10,11 @@ properties:
   meta:
     allOf:
       - $ref: ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [GAIN]
   data:
     title: The detector gain map
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -11,6 +11,11 @@ properties:
   meta:
     allOf:
       - $ref: ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [MASK]
   dq:
     title: Data quality mask array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -10,6 +10,11 @@ properties:
   meta:
     allOf:
       - $ref: ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [READNOISE]
   data:
     title: Read noise data array
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0


### PR DESCRIPTION
This prevents files from mixing and matching e.g. the FLAT reftype with the dark-1.0.0 tag.