### PR TITLE
Add tag-and-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Tag and release
+
+on:
+  workflow_dispatch:
+    inputs:
+      description:
+        description: Release description (used as tag message and GitHub release body)
+        required: true
+
+jobs:
+  release:
+    name: Tag and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+
+      - name: Set changelog release date
+        run: |
+          echo "::set-output name=version::$(scripts/set_release_date)"
+        id: set_release_date
+
+      - name: Commit changelog and tag release
+        run: |
+          git add CHANGES.rst
+          git commit -m "Set ${{ steps.set_release_date.version }} release date"
+          git push origin HEAD
+          git tag -a ${{ steps.set_release_date.version }} -m "${{ github.event.inputs.description }}"
+          git push origin ${{ steps.set_release_date.version }}
+
+      - name: Create GitHub release (triggers publish-to-pypi workflow)
+        uses: zendesk/action-create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.set_release_date.version }}
+          release_name: ${{ steps.set_release_date.version }}
+          body: ${{ github.event.inputs.description }}
+          draft: false
+          prerelease: false
+
+      - name: Create next changelog release section
+        run: |
+          echo "::set-output name=version::$(scripts/insert_next_release)"
+        id: insert_next_release
+
+      - name: Commit changelog
+        run: |
+          git add CHANGES.rst
+          git commit -m "Create ${{ steps.insert_next_release.version }} changelog section"
+          git push origin HEAD

--- a/scripts/insert_next_release
+++ b/scripts/insert_next_release
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Insert the next release's changelog header.  Prints the version, which
+our GitHub Actions workflow uses to generate a commit message.
+"""
+from pathlib import Path
+import re
+
+
+RELEASED_VERSION_RE = re.compile(r"\A(?P<major>[0-9]+)\.(?P<minor>[0-9])+\.[0-9]+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$", re.MULTILINE)
+
+
+def main():
+    changelog_path = Path(__file__).absolute().parent.parent / "CHANGES.rst"
+    content = changelog_path.read_text()
+
+    match = RELEASED_VERSION_RE.match(content)
+    if not match:
+        raise RuntimeError("cannot determine latest released version")
+
+    new_major = int(match.group("major"))
+    new_minor = int(match.group("minor")) + 1
+    version = f"{new_major}.{new_minor}.0"
+
+    with changelog_path.open("w") as f:
+        header = f"{version} (unreleased)"
+        f.write(header + "\n")
+        f.write("=" * len(header) + "\n\n")
+        f.write(content)
+
+    print(version, end=None)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/set_release_date
+++ b/scripts/set_release_date
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Set the (latest and unreleased) changelog header release date to today.
+Prints the version, which our GitHub Actions workflow uses to
+generate a commit message and release tag.
+"""
+from datetime import date
+from pathlib import Path
+import re
+
+
+UNRELEASED_VERSION_RE = re.compile(r"\A(?P<version>[0-9]+\.[0-9]+\.[0-9]+) \(unreleased\)$", re.MULTILINE)
+
+
+def main():
+    changelog_path = Path(__file__).absolute().parent.parent / "CHANGES.rst"
+    content = changelog_path.read_text()
+
+    match = UNRELEASED_VERSION_RE.match(content)
+    if not match:
+        raise RuntimeError("cannot determine latest unreleased version")
+
+    version = match.group("version")
+    new_heading = f"{version} ({date.today().isoformat()})"
+    new_content = UNRELEASED_VERSION_RE.sub(new_heading, content)
+
+    with changelog_path.open("w") as f:
+        f.write(new_content)
+
+    print(version, end=None)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a workflow that tags and releases a new version of the package.  I'm trying to make releases low-friction so that we can do them every day if we need to.

The workflow may have bugs, but I'm not sure how to test it until we actually want a release.