### PR TITLE
Fix `ref_file` and and archive info to it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Add ``IPAC/SSC`` to ``origin`` enum. [#160]
 
+- Add archive information to ``ref_file`` and fix indentation there. [#161]
+
 0.13.1 (2022-07-29)
 -------------------
 

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -18,33 +18,34 @@ properties:
       context_used:
         title: CRDS context (.pmap) used to select ref files
         type: string
-    dark:
-      title: Dark reference file information
-      type: string
-    mask:
-      title: Mask reference file information
-      type: string
-    flat:
-      title: Flat reference file information
-      type: string
-    gain:
-      title: Gain reference file information
-      type: string
-    readnoise:
-      title: Read noise reference file information
-      type: string
-    linearity:
-      title: Linearity reference file information
-      type: string
-    photom:
-      title: Photometry reference file information
-      type: string
-    area:
-      title: Area reference file information
-      type: string
-    saturation:
-      title: Saturation reference file information
-      type: string
+
+  dark:
+    title: Dark reference file information
+    type: string
+  mask:
+    title: Mask reference file information
+    type: string
+  flat:
+    title: Flat reference file information
+    type: string
+  gain:
+    title: Gain reference file information
+    type: string
+  readnoise:
+    title: Read noise reference file information
+    type: string
+  linearity:
+    title: Linearity reference file information
+    type: string
+  photom:
+    title: Photometry reference file information
+    type: string
+  area:
+    title: Area reference file information
+    type: string
+  saturation:
+    title: Saturation reference file information
+    type: string
 
 flowStyle: block
 ...

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -15,9 +15,24 @@ properties:
       sw_version:
         title: Version of CRDS file selection software used
         type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ScienceCommon.crds_software_version]
+
       context_used:
         title: CRDS context (.pmap) used to select ref files
         type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [ScienceCommon.crds_context_used]
 
   dark:
     title: Dark reference file information


### PR DESCRIPTION
This PR accomplishes two things:

1. Fixes the indentation of the ref_file.
2. Adds archive information to the CRDS keywords in the file.

Note: The archive information is fully accessible via the `schema_info` command (I have tested this). Moreover, the indentation exposed an issue with some of the test utilities in `roman_datamodels`, so this PR depends on spacetelescope/roman_datamodels#96 in order for all the tests to pass everywhere.