### PR TITLE
RAD 99: Add schema to support Roman's non-VOUnit units.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 -------------------
 
 - Use PSS views in SDF origin attribute. [#167]
+- Add support for specific non-VOUnit units used by Roman. [#168]
 
 0.13.2 (2022-08-23)
 -------------------

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -223,4 +223,13 @@ tags:
   title: Telescope used to acquire the data
   description: |-
     Telescope used to acquire the data
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/unit/unit-1.0.0
+  title: Special Units used by Roman
+  description: |-
+    This represents the units used by Roman which are not part of
+    [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+
+    The specific non-VOUnit units used by Roman will be checked/enforced by the
+    converter.
 ...

--- a/src/rad/resources/schemas/unit/unit-1.0.0.yaml
+++ b/src/rad/resources/schemas/unit/unit-1.0.0.yaml
@@ -12,7 +12,7 @@ description: >
   converter.
 
 $ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
-enum: [DN, electron]
+# enum: [DN, electron]
 
 flowStyle: block
 ...

--- a/src/rad/resources/schemas/unit/unit-1.0.0.yaml
+++ b/src/rad/resources/schemas/unit/unit-1.0.0.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/unit/unit-1.0.0
+
+title: Special Units used by Roman
+description: >
+  This represents the units used by Roman which are not part of
+  [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+
+  The specific non-VOUnit units used by Roman will be checked/enforced by the
+  converter.
+
+$ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+enum: [DN, electron]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/unit/unit-1.0.0.yaml
+++ b/src/rad/resources/schemas/unit/unit-1.0.0.yaml
@@ -12,7 +12,6 @@ description: >
   converter.
 
 $ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
-# enum: [DN, electron]
 
 flowStyle: block
 ...


### PR DESCRIPTION
Adds a schema and tag to support the non-VOUnits (`DN` and `electron`) that Roman will need to serialize in ASDF. 