### PR TITLE
Add enumeration for pedigree values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.6.0 (unreleased)
 ==================
 
+- Added enumeration for ``meta.pedigree``. [#65]
+
 0.5.0 (2021-08-06)
 ==================
 
@@ -50,7 +52,7 @@
 - Added misc. required db keyword attributes. [JIRA RAD-7]
 
 - Added wfi photom schema and tests. [#34]
-  
+
 - Added Dark schema and updated Flat schema. [#35]
 
 - Added dq schema. [#32]
@@ -58,10 +60,10 @@
 - Added readnoise, mask, and gain schemas. [#37]
 
 - Added support for ramp fitting schemas. [#43]
-  
-- Updated aperture, basic, ephemeris, exposure, guidestar, observation, pixelarea, and visit schemas. [#46]  
 
-- Added support for variance object schemas. [#38] 
+- Updated aperture, basic, ephemeris, exposure, guidestar, observation, pixelarea, and visit schemas. [#46]
+
+- Added support for variance object schemas. [#38]
 
 0.1.0 (unreleased)
 ==================

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -14,6 +14,7 @@ allOf:
     pedigree:
       title: The pedigree of the reference file
       type: string
+      enum: [INFLIGHT, GROUND, MODEL, DUMMY, SIMULATION]
     description:
       title: Description of the reference file
       type: string


### PR DESCRIPTION
`PEDIGREE` is defined only as type string, however CRDs validates it against the following values:
`[INFLIGHT, GROUND, MODEL, DUMMY, SIMULATION]` and so files with arbitrary string values fail validation in CRDS.
This PR adds the enumeration to the schema.