### PR TITLE
Remove 'photometry' from 'required' attributes in 'common'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@
 - Added ``uncertainty`` attributes to ``photometry`` and ``pixelareasr``
   to the photometry reference file schema. [#114]
 
+- Removed ``Photometry`` from required properties in ``common``. [#115]
+
 0.8.0 (2021-11-22)
 ==================
 

--- a/src/rad/resources/schemas/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/common-1.0.0.yaml
@@ -42,6 +42,6 @@ allOf:
     wcsinfo:
       tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.0.0
   required: [aperture, cal_step, coordinates, ephemeris, exposure, guidestar,
-             instrument, observation, photometry, pointing, program,
+             instrument, observation, pointing, program,
              target, velocity_aberration, visit, wcsinfo]
 ...


### PR DESCRIPTION
The `photometry` section is updated in the image file, in the last step of ELPP. 
Having it as a required property adds it to L1 files.
This PR makes it possible not to include it in L1 files. 
The alternative is to have it with dummy values.