### PR TITLE
tweaks to schemas

### DIFF
--- a/src/rad/resources/schemas/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/common-1.0.0.yaml
@@ -27,8 +27,6 @@ allOf:
       tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
     observation:
       tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
-    photometry:
-      tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
     pointing:
       tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.0.0
     program:

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -54,9 +54,6 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.conversion_microjanskys_uncertainty]
-propertyOrder: [conversion_microjanskys, conversion_megajanskys,
-                pixelarea_steradians, pixelarea_arcsecsq,
-                conversion_megajanskys_uncertainty, conversion_microjanskys_uncertainty]
 flowStyle: block
 required: [conversion_microjanskys, conversion_megajanskys,
            pixelarea_steradians, pixelarea_arcsecsq,

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -9,7 +9,7 @@ properties:
   conversion_megajanskys:
     title: Flux density (MJy/steradian) producing 1 cps
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float
@@ -17,7 +17,7 @@ properties:
   conversion_microjanskys:
     title: Flux density (uJy/arcsec2) producing 1 cps
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float
@@ -25,7 +25,7 @@ properties:
   pixelarea_steradians:
     title: Nominal pixel area in steradians
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float
@@ -33,7 +33,7 @@ properties:
   pixelarea_arcsecsq:
     title: Nominal pixel area in arcsec^2
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float
@@ -41,7 +41,7 @@ properties:
   conversion_megajanskys_uncertainty:
     title: Uncertainty in flux density conversion to MJy/steradians
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float
@@ -49,7 +49,7 @@ properties:
   conversion_microjanskys_uncertainty:
     title: Uncertainty in flux density conversion to uJy/steradians
     anyOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
       - type: "null"
     archive_catalog:
       datatype: float

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -54,6 +54,9 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.conversion_microjanskys_uncertainty]
+propertyOrder: [conversion_microjanskys, conversion_megajanskys,
+                pixelarea_steradians, pixelarea_arcsecsq,
+                conversion_megajanskys_uncertainty, conversion_microjanskys_uncertainty]
 flowStyle: block
 required: [conversion_microjanskys, conversion_megajanskys,
            pixelarea_steradians, pixelarea_arcsecsq,

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -14,7 +14,7 @@ allOf:
     data:
       title: Science data, including the border reference pixels.
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      datatype: uint16
+      datatype: float32
       ndim: 3
     pixeldq:
       title: 2-D data quality array for all planes

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -21,12 +21,12 @@ properties:
               pixelarea_steradians:
                 title: Nominal pixel area in steradians
                 anyOf:
-                  - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
                   - type: "null"
               pixelarea_arcsecsq:
                 title: Nominal pixel area in arcsec^2
                 anyOf:
-                  - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
                   - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
         required: [photometry]

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -20,10 +20,14 @@ properties:
             properties:
               pixelarea_steradians:
                 title: Nominal pixel area in steradians
-                type: number
+                anyOf:
+                  - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - type: "null"
               pixelarea_arcsecsq:
                 title: Nominal pixel area in arcsec^2
-                type: number
+                anyOf:
+                  - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
         required: [photometry]
       - $ref: ref_optical_element-1.0.0

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -25,17 +25,17 @@ properties:
           photmjsr:
             title: Surface brightness, in MJy/steradian
             anyOf:
-              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
               - type: "null"
           uncertainty:
             title: Uncertainty of surface brightness, in MJy/steradian
             anyOf:
-              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
               - type: "null"
           pixelareasr:
             title: Nominal pixel area, in steradian
             anyOf:
-              - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
               - type: "null"
         required: [photmjsr, uncertainty, pixelareasr]
     additionalProperties: false

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -6,94 +6,94 @@ id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.0.0
 title: |
   The schema for WFI Level 2 images.
 
-allOf:
-  - type: object
-    properties:
-      meta:
-        allOf:
-          - $ref: common-1.0.0
-          - $ref: photometry-1.0.0
-      data:
-        title: Science data, excluding border reference pixels.
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 2
-      dq:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint32
-        ndim: 2
-      err:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 2
-      var_poisson:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 2
-      var_rnoise:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 2
-      var_flat:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 2
-      amp33:
-        title: Amp 33 reference pixel data
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint16
-        ndim: 3
-      border_ref_pix_left:
-        title: Original border reference pixels, on left (from viewers perspective).
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 3
-      border_ref_pix_right:
-        title: Original border reference pixels, on right (from viewers perspective).
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 3
-      border_ref_pix_top:
-        title: Original border reference pixels, on top.
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 3
-      border_ref_pix_bottom:
-        title: Original border reference pixels, on bottom.
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: float32
-        ndim: 3
-      dq_border_ref_pix_left:
-        title: DQ for border reference pixels, on left (from viewers perspective).
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint32
-        ndim: 2
-      dq_border_ref_pix_right:
-        title: DQ for border reference pixels, on right (from viewers perspective).
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint32
-        ndim: 2
-      dq_border_ref_pix_top:
-        title: DQ for border reference pixels, on top.
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint32
-        ndim: 2
-      dq_border_ref_pix_bottom:
-        title: DQ for border reference pixels, on bottom.
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-        datatype: uint32
-        ndim: 2
-      cal_logs:
-        tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
-    propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat,
-                    amp33, border_ref_pix_left, border_ref_pix_right,
-                    border_ref_pix_top, border_ref_pix_bottom,
-                    dq_border_ref_pix_left, dq_border_ref_pix_right,
-                    dq_border_ref_pix_top, dq_border_ref_pix_bottom, cal_logs]
-    flowStyle: block
-    required: [meta, data, dq, err, var_poisson, var_rnoise, amp33,
-               border_ref_pix_left, border_ref_pix_right, border_ref_pix_top,
-               border_ref_pix_bottom, dq_border_ref_pix_left,
-               dq_border_ref_pix_right, dq_border_ref_pix_top,
-               dq_border_ref_pix_bottom, cal_logs]
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: common-1.0.0
+      - photometry:
+          tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+  data:
+    title: Science data, excluding border reference pixels.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+  dq:
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint32
+    ndim: 2
+  err:
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+  var_poisson:
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+  var_rnoise:
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+  var_flat:
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 2
+  amp33:
+    title: Amp 33 reference pixel data
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint16
+    ndim: 3
+  border_ref_pix_left:
+    title: Original border reference pixels, on left (from viewers perspective).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  border_ref_pix_right:
+    title: Original border reference pixels, on right (from viewers perspective).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  border_ref_pix_top:
+    title: Original border reference pixels, on top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  border_ref_pix_bottom:
+    title: Original border reference pixels, on bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: float32
+    ndim: 3
+  dq_border_ref_pix_left:
+    title: DQ for border reference pixels, on left (from viewers perspective).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint32
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: DQ for border reference pixels, on right (from viewers perspective).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint32
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: DQ for border reference pixels, on top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint32
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: DQ for border reference pixels, on bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    datatype: uint32
+    ndim: 2
+  cal_logs:
+    tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat,
+                amp33, border_ref_pix_left, border_ref_pix_right,
+                border_ref_pix_top, border_ref_pix_bottom,
+                dq_border_ref_pix_left, dq_border_ref_pix_right,
+                dq_border_ref_pix_top, dq_border_ref_pix_bottom, cal_logs]
+flowStyle: block
+required: [meta, data, dq, err, var_poisson, var_rnoise, amp33,
+           border_ref_pix_left, border_ref_pix_right, border_ref_pix_top,
+           border_ref_pix_bottom, dq_border_ref_pix_left,
+           dq_border_ref_pix_right, dq_border_ref_pix_top,
+           dq_border_ref_pix_bottom, cal_logs]
 ...

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -11,8 +11,11 @@ properties:
   meta:
     allOf:
       - $ref: common-1.0.0
-      - photometry:
-          tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+      - type: object
+        properties:
+          photometry:
+            tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+        required: [photometry]
   data:
     title: Science data, excluding border reference pixels.
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -7,12 +7,12 @@ title: |
   The schema for WFI Level 2 images.
 
 allOf:
-  - $ref: pixelarea-1.0.0
   - type: object
     properties:
       meta:
         allOf:
           - $ref: common-1.0.0
+          - $ref: photometry-1.0.0
       data:
         title: Science data, excluding border reference pixels.
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -39,6 +39,7 @@ def valid_tag_uris(manifest):
     uris.update([
         "tag:stsci.edu:asdf/time/time-1.1.0",
         "tag:stsci.edu:asdf/core/ndarray-1.0.0",
+        "tag:stsci.edu:asdf/unit/quantity-1.1.0",
     ])
     return uris
 


### PR DESCRIPTION
Changes:

- remove `photometry` from `common`
- change the datatype of `ramp.data` to float32
- change data types of attributes in pixelarea to `Quantity`
- remove `pixelarea` from Level2 schemas. The latest photometry algorithm specifies it won't be attached to files.