### PR TITLE
RAD-63: Move MA_Table Identifiers from Observation to Exposure Schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.12.0 (unreleased)
 ===================
 
+- Moved ma_table_name and ma_table_number from observation to exposure schemas. [#138]
+
 
 0.11.0 (2022-04-06)
 ===================

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -260,6 +260,26 @@ properties:
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.exposure_duration]
+  ma_table_name:
+    title: Identifier for the multi-accumulation table used
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination: [ScienceCommon.ma_table_name]
+  ma_table_number:
+    title: Numerical identifier for the multi-accumulation table used
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [ScienceCommon.ma_table_number]
   level0_compressed:
     title: Level 0 data was compressed
     type: boolean
@@ -278,7 +298,8 @@ propertyOrder: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, level0_compressed]
+           effective_exposure_time, duration,
+           ma_table_name, ma_table_number, level0_compressed]
 flowStyle: block
 required: [id, type,
            start_time, mid_time, end_time,
@@ -288,5 +309,6 @@ required: [id, type,
            gain_factor, integration_time, elapsed_exposure_time,
            frame_divisor, groupgap,
            frame_time, group_time, exposure_time,
-           effective_exposure_time, duration, level0_compressed]
+           effective_exposure_time, duration,
+           ma_table_name, ma_table_number, level0_compressed]
 ...

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -185,26 +185,6 @@ properties:
     archive_catalog:
       datatype: nvarchar(max)
       destination: [ScienceCommon.observation_label]
-  ma_table_name:
-    title: Identifier for the multi-accumulation table used
-    type: string
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: nvarchar(50)
-      destination: [ScienceCommon.ma_table_name]
-  ma_table_number:
-    title: Numerical identifier for the multi-accumulation table used
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: smallint
-      destination: [ScienceCommon.ma_table_number]
   survey:
     title: Observation Survey
     type: string
@@ -216,11 +196,11 @@ propertyOrder: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name, ma_table_number, survey]
+           observation_label, survey]
 flowStyle: block
 required: [start_time, end_time, obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
-           observation_label, ma_table_name, ma_table_number, survey]
+           observation_label, survey]
 ...

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -14,16 +14,6 @@ properties:
         properties:
           reftype:
             enum: [DARK]
-          observation:
-            type: object
-            properties:
-              ma_table_name:
-                title: Identifier for the multi-accumulation table used
-                type: string
-              ma_table_number:
-                title: Number of the multi-accumulation table used
-                type: integer
-            required: [ma_table_name, ma_table_number]
           exposure:
             type: object
             properties:
@@ -36,8 +26,14 @@ properties:
               groupgap:
                 title: Number of frames dropped between groups
                 type: integer
-            required: [ngroups, nframes, groupgap]
-        required: [observation, exposure]
+              ma_table_name:
+                title: Identifier for the multi-accumulation table used
+                type: string
+              ma_table_number:
+                title: Number of the multi-accumulation table used
+                type: integer
+            required: [ngroups, nframes, groupgap, ma_table_name, ma_table_number]
+        required: [exposure]
       - $ref: ref_exposure_type-1.0.0
       - $ref: ref_optical_element-1.0.0
   data:


### PR DESCRIPTION
Moved ma_table_name and ma_table_number from observation to exposure schemas.