### PR TITLE
Bugfix for `enum`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add units to the schemas for science data quantities to specify allowed values. [#195]
 
+- Fix ``enum`` bug in schemas. [#194]
+
 0.14.0 (2022-11-04)
 -------------------
 

--- a/src/rad/resources/schemas/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/tagged_scalars/origin-1.0.0.yaml
@@ -4,8 +4,10 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/origin-1.0.0
 
 title: Organization responsible for creating file
-# There is a bug in enum validation, currently being enforced by the converter, see issue #155 for details.
-# enum: ["STSCI", "IPAC/SSC"]
+
+type: string
+enum: ["STSCI", "IPAC/SSC"]
+
 sdf:
   special_processing: VALUE_REQUIRED
   source:

--- a/src/rad/resources/schemas/tagged_scalars/telescope-1.0.0.yaml
+++ b/src/rad/resources/schemas/tagged_scalars/telescope-1.0.0.yaml
@@ -4,9 +4,10 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/telescope-1.0.0
 
 title: Telescope used to acquire the data
+
 type: string
-# There is a bug in enum validation, currently being enforced by the converter, see issue #155 for details.
-# enum: [ROMAN]
+enum: [ROMAN]
+
 archive_catalog:
   datatype: nvarchar(5)
   destination: [ScienceCommon.telescope]


### PR DESCRIPTION
Fixes #155 

ASDF 2.14.2 fixes the bug causing #155 upstream. This PR re-enables `enum` for some tagged strings.