### PR TITLE
Pedestal array needs to be 2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@
 
 - Removed ``pixelarea`` and ``var_flat`` from the list of required attributes in ``wfi_image``. [#83]
 
+- ``RampFitOutput.pedestal`` needs to be 2-dimensional. [#86]
 
 0.6.1 (2021-08-26)
 ==================

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -34,7 +34,7 @@ allOf:
     pedestal:
       title: Pedestal array
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      ndim: 3
+      ndim: 2
       datatype: float32
     weights:
       title: Weights for segment-specific fits


### PR DESCRIPTION
The `pedestal` array in the optional output from ramp fitting, `ramp_fit_output`, represents the signal at zero exposure time for each pixel. Since Roman has one integration only I believe this array needs to be 2 dimensional.

