### PR TITLE
Idea 2 (Quantities)

### DIFF
--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -75,6 +75,11 @@ tags:
   title: Photometry information
   description: |-
     Photometry information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image_units-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image_units-1.0.0
+  title: WFI Level 2 Image Data Variable Units
+  description: |-
+    WFI Level 2 Image Data Variable Units
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/coordinates-1.0.0
   title: Coordinate frame information

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -15,7 +15,9 @@ properties:
         properties:
           photometry:
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
-        required: [photometry]
+          units:
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_image_units-1.0.0
+        required: [photometry, units]
   data:
     title: Science data, excluding border reference pixels.
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/wfi_image_units-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image_units-1.0.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image_units-1.0.0
+
+title: WFI Level 2 Image Data Variable Units
+type: object
+properties:
+  data:
+    title: Units for the variable data.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [ScienceCommon.unit_data]
+  dq:
+    title: Units for the variable dq.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [ScienceCommon.unit_dq]
+  amp33:
+    title: Units for the variable amp33.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [ScienceCommon.unit_amp33]
+propertyOrder: [data, dq, amp33]
+flowStyle: block
+required: [data, dq, amp33]
+...

--- a/src/rad/resources/schemas/wfi_image_units-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image_units-1.0.0.yaml
@@ -8,7 +8,9 @@ type: object
 properties:
   data:
     title: Units for the variable data.
-    type: string
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -18,7 +20,9 @@ properties:
       destination: [ScienceCommon.unit_data]
   dq:
     title: Units for the variable dq.
-    type: string
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -28,7 +32,9 @@ properties:
       destination: [ScienceCommon.unit_dq]
   amp33:
     title: Units for the variable amp33.
-    type: string
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - type: "null"
     sdf:
       special_processing: VALUE_REQUIRED
       source:


### PR DESCRIPTION
Units folder in meta unique to each datafile type, e.g.
(NOTE: I only did units for 2 variables for display clarity - the implementation would be one for each array.)

Image Model:
> type(l2m)
<class 'roman_datamodels.datamodels.ImageModel'>

Contents of meta/units in Image Model:
> l2m.meta.units
{'data': 'electrons', 'dq': 'null', 'amp33': 'dN'}

Output of db schema info tool for units in Image Model:
> pprint(l2m.schema_info(key='archive_catalog')['roman']['meta']['units'])
{'amp33': {'archive_catalog': SchemaInfo(info={'datatype': 'nvarchar(10)', 'destination': ['ScienceCommon.unit_amp33']}, value='dN')},
'data': {'archive_catalog': SchemaInfo(info={'datatype': 'nvarchar(10)', 'destination': ['ScienceCommon.unit_data']}, value='electrons')},
'dq': {'archive_catalog': SchemaInfo(info={'datatype': 'nvarchar(10)', 'destination': ['ScienceCommon.unit_dq']}, value='null')}}