### PR TITLE
Remove basic from ref_common as well as reftype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4.0 (unreleased)
 ==================
 
+- Removed basic from ref_common and moved some of its attributes directly to ref_common [#59]
+
 0.3.0 (2021-06-28)
 ==================
 

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -31,5 +31,5 @@ allOf:
     origin:
       title: Organization responsible for creating file
       type: string
-  required: [reftype, author, description, pedigree, useafter, origin]
+  required: [reftype, author, description, pedigree, useafter, telescope, origin]
 ...

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -20,6 +20,10 @@ allOf:
     useafter:
       title: Use after date of the reference file
       tag: tag:stsci.edu:asdf/time/time-1.1.0
+    telescope:
+      title: Telescope data reference data is used to calibrate
+      type: string
+      enum: [ROMAN]
     filename:
       title: Name of the file
       type: string

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -6,14 +6,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
 title: Common reference metadata properties
 
 allOf:
-- $ref: ../basic-1.0.0
 - type: object
   properties:
-    reftype:
-      title: Reference file type
-      type: string
-      enum: [AREA, DARK, FLAT, GAIN, LINEARITY, MASK, PERSAT, PHOTOM, READNOISE, REFPIX,
-             SATURATION, SUPERBIAS, TRAPDENSITY, TRAPPARS]
     pedigree:
       title: The pedigree of the reference file
       type: string
@@ -26,5 +20,14 @@ allOf:
     useafter:
       title: Use after date of the reference file
       tag: tag:stsci.edu:asdf/time/time-1.1.0
-  required: [author, description, pedigree, useafter, reftype]
+    filename:
+      title: Name of the file
+      type: string
+    file_date:
+      title: Date this file was created (UTC)
+      tag: tag:stsci.edu:asdf/time/time-1.1.0
+    origin:
+      title: Organization responsible for creating file
+      type: string
+  required: [author, description, pedigree, useafter, filename, file_date, origin]
 ...

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -8,6 +8,9 @@ title: Common reference metadata properties
 allOf:
 - type: object
   properties:
+    reftype:
+      title: Reference File type
+      type: string
     pedigree:
       title: The pedigree of the reference file
       type: string
@@ -24,14 +27,9 @@ allOf:
       title: Telescope data reference data is used to calibrate
       type: string
       enum: [ROMAN]
-    filename:
-      title: Name of the file
       type: string
-    file_date:
-      title: Date this file was created (UTC)
-      tag: tag:stsci.edu:asdf/time/time-1.1.0
     origin:
       title: Organization responsible for creating file
       type: string
-  required: [author, description, pedigree, useafter, filename, file_date, origin]
+  required: [reftype, author, description, pedigree, useafter, origin]
 ...


### PR DESCRIPTION
Much of what is in basic is irrelevant to reference files and should not be required in reference files. This PR removes that $ref of basic, and transfers the presumably required attributes directly to ref_common (as I understand it, this includes filename, file_date, telescope, and origin; if not, please comment).

Also removed is reftype since each reference file schema should include this attribute with a single enum value.

This closes #54