### PR TITLE
RAD-46: changes to schemas for reference pixels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Added boolean level0_compressed attribute keyword to exposure group to indicate if the level 0 data was compressed. [#104]
 
+- Update schemas for ramp, level 1, and 2 files to contain accurate representation of reference pixels. The level 1 file has an array that contains both the science and the border reference pixels, and another array containing the amp33 reference pixels. Ramp models also have an array that contains the science data and the border reference pixels and another array for the amp33 reference pixels, and they also contain four seperate arrays that contain the original border reference pixels copied during the dq_init step (and four additional arrays for their DQ). The level 2 file data array only contains the science pixels (the border pixels are trimmed during ramp fit), and contains seperate arrays for the original border pixels and their dq arrays, and the amp33 reference pixels. [#112]
+
 
 0.8.0 (2021-11-22)
 ==================

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -12,10 +12,10 @@ allOf:
       allOf:
         - $ref: common-1.0.0
     data:
-      title: The science data
+      title: Science data, including the border reference pixels.
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint16
       ndim: 3
-      datatype: float32
     pixeldq:
       title: 2-D data quality array for all planes
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
@@ -31,7 +31,59 @@ allOf:
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
       ndim: 2
       datatype: float32
-  required: [meta, data, pixeldq, groupdq, err]
-  propertyOrder: [meta, data, pixeldq, groupdq, err]
-flowStyle: block
+    amp33:
+      title: Amp 33 reference pixel data
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint16
+      ndim: 3
+    border_ref_pix_left:
+      title: Original border reference pixels, on left (from viewers perspective).
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: float32
+      ndim: 3
+    border_ref_pix_right:
+      title: Original border reference pixels, on right (from viewers perspective).
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: float32
+      ndim: 3
+    border_ref_pix_top:
+      title: Original border reference pixels, on top.
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: float32
+      ndim: 3
+    border_ref_pix_bottom:
+      title: Original border reference pixels, on bottom.
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: float32
+      ndim: 3
+    dq_border_ref_pix_left:
+      title: DQ for border reference pixels, on left (from viewers perspective).
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint32
+      ndim: 2
+    dq_border_ref_pix_right:
+      title: DQ for border reference pixels, on right (from viewers perspective).
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint32
+      ndim: 2
+    dq_border_ref_pix_top:
+      title: DQ for border reference pixels, on top.
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint32
+      ndim: 2
+    dq_border_ref_pix_bottom:
+      title: DQ for border reference pixels, on bottom.
+      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      datatype: uint32
+      ndim: 2
+  propertyOrder: [meta, data, pixeldq, groupdq, err, amp33, border_ref_pix_left,
+                  border_ref_pix_right, border_ref_pix_top,
+                  border_ref_pix_bottom, dq_border_ref_pix_left,
+                  dq_border_ref_pix_right, dq_border_ref_pix_top,
+                  dq_border_ref_pix_bottom]
+  flowStyle: block
+  required: [meta, data, pixeldq, groupdq, err, amp33, border_ref_pix_left,
+             border_ref_pix_right, border_ref_pix_top, border_ref_pix_bottom,
+             dq_border_ref_pix_left, dq_border_ref_pix_right,
+             dq_border_ref_pix_top, dq_border_ref_pix_bottom]
 ...

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -4,7 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.0.0
 
 title: |
-  The schema for WFI level 2 images
+  The schema for WFI Level 2 images.
 
 allOf:
   - $ref: pixelarea-1.0.0
@@ -14,6 +14,7 @@ allOf:
         allOf:
           - $ref: common-1.0.0
       data:
+        title: Science data, excluding border reference pixels.
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
@@ -37,9 +38,62 @@ allOf:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      amp33:
+        title: Amp 33 reference pixel data
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: uint16
+        ndim: 3
+      border_ref_pix_left:
+        title: Original border reference pixels, on left (from viewers perspective).
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 3
+      border_ref_pix_right:
+        title: Original border reference pixels, on right (from viewers perspective).
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 3
+      border_ref_pix_top:
+        title: Original border reference pixels, on top.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 3
+      border_ref_pix_bottom:
+        title: Original border reference pixels, on bottom.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 3
+      dq_border_ref_pix_left:
+        title: DQ for border reference pixels, on left (from viewers perspective).
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: uint32
+        ndim: 2
+      dq_border_ref_pix_right:
+        title: DQ for border reference pixels, on right (from viewers perspective).
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: uint32
+        ndim: 2
+      dq_border_ref_pix_top:
+        title: DQ for border reference pixels, on top.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: uint32
+        ndim: 2
+      dq_border_ref_pix_bottom:
+        title: DQ for border reference pixels, on bottom.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: uint32
+        ndim: 2
       cal_logs:
         tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
-    propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat, cal_logs]
+    propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat,
+                    amp33, border_ref_pix_left, border_ref_pix_right,
+                    border_ref_pix_top, border_ref_pix_bottom,
+                    dq_border_ref_pix_left, dq_border_ref_pix_right,
+                    dq_border_ref_pix_top, dq_border_ref_pix_bottom, cal_logs]
     flowStyle: block
-    required: [meta, data, dq, err, var_poisson, var_rnoise, cal_logs]
+    required: [meta, data, dq, err, var_poisson, var_rnoise, amp33,
+               border_ref_pix_left, border_ref_pix_right, border_ref_pix_top,
+               border_ref_pix_bottom, dq_border_ref_pix_left,
+               dq_border_ref_pix_right, dq_border_ref_pix_top,
+               dq_border_ref_pix_bottom, cal_logs]
 ...

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -4,7 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.0.0
 
 title: |
-  The schema for WFI science data (both imaging and spectrographic)
+  The schema for Level 1 WFI science data (both imaging and spectrographic).
 
 type: object
 properties:
@@ -12,10 +12,16 @@ properties:
     allOf:
       - $ref: common-1.0.0
   data:
+    title: Science data, including the border reference pixels.
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: uint16
     ndim: 3
-propertyOrder: [meta, data]
+  amp33:
+    title: Amp 33 reference pixel data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint16
+    ndim: 3
+propertyOrder: [meta, data, amp33]
 flowStyle: block
-required: [meta, data]
+required: [meta, data, amp33]
 ...


### PR DESCRIPTION
Closes #107
Resolves [RAD-46](https://jira.stsci.edu/browse/RAD-46)

Changes to the schemas for the level 1 and 2 output files, as well as ramp model.

The level 1 file has a science data array that includes the border reference pixels, and a separate array for the amp 33 reference pixels.

The ramp model also has a data array that contains both science and border reference pixels, another for the amp 33 reference pixels, and four additional arrays for the original border reference pixels copied during the dq init step (plus four more for their dq arrays).

The level 2 file has a science data array only containing science pixles, 4 separate arrays for the top, bottom, left, and right original reference pixels (3d), four more for their dq arrays, and the amp33 array.

