### PR TITLE
Keep "telescope" attribute in ref_common of type string 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,14 @@
 
 - Create docs for RTD. [#151]
 
-- Moved gw_function_start_time, gw_function_end_time, and gw_acq_exec_stat from GuideStar to GuideWindow. Removed duplicate gw time entries. [#154]
+- Moved gw_function_start_time, gw_function_end_time, and
+  gw_acq_exec_stat from GuideStar to GuideWindow. Removed duplicate
+  gw time entries. [#154]
 
 - Changed optical filter name W146 to F146. [#156]
+
+- Moved archive related information in the ``basic`` schema directly
+  into a tagged object for easier retrieval by ASDF. [#153, #158]
 
 
 0.13.0 (2022-04-25)

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -26,7 +26,8 @@ allOf:
       tag: tag:stsci.edu:asdf/time/time-1.1.0
     telescope:
       title: Telescope data reference data is used to calibrate
-      tag: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+      type: string
+      enum: [ROMAN]
     origin:
       title: Organization responsible for creating file
       type: string


### PR DESCRIPTION
to avoid regenration of reference files
Follow up on #153 - reverted `ref_common.telescope` back to type `string` to avoid a last minute need to generate all reference files again.