### PR TITLE
Rad 104: Enumerate Allowed Units for Science Data Quantities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Changed science arrays to quantities. [#192]
 
+- Add units to the schemas for science data quantities to specify allowed values. [#195]
+
 0.14.0 (2022-11-04)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf >= 2.9.2
+    asdf >= 2.14.2
 package_dir =
     =src
 packages = find:

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -194,6 +194,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 5
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
   signal_frames:
     title: "Reconstituted and oriented signal frames. Dimensions: num_frames,
             num_combined_resultants (or num_uncombined_resultants), num_reads, x, y"
@@ -203,6 +206,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 5
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
   amp33:
     title: "Amp 33 reference pixel data. Dimensions: num_frames,
             num_combined_resultants (or num_uncombined_resultants), num_reads, x, y"
@@ -212,6 +218,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 5
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
 propertyOrder: [meta, pedestal_frames, signal_frames, amp33]
 flowStyle: block
 required: [meta, pedestal_frames, signal_frames, amp33]

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -19,6 +19,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     pixeldq:
       title: 2-D data quality array for all planes
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
@@ -37,6 +40,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     amp33:
       title: Amp 33 reference pixel data
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -45,6 +51,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: uint16
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN"]
     border_ref_pix_left:
       title: Original border reference pixels, on left (from viewers perspective).
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -52,6 +61,9 @@ allOf:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
     border_ref_pix_right:
       title: Original border reference pixels, on right (from viewers perspective).
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -60,6 +72,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN"]
     border_ref_pix_top:
       title: Original border reference pixels, on top.
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -68,6 +83,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN"]
     border_ref_pix_bottom:
       title: Original border reference pixels, on bottom.
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -76,6 +94,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN"]
     dq_border_ref_pix_left:
       title: DQ for border reference pixels, on left (from viewers perspective).
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -21,7 +21,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["DN", "electron"]
     pixeldq:
       title: 2-D data quality array for all planes
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
@@ -42,7 +42,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["DN", "electron"]
     amp33:
       title: Amp 33 reference pixel data
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -13,24 +13,48 @@ allOf:
         - $ref: common-1.0.0
     slope:
       title: Segment-specific slope
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      ndim: 3
-      datatype: float32
+      tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      properties:
+        value:
+          tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+          datatype: float32
+          ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     sigslope:
       title: Sigma for segment-specific slope
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      ndim: 3
-      datatype: float32
+      tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      properties:
+        value:
+          tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+          datatype: float32
+          ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     yint:
       title: Segment-specific y-intercept
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      ndim: 3
-      datatype: float32
+      tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      properties:
+        value:
+          tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+          datatype: float32
+          ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     sigyint:
       title: Sigma for segment-specific y-intercept
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-      ndim: 3
-      datatype: float32
+      tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      properties:
+        value:
+          tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+          datatype: float32
+          ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     pedestal:
       title: Pedestal array
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -39,6 +63,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 2
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["DN", "electron / s"]
     weights:
       title: Weights for segment-specific fits
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
@@ -47,11 +74,16 @@ allOf:
     crmag:
       title: Approximate CR magnitudes
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      # Possibly use u.Magnitude instead?
+      # https://docs.astropy.org/en/stable/units/logarithmic_units.html
       properties:
         value:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["count / s"]
     var_poisson:
       title: Variance due to poisson noise for segment-specific slope
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -60,6 +92,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["electron2 / s2"]
     var_rnoise:
       title: Variance due to read noise for segment-specific slope
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -68,6 +103,9 @@ allOf:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
           datatype: float32
           ndim: 3
+        unit:
+          tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+          enum: ["electron2 / s2"]
   required: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,
              var_rnoise]
   propertyOrder: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -21,7 +21,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["electron / s"]
     sigslope:
       title: Sigma for segment-specific slope
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -32,7 +32,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["electron / s"]
     yint:
       title: Segment-specific y-intercept
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -43,7 +43,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["electron"]
     sigyint:
       title: Sigma for segment-specific y-intercept
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -54,7 +54,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["electron"]
     pedestal:
       title: Pedestal array
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -65,7 +65,7 @@ allOf:
           ndim: 2
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN", "electron / s"]
+          enum: ["electron"]
     weights:
       title: Weights for segment-specific fits
       tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
@@ -83,7 +83,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["count / s"]
+          enum: ["DN"]
     var_poisson:
       title: Variance due to poisson noise for segment-specific slope
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -74,8 +74,6 @@ allOf:
     crmag:
       title: Approximate CR magnitudes
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
-      # Possibly use u.Magnitude instead?
-      # https://docs.astropy.org/en/stable/units/logarithmic_units.html
       properties:
         value:
           tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -83,7 +83,7 @@ allOf:
           ndim: 3
         unit:
           tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-          enum: ["DN"]
+          enum: ["electron"]
     var_poisson:
       title: Variance due to poisson noise for segment-specific slope
       tag: tag:stsci.edu:asdf/unit/quantity-1.1.0

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -24,6 +24,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["electron / s"]	
   dq:
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: uint32
@@ -35,6 +38,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["electron / s"]	
   var_poisson:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -42,6 +48,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["electron2 / s2"]	
   var_rnoise:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -49,6 +58,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["electron2 / s2"]	
   var_flat:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -56,6 +68,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 2
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["electron2 / s2"]	
   amp33:
     title: Amp 33 reference pixel data
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -64,6 +79,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]	
   border_ref_pix_left:
     title: Original border reference pixels, on left (from viewers perspective).
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -72,6 +90,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]	
   border_ref_pix_right:
     title: Original border reference pixels, on right (from viewers perspective).
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -80,6 +101,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]	
   border_ref_pix_top:
     title: Original border reference pixels, on top.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -88,6 +112,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]	
   border_ref_pix_bottom:
     title: Original border reference pixels, on bottom.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -96,6 +123,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: float32
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]	
   dq_border_ref_pix_left:
     title: DQ for border reference pixels, on left (from viewers perspective).
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -26,7 +26,7 @@ properties:
         ndim: 2
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["electron / s"]	
+        enum: ["electron / s"]
   dq:
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
     datatype: uint32
@@ -40,7 +40,7 @@ properties:
         ndim: 2
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["electron / s"]	
+        enum: ["electron / s"]
   var_poisson:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -50,7 +50,7 @@ properties:
         ndim: 2
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["electron2 / s2"]	
+        enum: ["electron2 / s2"]
   var_rnoise:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -60,7 +60,7 @@ properties:
         ndim: 2
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["electron2 / s2"]	
+        enum: ["electron2 / s2"]
   var_flat:
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
@@ -70,7 +70,7 @@ properties:
         ndim: 2
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["electron2 / s2"]	
+        enum: ["electron2 / s2"]
   amp33:
     title: Amp 33 reference pixel data
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -81,7 +81,7 @@ properties:
         ndim: 3
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["DN"]	
+        enum: ["DN"]
   border_ref_pix_left:
     title: Original border reference pixels, on left (from viewers perspective).
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -92,7 +92,7 @@ properties:
         ndim: 3
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["DN"]	
+        enum: ["DN"]
   border_ref_pix_right:
     title: Original border reference pixels, on right (from viewers perspective).
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -103,7 +103,7 @@ properties:
         ndim: 3
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["DN"]	
+        enum: ["DN"]
   border_ref_pix_top:
     title: Original border reference pixels, on top.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -114,7 +114,7 @@ properties:
         ndim: 3
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["DN"]	
+        enum: ["DN"]
   border_ref_pix_bottom:
     title: Original border reference pixels, on bottom.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -125,7 +125,7 @@ properties:
         ndim: 3
       unit:
         tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
-        enum: ["DN"]	
+        enum: ["DN"]
   dq_border_ref_pix_left:
     title: DQ for border reference pixels, on left (from viewers perspective).
     tag: tag:stsci.edu:asdf/core/ndarray-1.0.0

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -19,6 +19,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
   amp33:
     title: Amp 33 reference pixel data.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -27,6 +30,9 @@ properties:
         tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
         datatype: uint16
         ndim: 3
+      unit:
+        tag: asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0
+        enum: ["DN"]
 propertyOrder: [meta, data, amp33]
 flowStyle: block
 required: [meta, data, amp33]


### PR DESCRIPTION
Add units to the schemas for science data quantities to specify allowed values.

Notes:
- ASDF library requirement update is to capture enum fix.
- Some objects have multiple units supported due to unit conversion (e.g. gain application, etc.) happening to model objects. (It is possible this may need expanding depending on how quantities are converted.)
- I made the units of crmag counts / s, but would it be better to use magnitude from astropy instead?
- I am less confident about the units of the intermediate ramp arrays (slope, yint, etc.).