### PR TITLE
RCAL-111 Changes to photom schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,26 @@
 
 - Set all calsteps to required. [#102]
 
-- Added p_exptype to exposure group for reference files (dark & readnoise) to enable automatic rmap generation. Added test to ensure that the p_exptype expression matched the exposure/type enum list. [#105]
+- Added p_exptype to exposure group for reference files (dark & readnoise)
+  to enable automatic rmap generation. Added test to ensure that the p_exptype
+  expression matched the exposure/type enum list. [#105]
 
-- Added boolean level0_compressed attribute keyword to exposure group to indicate if the level 0 data was compressed. [#104]
+- Added boolean level0_compressed attribute keyword to exposure group to
+  indicate if the level 0 data was compressed. [#104]
 
-- Update schemas for ramp, level 1, and 2 files to contain accurate representation of reference pixels. The level 1 file has an array that contains both the science and the border reference pixels, and another array containing the amp33 reference pixels. Ramp models also have an array that contains the science data and the border reference pixels and another array for the amp33 reference pixels, and they also contain four seperate arrays that contain the original border reference pixels copied during the dq_init step (and four additional arrays for their DQ). The level 2 file data array only contains the science pixels (the border pixels are trimmed during ramp fit), and contains seperate arrays for the original border pixels and their dq arrays, and the amp33 reference pixels. [#112]
+- Update schemas for ramp, level 1, and 2 files to contain accurate representation of
+  reference pixels. The level 1 file has an array that contains both the science and
+  the border reference pixels, and another array containing the amp33 reference pixels.
+  Ramp models also have an array that contains the science data and the border reference
+  pixels and another array for the amp33 reference pixels, and they also contain four
+  seperate arrays that contain the original border reference pixels copied during
+  the dq_init step (and four additional arrays for their DQ). The level 2 file data
+  array only contains the science pixels (the border pixels are trimmed during ramp fit),
+  and contains seperate arrays for the original border pixels and their dq arrays, and
+  the amp33 reference pixels. [#112]
 
+- Added ``uncertainty`` attributes to ``photometry`` and ``pixelareasr``
+  to the photometry reference file schema. [#114]
 
 0.8.0 (2021-11-22)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf >= 2.8.0
+    asdf >= 2.9.2
 package_dir =
     =src
 packages = find:

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -8,31 +8,57 @@ type: object
 properties:
   conversion_megajanskys:
     title: Flux density (MJy/steradian) producing 1 cps
-    type: number
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.conversion_megajanskys]
   conversion_microjanskys:
     title: Flux density (uJy/arcsec2) producing 1 cps
-    type: number
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.conversion_microjanskys]
   pixelarea_steradians:
     title: Nominal pixel area in steradians
-    type: number
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.pixelarea_steradians]
   pixelarea_arcsecsq:
     title: Nominal pixel area in arcsec^2
-    type: number
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.pixelarea_arcsecsq]
+  conversion_megajanskys_uncertainty:
+    title: Uncertainty in flux density conversion to MJy/steradians
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
+    archive_catalog:
+      datatype: float
+      destination: [ScienceCommon.conversion_megajanskys_uncertainty]
+  conversion_microjanskys_uncertainty:
+    title: Uncertainty in flux density conversion to uJy/steradians
+    anyOf:
+      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
+    archive_catalog:
+      datatype: float
+      destination: [ScienceCommon.conversion_microjanskys_uncertainty]
 propertyOrder: [conversion_microjanskys, conversion_megajanskys,
-           pixelarea_steradians, pixelarea_arcsecsq]
+                pixelarea_steradians, pixelarea_arcsecsq,
+                conversion_megajanskys_uncertainty, conversion_microjanskys_uncertainty]
 flowStyle: block
 required: [conversion_microjanskys, conversion_megajanskys,
-           pixelarea_steradians, pixelarea_arcsecsq]
+           pixelarea_steradians, pixelarea_arcsecsq,
+           conversion_megajanskys_uncertainty, conversion_microjanskys_uncertainty]
 ...

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -23,12 +23,21 @@ properties:
         type: object
         properties:
           photmjsr:
-            title: surface brightness, in MJy/steradian
-            type: number
+            title: Surface brightness, in MJy/steradian
+            anyOf:
+              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - type: "null"
           uncertainty:
-            title: uncertainty of surface brightness, in MJy/steradian
-            type: number
-        required: [photmjsr, uncertainty]
+            title: Uncertainty of surface brightness, in MJy/steradian
+            anyOf:
+              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - type: "null"
+          pixelareasr:
+            title: Nominal pixel area, in steradian
+            anyOf:
+              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - type: "null"
+        required: [photmjsr, uncertainty, pixelareasr]
     additionalProperties: false
 required: [meta, phot_table]
 flowStyle: block


### PR DESCRIPTION
This is part of RCAL-111 - updating the `photometry` and `wfi_img_photom` schemas.
- Added "uncertainty" attributes
- - Changed the type to be either a Quantity (for imaging) or None (for spectral data)