### PR TITLE
Apply code formatters to `rad`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
       args: ["--py38-plus"]
       exclude: "asdf/extern/.*"
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,16 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py38-plus"]
-      exclude: "asdf/extern/.*"
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:
     - id: isort
+
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+    - id: black
 
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
-0.5.0 (unreleased)
-==================
+0.15.0 (unreleased)
+-------------------
+
+- Format the code with ``isort`` and ``black``. [#200]
 
 0.14.1 (2023-01-31)
 -------------------
@@ -30,8 +32,7 @@
 
 - Add reftype to IPC Schema. [#214]
 
-
-  0.14.0 (2022-11-04)
+0.14.0 (2022-11-04)
 -------------------
 
 - Use PSS views in SDF origin attribute. [#167]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,15 +25,13 @@
 import datetime
 import os
 import sys
-
-import stsci_rtd_theme
-
 from pathlib import Path
-from importlib_metadata import distribution
-import tomli
 
 # Ensure documentation examples are determinstically random.
 import numpy
+import stsci_rtd_theme
+import tomli
+from importlib_metadata import distribution
 
 try:
     numpy.random.seed(int(os.environ["SOURCE_DATE_EPOCH"]))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ version = ".".join(release.split(".")[:2])
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. To override the custom theme, set this to the
 # name of a builtin theme or the name of a custom theme in html_theme_path.
-html_theme = 'stsci_rtd_theme'
+html_theme = "stsci_rtd_theme"
 html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 
 html_static_path = ["_static"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,16 @@ asdf_schema_root = 'src/rad/resources/schemas'
 profile = "black"
 filter_files = true
 line_length = 130
+
+[tool.black]
+line-length = 130
+force-exclude = '''
+^/(
+  (
+      \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+  )/
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,8 @@ testpaths = [
 asdf_schema_tests_enabled = 'true'
 asdf_schema_skip_tests = 'src/rad/resources/schemas/rad_schema-1.0.0.yaml'
 asdf_schema_root = 'src/rad/resources/schemas'
+
+[tool.isort]
+profile = "black"
+filter_files = true
+line_length = 130

--- a/scripts/insert_next_release
+++ b/scripts/insert_next_release
@@ -3,9 +3,8 @@
 Insert the next release's changelog header.  Prints the version, which
 our GitHub Actions workflow uses to generate a commit message.
 """
-from pathlib import Path
 import re
-
+from pathlib import Path
 
 RELEASED_VERSION_RE = re.compile(r"\A(?P<major>[0-9]+)\.(?P<minor>[0-9])+\.[0-9]+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$", re.MULTILINE)
 

--- a/scripts/set_release_date
+++ b/scripts/set_release_date
@@ -4,10 +4,9 @@ Set the (latest and unreleased) changelog header release date to today.
 Prints the version, which our GitHub Actions workflow uses to
 generate a commit message and release tag.
 """
+import re
 from datetime import date
 from pathlib import Path
-import re
-
 
 UNRELEASED_VERSION_RE = re.compile(r"\A(?P<version>[0-9]+\.[0-9]+\.[0-9]+) \(unreleased\)$", re.MULTILINE)
 

--- a/src/rad/__init__.py
+++ b/src/rad/__init__.py
@@ -1,4 +1,3 @@
 from ._version import version as __version__
 
-
 __all__ = ["__version__"]

--- a/src/rad/integration.py
+++ b/src/rad/integration.py
@@ -19,6 +19,7 @@ def get_resource_mappings():
     list of collections.abc.Mapping
     """
     from . import resources
+
     resources_root = importlib_resources.files(resources)
 
     return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,4 @@ import yaml
 
 @pytest.fixture(scope="session")
 def manifest():
-    return yaml.safe_load(
-        asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"]
-    )
+    return yaml.safe_load(asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"])

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,16 +10,11 @@ import yaml
 
 SCHEMA_URI_PREFIX = "asdf://stsci.edu/datamodels/roman/schemas/"
 METASCHEMA_URI = "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0"
-SCHEMA_URIS = [
-    u for u in asdf.get_config().resource_manager
-    if u.startswith(SCHEMA_URI_PREFIX) and u != METASCHEMA_URI
-]
-WFI_OPTICAL_ELEMENTS = list(asdf.schema.load_schema(
-    "asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0")
-    ["enum"])
-EXPOSURE_TYPE_ELEMENTS = list(asdf.schema.load_schema(
-    "asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0")
-    ["enum"])
+SCHEMA_URIS = [u for u in asdf.get_config().resource_manager if u.startswith(SCHEMA_URI_PREFIX) and u != METASCHEMA_URI]
+WFI_OPTICAL_ELEMENTS = list(
+    asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0")["enum"]
+)
+EXPOSURE_TYPE_ELEMENTS = list(asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0")["enum"])
 
 
 @pytest.fixture(scope="session", params=SCHEMA_URIS)
@@ -35,12 +30,14 @@ def schema(request):
 @pytest.fixture(scope="session")
 def valid_tag_uris(manifest):
     uris = {t["tag_uri"] for t in manifest["tags"]}
-    uris.update([
-        "tag:stsci.edu:asdf/time/time-1.1.0",
-        "tag:stsci.edu:asdf/core/ndarray-1.0.0",
-        "tag:stsci.edu:asdf/unit/quantity-1.1.0",
-        "tag:stsci.edu:asdf/unit/unit-1.0.0",
-    ])
+    uris.update(
+        [
+            "tag:stsci.edu:asdf/time/time-1.1.0",
+            "tag:stsci.edu:asdf/core/ndarray-1.0.0",
+            "tag:stsci.edu:asdf/unit/quantity-1.1.0",
+            "tag:stsci.edu:asdf/unit/unit-1.0.0",
+        ]
+    )
     return uris
 
 
@@ -61,6 +58,7 @@ def test_property_order(schema, manifest):
     is_tag_schema = schema["id"] in {t["schema_uri"] for t in manifest["tags"]}
 
     if is_tag_schema:
+
         def callback(node):
             if isinstance(node, Mapping) and "propertyOrder" in node:
                 assert node.get("type") == "object"
@@ -78,6 +76,7 @@ def test_property_order(schema, manifest):
 
         asdf.treeutil.walk(schema, callback)
     else:
+
         def callback(node):
             if isinstance(node, Mapping):
                 assert "propertyOrder" not in node, "Only schemas associated with a tag may specify propertyOrder"
@@ -114,6 +113,7 @@ def test_flowstyle(schema, manifest):
 
         assert found_flowstyle, "Schemas associated with a tag must specify flowStyle: block"
     else:
+
         def callback(node):
             if isinstance(node, Mapping):
                 assert "flowStyle" not in node, "Only schemas associated with a tag may specify flowStyle"
@@ -131,9 +131,11 @@ def test_tag(schema, valid_tag_uris):
 
 # Confirm that the optical_element filter in wfi_img_photom.yml matches WFI_OPTICAL_ELEMENTS
 def test_matched_optical_element_entries():
-    phot_table_keys = list(asdf.schema.load_schema(
-        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0.0")
-        ["properties"]["phot_table"]["patternProperties"])
+    phot_table_keys = list(
+        asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0.0")["properties"][
+            "phot_table"
+        ]["patternProperties"]
+    )
     r = re.compile(phot_table_keys[0])
     for element_str in WFI_OPTICAL_ELEMENTS:
         assert r.search(element_str)
@@ -141,9 +143,9 @@ def test_matched_optical_element_entries():
 
 # Confirm that the p_keyword version of exposure type match the enum version
 def test_matched_p_exptype_entries():
-    p_exptype = asdf.schema.load_schema(
-        "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")[
-        "properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
+    p_exptype = asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")[
+        "properties"
+    ]["exposure"]["properties"]["p_exptype"]["pattern"]
     r = re.compile(p_exptype)
     for element_str in EXPOSURE_TYPE_ELEMENTS:
-        assert r.search(element_str + '|')
+        assert r.search(element_str + "|")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,13 +1,12 @@
 """
 Test features of the schemas not covered by the metaschema.
 """
+import re
 from collections.abc import Mapping
 
 import asdf
 import pytest
 import yaml
-import re
-
 
 SCHEMA_URI_PREFIX = "asdf://stsci.edu/datamodels/roman/schemas/"
 METASCHEMA_URI = "asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0"


### PR DESCRIPTION
This PR applies some code formatters to `rad`. Namely:

- [`isort`](https://pycqa.github.io/isort/) to sort the imports.
- [`black`](https://black.readthedocs.io/en/stable/) to consistently format the code.

Note that this PR is based off #199, which should be merged first.
