### PR TITLE
Changed certain exposure time types to string. Added units to guidest…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Removed ``pixelarea`` and ``var_flat`` from the list of required attributes in ``wfi_image``. [#83]
 
+- Changed certain exposure time types to string. Added units to guidestar variables, where appropriate. Removed references to RGS in guidestar. Added examples of observation numbers. [#91]
+
 
 0.6.1 (2021-08-26)
 ==================

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -37,7 +37,7 @@ properties:
 
   start_time:
     title: UTC exposure start time
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    type: string
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -47,7 +47,7 @@ properties:
       destination: [ScienceCommon.exposure_start_time]
   mid_time:
     title: UTC exposure mid time
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    type: string
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -57,7 +57,7 @@ properties:
       destination: [ScienceCommon.exposure_mid_time]
   end_time:
     title: UTC exposure end time
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    type: string
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -40,7 +40,7 @@ properties:
       datatype: nvarchar(20)
       destination: [ScienceCommon.gw_id]
   gs_ra:
-    title: guide star right ascension
+    title: [deg] guide star right ascension
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -50,7 +50,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_ra]
   gs_dec:
-    title: guide star declination
+    title: [deg] guide star declination
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -60,7 +60,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_dec]
   gs_ura:
-    title: guide star right ascension uncertainty
+    title: [deg] guide star right ascension uncertainty
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -70,7 +70,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_ura]
   gs_udec:
-    title: guide star declination uncertainty
+    title: [deg] guide star declination uncertainty
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -80,7 +80,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_udec]
   gs_mag:
-    title: guide star magnitude in FGS detector
+    title: guide star magnitude in detector
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -160,7 +160,7 @@ properties:
       datatype: nvarchar(15)
       destination: [ScienceCommon.gw_acq_exec_stat]
   gs_ctd_x:
-    title: "[arcsec] guide star centroid x position in FGS ideal frame"
+    title: "[arcsec] guide star centroid x position in guider ideal frame"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -170,7 +170,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_ctd_x]
   gs_ctd_y:
-    title: "[arcsec] guide star centroid y position in FGS ideal frame"
+    title: "[arcsec] guide star centroid y position in guider ideal frame"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -210,7 +210,7 @@ properties:
       datatype: nvarchar(10)
       destination: [ScienceCommon.gs_epoch]
   gs_mura:
-    title: Guide star ICRS right ascension proper motion
+    title: [mas/yr] Guide star ICRS right ascension proper motion
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -220,7 +220,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_mura]
   gs_mudec:
-    title: Guide star ICRS declination proper motion
+    title: [mas/yr] Guide star ICRS declination proper motion
     type: number
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -40,7 +40,7 @@ properties:
       datatype: nvarchar(20)
       destination: [ScienceCommon.gw_id]
   gs_ra:
-    title: [deg] guide star right ascension
+    title: "[deg] guide star right ascension"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -50,7 +50,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_ra]
   gs_dec:
-    title: [deg] guide star declination
+    title: "[deg] guide star declination"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -60,7 +60,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_dec]
   gs_ura:
-    title: [deg] guide star right ascension uncertainty
+    title: "[deg] guide star right ascension uncertainty"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -70,7 +70,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_ura]
   gs_udec:
-    title: [deg] guide star declination uncertainty
+    title: "[deg] guide star declination uncertainty"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -210,7 +210,7 @@ properties:
       datatype: nvarchar(10)
       destination: [ScienceCommon.gs_epoch]
   gs_mura:
-    title: [mas/yr] Guide star ICRS right ascension proper motion
+    title: "[mas/yr] Guide star ICRS right ascension proper motion"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -220,7 +220,7 @@ properties:
       datatype: float
       destination: [ScienceCommon.gs_mura]
   gs_mudec:
-    title: [mas/yr] Guide star ICRS declination proper motion
+    title: "[mas/yr] Guide star ICRS declination proper motion"
     type: number
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -133,7 +133,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.visit_file_group]
   visit_file_sequence:
-    title: Visit file sequence within the group, defined range of values is 1..9; included in
+    title: Visit file sequence within the group, defined range of values is 1..5; included in
            obs_id as 's'.
     type: integer
     sdf:

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -29,7 +29,7 @@ properties:
       datatype: datetime2
       destination: [ScienceCommon.obs_end_time]
   obs_id:
-    title: Programmatic observation identifier
+    title: Programmatic observation identifier, 'PPPPPCCAAALLLOOOVVVggsaaeeee'
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -39,7 +39,9 @@ properties:
       datatype: nvarchar(28)
       destination: [ScienceCommon.obs_id]
   visit_id:
-    title: Visit identifier
+    title: A unique identifier for a visit. The format is PPPPPCCAAASSSOOOVVV where PPPPP is the
+           Program, CC is the execution plan, AAA is the pass, SSS is the segment number, OOO is
+           the Observation and VVV is the Visit.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -49,7 +51,7 @@ properties:
       datatype: nvarchar(19)
       destination: [ScienceCommon.visit_id]
   program:
-    title: Program number
+    title: Program number. Defined range is 1..18445.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -59,7 +61,7 @@ properties:
       datatype: int
       destination: [ScienceCommon.program]
   execution_plan:
-    title: Execution plan number
+    title: Execution plan number. Defined range is 1..99.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -69,7 +71,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.execution_plan]
   pass:
-    title: Pass number (within execution plan)
+    title: Pass number (within execution plan). Defined range is 1..999.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -79,7 +81,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.pass]
   segment:
-    title: Segment Number (within pass)
+    title: Segment Number (within pass). Defined range is 1..999.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -89,7 +91,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.segment]
   observation:
-    title: Observation number
+    title: Observation number. Defined range is 1..999.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -99,7 +101,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.observation]
   visit:
-    title: Visit number
+    title: Visit number. Expected range of values is 1..999.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -109,7 +111,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.visit]
   visit_file_group:
-    title: Visit file group identifier
+    title: Visit file group identifier, format is 1..99.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -119,7 +121,7 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.visit_file_group]
   visit_file_sequence:
-    title: Visit file sequence identifier
+    title: Visit file sequence identifier, format is 1..999.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -129,7 +131,7 @@ properties:
       datatype: tinyint
       destination: [ScienceCommon.visit_file_sequence]
   visit_file_activity:
-    title: Visit file activity identifier
+    title: Visit file activity identifier, format is AA.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -139,7 +141,9 @@ properties:
       datatype: nvarchar(2)
       destination: [ScienceCommon.visit_file_activity]
   exposure:
-    title: Exposure request number
+    title: Exposure request number. This field identifies an exposure that will be taken on board
+           by the SOSE scripts. It accounts for all implicit and explicit exposures. Expected range
+           of values is 1..65536.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -29,7 +29,13 @@ properties:
       datatype: datetime2
       destination: [ScienceCommon.obs_end_time]
   obs_id:
-    title: Programmatic observation identifier (format 'PPPPPCCAAALLLOOOVVVggsaaeeee')
+    title: Programmatic observation identifier. The format is 'PPPPPCCAAASSSOOOVVVggsaaeeee' where
+           'PPPPP' is the Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the
+           segment, 'OOO' is the Observation, 'VVV' is the Visit, 'gg' is the visit file group,
+           's' is the visit file sequence, 'aa' is the visit file activity, and 'eeee' is the
+           exposure ID. The observation ID is the complete concatenation of visit_id +
+           visit_file_statement (visit_file_group + visit_file_sequence + visit_file_activity) +
+           exposure.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -51,7 +57,7 @@ properties:
       datatype: nvarchar(19)
       destination: [ScienceCommon.visit_id]
   program:
-    title: Program number, defined range is 1..18445.
+    title: Program number, defined range is 1..18445; included in obs_id and visit_id as 'PPPPP'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -61,7 +67,8 @@ properties:
       datatype: int
       destination: [ScienceCommon.program]
   execution_plan:
-    title: Execution plan number, defined range is 1..99.
+    title: Execution plan within the program, defined range is 1..99; included in obs_id and
+           visit_id as 'CC'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -71,7 +78,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.execution_plan]
   pass:
-    title: Pass number (within execution plan), defined range is 1..999.
+    title: Pass number within execution plan, defined range is 1..999; included in obs_id and
+           visit_id as 'AA'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -81,7 +89,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.pass]
   segment:
-    title: Segment Number (within pass), defined range is 1..999.
+    title: Segment Number within pass, defined range is 1..999; included in obs_id and visit_id as
+           'SSS'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -91,7 +100,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.segment]
   observation:
-    title: Observation number, defined range is 1..999.
+    title: Observation number within the segment, defined range is 1..999; included in obs_id and
+           visit_id as 'OOO'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -101,7 +111,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.observation]
   visit:
-    title: Visit number, defined range of values is 1..999.
+    title: Visit number within the observation, defined range of values is 1..999; included in
+           obs_id and visit_id as 'VVV'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -111,7 +122,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.visit]
   visit_file_group:
-    title: Visit file group identifier, defined range of values is 1..99.
+    title: Sequence group within the visit file, defined range of values is 1..99; included in
+           obs_id as 'gg'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -121,7 +133,8 @@ properties:
       datatype: smallint
       destination: [ScienceCommon.visit_file_group]
   visit_file_sequence:
-    title: Visit file sequence identifier, defined range of values is 1..999.
+    title: Visit file sequence within the group, defined range of values is 1..9; included in
+           obs_id as 's'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -131,7 +144,8 @@ properties:
       datatype: tinyint
       destination: [ScienceCommon.visit_file_sequence]
   visit_file_activity:
-    title: Visit file activity identifier (format 'AA').
+    title: Visit file activity within the sequence, defined range of values is 1..99; included in
+           obs_id as 'aa'.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -141,9 +155,8 @@ properties:
       datatype: nvarchar(2)
       destination: [ScienceCommon.visit_file_activity]
   exposure:
-    title: Exposure request number. This field identifies an exposure that will be taken on board
-           by the SOSE scripts. It accounts for all implicit and explicit exposures, defined range
-           of values is 1..65536.
+    title: Exposure within the visit, defined range of values is 1..9999; included in obs_id as
+           'eeee'.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED


### PR DESCRIPTION
Addressing Issue #82 
Changed certain exposure time types to string. 
Added units to guidestar variables, where appropriate. 
Removed references to RGS in guidestar. 
Added examples of observation numbers.

Number examples were pulled from the RPS database documentation, except for visit_file_activity, visit_file_group, and visit_file_sequence, which were pulled from the Roman Metadata Level 1 document.
