### PR TITLE
RAD-44: Add p_keywords to readnoise and dark 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Set all calsteps to required. [#102]
 
+- Added p_exptype to exposure group for reference files (dark & readnoise) to enable automatic rmap generation. Added test to ensure that the p_exptype expression matched the exposure/type enum list. [#105]
+
 0.8.0 (2021-11-22)
 ==================
 

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
@@ -14,6 +14,12 @@ properties:
         allOf:
           - $ref: ../exposure_type-1.0.0
           - title: Type of data in the exposure (viewing mode)
-    required: [type]
+      p_exptype:
+        title: Applicable EXP_TYPE.
+          type: string
+          pattern: "\
+            ^((WFI_IMAGE|WFI_GRISM|WFI_PRISM|WFI_DARK|WFI_FLAT|\
+            WFI_WFSC)\\s*\\|\\s*)+$"
+    required: [type,p_exptype]
 required: [exposure]
 ...

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
@@ -15,11 +15,9 @@ properties:
           - $ref: ../exposure_type-1.0.0
           - title: Type of data in the exposure (viewing mode)
       p_exptype:
-        title: Applicable EXP_TYPE.
-          type: string
-          pattern: "\
-            ^((WFI_IMAGE|WFI_GRISM|WFI_PRISM|WFI_DARK|WFI_FLAT|\
-            WFI_WFSC)\\s*\\|\\s*)+$"
+        title: Applicable exposure type.
+        type: string
+        pattern: "^((WFI_IMAGE|WFI_GRISM|WFI_PRISM|WFI_DARK|WFI_FLAT|WFI_WFSC)\\s*\\|\\s*)+$"
     required: [type,p_exptype]
 required: [exposure]
 ...

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -18,6 +18,9 @@ SCHEMA_URIS = [
 WFI_OPTICAL_ELEMENTS = list(asdf.schema.load_schema(
     "asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0")
     ["enum"])
+EXPOSURE_TYPE_ELEMENTS = list(asdf.schema.load_schema(
+    "asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0")
+    ["enum"])
 
 
 @pytest.fixture(scope="session", params=SCHEMA_URIS)
@@ -132,4 +135,13 @@ def test_matched_optical_element_entries():
         ["properties"]["phot_table"]["patternProperties"])
     r = re.compile(phot_table_keys[0])
     for element_str in WFI_OPTICAL_ELEMENTS:
+        assert r.search(element_str)
+
+# Confirm that the p_keyword version of exposure type match the enum version
+def test_matched_p_exptype_entries():
+    p_exptype = list(asdf.schema.load_schema(
+        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")
+        ["properties"]["exposure"]["p_exptype"])
+    r = re.compile(p_exptype[0])
+    for element_str in EXPOSURE_TYPE_ELEMENTS:
         assert r.search(element_str)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -139,9 +139,9 @@ def test_matched_optical_element_entries():
 
 # Confirm that the p_keyword version of exposure type match the enum version
 def test_matched_p_exptype_entries():
-    p_exptype = list(asdf.schema.load_schema(
-        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")
-        ["properties"]["exposure"]["p_exptype"])
-    r = re.compile(p_exptype[0])
+    p_exptype = asdf.schema.load_schema(
+        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0"
+        )["properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
+    r = re.compile(p_exptype)
     for element_str in EXPOSURE_TYPE_ELEMENTS:
-        assert r.search(element_str)
+        assert r.search(element_str+'|')

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -137,11 +137,12 @@ def test_matched_optical_element_entries():
     for element_str in WFI_OPTICAL_ELEMENTS:
         assert r.search(element_str)
 
+
 # Confirm that the p_keyword version of exposure type match the enum version
 def test_matched_p_exptype_entries():
     p_exptype = asdf.schema.load_schema(
-        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0"
-        )["properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
+        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")[
+        "properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
     r = re.compile(p_exptype)
     for element_str in EXPOSURE_TYPE_ELEMENTS:
-        assert r.search(element_str+'|')
+        assert r.search(element_str + '|')


### PR DESCRIPTION
Add p_exptype to exposure group for reference files (dark & readnoise) to enable automatic rmap generation. Added test to ensure that the p_exptype expression matched the exposure/type enum list.