### PR TITLE
fix ref_file schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
 - Moved archive related information in the ``basic`` schema directly
   into a tagged object for easier retrieval by ASDF. [#153, #158]
 
+- Fix ref_file schema. [#157]
 
 0.13.0 (2022-04-25)
 -------------------

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -5,82 +5,46 @@ id: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.0.0
 
 title: Reference file information
 
-allOf:
-- type: object
-  properties:
-    crds:
-      title: CRDS parameters
-      type: object
-      properties:
-        sw_version:
-          title: Version of CRDS file selection software used
-          type: string
-        context_used:
-          title: CRDS context (.pmap) used to select ref files
-          type: string
-      dark:
-        title: Dark reference file information
-        type: object
-        properties:
-          name:
-            title: Dark reference file name
-            type: string
-      mask:
-        title: Mask reference file information
-        type: object
-        properties:
-          name:
-            title: Mask reference file name
-            type: string
-      flat:
-        title: Flat reference file information
-        type: object
-        properties:
-          name:
-            title: Flat reference file name
-            type: string
-      gain:
-        title: Gain reference file information
-        type: object
-        properties:
-          name:
-            title: Gain file name
-            type: string
-      readnoise:
-        title: Read noise reference file information
-        type: object
-        properties:
-          name:
-            title: Read noise file name
-            type: string
-      linearity:
-        title: Linearity reference file information
-        type: object
-        properties:
-          name:
-            title: Linearity file name
-            type: string
-      photom:
-        title: Photometry reference file information
-        type: object
-        properties:
-          name:
-            title: Photometry file name
-            type: string
-      area:
-        title: Area reference file information
-        type: object
-        properties:
-          name:
-            title: Area file name
-            type: string
-      saturation:
-        title: Saturation reference file information
-        type: object
-        properties:
-          name:
-            title: Saturation file name
-            type: string
+
+type: object
+properties:
+  crds:
+    title: CRDS parameters
+    type: object
+    properties:
+      sw_version:
+        title: Version of CRDS file selection software used
+        type: string
+      context_used:
+        title: CRDS context (.pmap) used to select ref files
+        type: string
+    dark:
+      title: Dark reference file information
+      type: string
+    mask:
+      title: Mask reference file information
+      type: string
+    flat:
+      title: Flat reference file information
+      type: string
+    gain:
+      title: Gain reference file information
+      type: string
+    readnoise:
+      title: Read noise reference file information
+      type: string
+    linearity:
+      title: Linearity reference file information
+      type: string
+    photom:
+      title: Photometry reference file information
+      type: string
+    area:
+      title: Area reference file information
+      type: string
+    saturation:
+      title: Saturation reference file information
+      type: string
 
 flowStyle: block
 ...


### PR DESCRIPTION
Fix indentation issue, and change types from 'object' to string - reference file names don't need to be in a dictionary since their only property is their name.