### PR TITLE
RAD-96 update SDF origin tags to use PSS views instead of DB relations

### DIFF
--- a/src/rad/resources/schemas/ephemeris-1.0.0.yaml
+++ b/src/rad/resources/schemas/ephemeris-1.0.0.yaml
@@ -63,7 +63,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_state.ingest_time????
+        origin: PSS:ephemeris_state.ingest_time
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.ephemeris_time]
@@ -73,7 +73,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.x
+        origin: PSS:sts_ephemeris_state.x
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.spatial_x]
@@ -83,7 +83,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.y
+        origin: PSS:sts_ephemeris_state.y
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.spatial_y]
@@ -93,7 +93,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.z
+        origin: PSS:sts_ephemeris_state.z
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.spatial_z]
@@ -103,7 +103,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.dx
+        origin: PSS:sts_ephemeris_state.dx
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.velocity_x]
@@ -113,7 +113,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.dy
+        origin: PSS:sts_ephemeris_state.dy
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.velocity_y]
@@ -123,7 +123,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:ephemeris_status.dz
+        origin: PSS:sts_ephemeris_state.dz
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.velocity_z]

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -30,7 +30,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:visit_track.visit_id
+        origin: TBD
     archive_catalog:
       datatype: nvarchar(19)
       destination: [ScienceCommon.visit_id]
@@ -149,7 +149,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:visit.template
+        origin: PSS:dms_visit.template
     archive_catalog:
       datatype: nvarchar(50)
       destination: [ScienceCommon.template]

--- a/src/rad/resources/schemas/program-1.0.0.yaml
+++ b/src/rad/resources/schemas/program-1.0.0.yaml
@@ -12,7 +12,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:program.title
+        origin: PSS:dms_program.title
     archive_catalog:
       datatype: nvarchar(200)
       destination: [ScienceCommon.program_title]
@@ -34,7 +34,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:program.category
+        origin: PSS:dms_program.category
     archive_catalog:
       datatype: nvarchar(6)
       destination: [ScienceCommon.program_category]
@@ -44,7 +44,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:program.subcategory
+        origin: PSS:dms_program.subcategory
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceCommon.program_subcategory]
@@ -54,7 +54,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:program_track.science_category
+        origin: PSS:dms_program.science_category
     archive_catalog:
       datatype: nvarchar(50)
       destination: [ScienceCommon.science_category]
@@ -64,7 +64,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:program_track.continuation_id
+        origin: PSS:dms_program.continuation_id
     archive_catalog:
       datatype: int
       destination: [ScienceCommon.continuation_id]

--- a/src/rad/resources/schemas/target-1.0.0.yaml
+++ b/src/rad/resources/schemas/target-1.0.0.yaml
@@ -12,7 +12,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:target.target_name
+        origin: PSS:dms_target.target_name
     archive_catalog:
       datatype: nvarchar(100)
       destination: [ScienceCommon.proposer_target_name]
@@ -22,7 +22,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:target.standard_target_name
+        origin: PSS:dms_target.standard_target_name
     archive_catalog:
       datatype: nvarchar(256)
       destination: [ScienceCommon.catalog_name]
@@ -33,7 +33,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:target.target_type
+        origin: PSS:dms_target.target_type
     archive_catalog:
       datatype: nvarchar(10)
       destination: [ScienceCommon.target_type]
@@ -43,7 +43,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.ra_computed
+        origin: PSS:dms_target.ra_computed
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.ra]
@@ -53,7 +53,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.dec_computed
+        origin: PSS:dms_target.dec_computed
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.dec]
@@ -63,7 +63,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.ra_uncertainty_computed
+        origin: PSS:dms_target.ra_uncertainty_computed
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.ra_uncertainty]
@@ -73,7 +73,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.dec_uncertainty_computed
+        origin: PSS:dms_target.dec_uncertainty_computed
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.dec_uncertainty]
@@ -83,7 +83,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.ra_proper_motion
+        origin: PSS:dms_target.ra_proper_motion
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.proper_motion_ra]
@@ -93,7 +93,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.dec_proper_motion
+        origin: PSS:dms_target.dec_proper_motion
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.proper_motion_dec]
@@ -103,7 +103,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:fixed_target.epoch
+        origin: PSS:dms_visit.epoch
     archive_catalog:
       datatype: nvarchar(10)
       destination: [ScienceCommon.proper_motion_epoch]

--- a/src/rad/resources/schemas/visit-1.0.0.yaml
+++ b/src/rad/resources/schemas/visit-1.0.0.yaml
@@ -34,7 +34,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: PSS:visit.visit_type
+        origin: PSS:dms_visit.visit_type
     archive_catalog:
       datatype: nvarchar(30)
       destination: [ScienceCommon.visit_type]


### PR DESCRIPTION
Changed:
- "sdf" "origin" attribute definitions to use PSS views where possible
- observation-1.0.0.yaml - Removed database query for visit_id.  This value should be set by value found in telemetry Head packet.

Question - Should following items be added to views via PSS ticket:
aperture-1.0.0.yaml  - origin: PSS:aperture.AperName 
target-1.0.0.yaml:
 proposer_ra -origin: PSS:fixed_target.ra_literal  
 proposer_dec - origin: PSS:fixed_target.dec_literal
 source_type_apt - origin: PSS:target.extended

FYI values currently set by PSS queries in yaml files:
$ grep "PSS:" *.yaml
aperture-1.0.0.yaml:        origin: PSS:aperture.AperName
ephemeris-1.0.0.yaml:        origin: PSS:ephemeris_state.ingest_time
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.x
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.y
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.z
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.dx
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.dy
ephemeris-1.0.0.yaml:        origin: PSS:sts_ephemeris_state.dz
observation-1.0.0.yaml:        origin: PSS:dms_visit.template
program-1.0.0.yaml:        origin: PSS:dms_program.title
program-1.0.0.yaml:        origin: PSS:dms_program.category
program-1.0.0.yaml:        origin: PSS:dms_program.subcategory
program-1.0.0.yaml:        origin: PSS:dms_program.science_category
program-1.0.0.yaml:        origin: PSS:dms_program.continuation_id
target-1.0.0.yaml:        origin: PSS:dms_target.target_name
target-1.0.0.yaml:        origin: PSS:dms_target.standard_target_name
target-1.0.0.yaml:        origin: PSS:dms_target.target_type
target-1.0.0.yaml:        origin: PSS:dms_target.ra_computed
target-1.0.0.yaml:        origin: PSS:dms_target.dec_computed
target-1.0.0.yaml:        origin: PSS:dms_target.ra_uncertainty_computed
target-1.0.0.yaml:        origin: PSS:dms_target.dec_uncertainty_computed
target-1.0.0.yaml:        origin: PSS:dms_target.ra_proper_motion
target-1.0.0.yaml:        origin: PSS:dms_target.dec_proper_motion
target-1.0.0.yaml:        origin: PSS:dms_visit.epoch
target-1.0.0.yaml:        origin: PSS:fixed_target.ra_literal
target-1.0.0.yaml:        origin: PSS:fixed_target.dec_literal
target-1.0.0.yaml:        origin: PSS:target.extended
visit-1.0.0.yaml:        origin: PSS:dms_visit.visit_type