### PR TITLE
RAD-59: Remove exptype and p_keywords from Distortion Model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Changed input_unit and output_unit keyword types, titles, and tests. [#126]
 
+- Removed exptype and p_keywords from Distortion schema. [#128]
+
 
 0.9.0 (2022-02-15)
 ==================

--- a/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
@@ -21,7 +21,6 @@ properties:
             title: Units of the inputs to this model.
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
         required: [output_units, input_units]
-      - $ref: ref_exposure_type-1.0.0
       - $ref: ref_optical_element-1.0.0
   coordinate_distortion_transform:
     title: Distortion transform as an instance of astropy.modeling.Model.


### PR DESCRIPTION
Removed exptype and p_keywords from Distortion schema.