### PR TITLE
some attributes should not be required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Added pixel area reference file support. [#80]
 
+- Removed ``pixelarea`` and ``var_flat`` from the list of required attributes in ``wfi_image``. [#83]
+
 0.6.1 (2021-08-26)
 ==================
 

--- a/src/rad/resources/schemas/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/pixelarea-1.0.0.yaml
@@ -15,5 +15,4 @@ properties:
     ndim: 2
 propertyOrder: [area]
 flowStyle: block
-required: [area]
 ...

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -39,5 +39,5 @@ allOf:
         ndim: 2
     propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat]
     flowStyle: block
-    required: [meta, data, dq, err, var_poisson, var_rnoise, var_flat]
+    required: [meta, data, dq, err, var_poisson, var_rnoise]
 ...


### PR DESCRIPTION
This PR removes `pixelarea` and `var_flat` from the list of required attributes in the `wfi_image` schema.
The `wfi_image` schema is used for the first time with the output of ramp fitting. `pixelarea` and `var_flat` are not available at that time and the validation of the output of ramp_fitting fails.