### PR TITLE
RAD-52 After review remove observation.start_time and end_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.13.0 (unreleased)
 ===================
 
+- remove start_time and end_time from the observation schema [#142]
 
 0.12.0 (2022-04-15)
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ where = src
 test =
     pytest>=4.6.0
     pytest-openfiles>=0.5.0
+    pytest-doctestplus>=0.11.1
 
 [flake8]
 max-line-length = 130

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -1,6 +1,5 @@
-%YAML 1.1
+%YAML 1.2
 ---
-
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
 
@@ -23,7 +22,7 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: nvarchar(28)
-      destination: [ScienceCommon.obs_id]    
+      destination: [ScienceCommon.obs_id]
   visit_id:
     title: A unique identifier for a visit. The format is 'PPPPPCCAAASSSOOOVVV' where 'PPPPP' is the
            Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the segment number,

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -1,10 +1,9 @@
-%YAML 1.2
+%YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
 
-title: |
-  Observation identifiers
+title: Observation identifiers
 type: object
 properties:
   obs_id:

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -8,6 +8,22 @@ title: |
   Observation identifiers
 type: object
 properties:
+  obs_id:
+    title: Programmatic observation identifier. The format is 'PPPPPCCAAASSSOOOVVVggsaaeeee' where
+           'PPPPP' is the Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the
+           segment, 'OOO' is the Observation, 'VVV' is the Visit, 'gg' is the visit file group,
+           's' is the visit file sequence, 'aa' is the visit file activity, and 'eeee' is the
+           exposure ID. The observation ID is the complete concatenation of visit_id +
+           visit_file_statement (visit_file_group + visit_file_sequence + visit_file_activity) +
+           exposure.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(28)
+      destination: [ScienceCommon.obs_id]    
   visit_id:
     title: A unique identifier for a visit. The format is 'PPPPPCCAAASSSOOOVVV' where 'PPPPP' is the
            Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the segment number,

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -1,49 +1,13 @@
 %YAML 1.1
 ---
+
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
-
 
 title: |
   Observation identifiers
 type: object
 properties:
-  start_time:
-    title: "[yyyy-mm-ddThh:mm:ss.sss] Date-time start of exposure"
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: datetime2
-      destination: [ScienceCommon.obs_start_time]
-  end_time:
-    title: "[yyyy-mm-ddThh:mm:ss.sss] Date-time end of exposure"
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: datetime2
-      destination: [ScienceCommon.obs_end_time]
-  obs_id:
-    title: Programmatic observation identifier. The format is 'PPPPPCCAAASSSOOOVVVggsaaeeee' where
-           'PPPPP' is the Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the
-           segment, 'OOO' is the Observation, 'VVV' is the Visit, 'gg' is the visit file group,
-           's' is the visit file sequence, 'aa' is the visit file activity, and 'eeee' is the
-           exposure ID. The observation ID is the complete concatenation of visit_id +
-           visit_file_statement (visit_file_group + visit_file_sequence + visit_file_activity) +
-           exposure.
-    type: string
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: nvarchar(28)
-      destination: [ScienceCommon.obs_id]
   visit_id:
     title: A unique identifier for a visit. The format is 'PPPPPCCAAASSSOOOVVV' where 'PPPPP' is the
            Program, 'CC' is the execution plan, 'AAA' is the pass, 'SSS' is the segment number,
@@ -192,13 +156,13 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceCommon.survey]
-propertyOrder: [start_time, end_time, obs_id, visit_id, program,
+propertyOrder: [obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,
            observation_label, survey]
 flowStyle: block
-required: [start_time, end_time, obs_id, visit_id, program,
+required: [obs_id, visit_id, program,
            execution_plan, pass, observation, segment,
            visit, visit_file_group, visit_file_sequence,
            visit_file_activity, exposure, template,


### PR DESCRIPTION
After review with INS it was decided to remove start_time and end_time from the observation schema since no use cases could be found and the origin of these times cannot be determined. 