### PR TITLE
Apply `codespell` to `rad`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+    - id: codespell
+      args: ["--write-changes"]
+      additional_dependencies:
+        - tomli
+
 - repo: https://github.com/asottile/pyupgrade
   rev: 'v3.3.1'
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Switch linting from ``flake8`` to ``ruff``. [#201]
 
+- Start using ``codespell`` to check and correct spelling mistakes. [#202]
+
 0.14.1 (2023-01-31)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,10 +127,10 @@
   the border reference pixels, and another array containing the amp33 reference pixels.
   Ramp models also have an array that contains the science data and the border reference
   pixels and another array for the amp33 reference pixels, and they also contain four
-  seperate arrays that contain the original border reference pixels copied during
+  separate arrays that contain the original border reference pixels copied during
   the dq_init step (and four additional arrays for their DQ). The level 2 file data
   array only contains the science pixels (the border pixels are trimmed during ramp fit),
-  and contains seperate arrays for the original border pixels and their dq arrays, and
+  and contains separate arrays for the original border pixels and their dq arrays, and
   the amp33 reference pixels. [#112]
 
 - Added ``uncertainty`` attributes to ``photometry`` and ``pixelareasr``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure documentation examples are determinstically random.
+# Ensure documentation examples are deterministically random.
 import numpy
 import stsci_rtd_theme
 import tomli

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Roman Space Telescope shared attributes for processing and archive.
 
 .. note::
   These schemas are schemas for the :ref:`ASDF file <asdf-standard:asdf-standard>` file format, which
-  are used by ASDF to serialize and deserialze data for the Nancy Grace Roman Space Telescope.
+  are used by ASDF to serialize and deserialize data for the Nancy Grace Roman Space Telescope.
 
 Included Resources
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,8 @@ force-exclude = '''
 
 [tool.ruff]
 line-length = 130
+
+[tool.codespell]
+skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
+# ignore-words-list="""
+# """

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -74,7 +74,7 @@ properties:
           pedestal_resultant_exp_time:
             title: Total exposure time for the guide window pedestal frames
             description: |
-               The cummulative exposure time for all the guide window
+               The cumulative exposure time for all the guide window
                pedestal frames
             type: number
             sdf:
@@ -87,7 +87,7 @@ properties:
           signal_resultant_exp_time:
             title: Total exposure time for the guide window resultant frames
             description: |
-              The cummulative exposure time for all the guide window
+              The cumulative exposure time for all the guide window
               resultant frames
             type: number
             sdf:

--- a/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
@@ -16,7 +16,7 @@ properties:
             type: string
             enum: [SATURATION]
   data:
-    title: Saturation threshhold
+    title: Saturation threshold
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
     properties:
       value:


### PR DESCRIPTION
Applies the [`codespell`](https://github.com/codespell-project/codespell) to `rad` in order to automatically catch (and fix) most common spelling mistakes. Note that if `codespell` catches/fixes a word which is not misspelled, one can easily ignore the word by adding it to a new line under the `ignore-words-list` in the `pyproject.toml` file.

Note this is based on #201 so that it should be merged first.