### PR TITLE
Fix schemas with $ref  at root level

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Added PR Template. [#221]
 
+- Fix schemas with $ref at root level. [#222]
+
 
 0.14.1 (2023-01-31)
 -------------------

--- a/src/rad/resources/schemas/tagged_scalars/file_date-1.0.0.yaml
+++ b/src/rad/resources/schemas/tagged_scalars/file_date-1.0.0.yaml
@@ -4,7 +4,10 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/file_date-1.0.0
 
 title: Date this file was created (UTC)
-$ref: http://stsci.edu/schemas/asdf/time/time-1.1.0
+
+allOf:
+  - $ref: http://stsci.edu/schemas/asdf/time/time-1.1.0
+
 sdf:
   special_processing: VALUE_REQUIRED
   source:

--- a/src/rad/resources/schemas/unit/unit-1.0.0.yaml
+++ b/src/rad/resources/schemas/unit/unit-1.0.0.yaml
@@ -11,7 +11,8 @@ description: >
   The specific non-VOUnit units used by Roman will be checked/enforced by the
   converter.
 
-$ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+allOf:
+  - $ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
 
 flowStyle: block
 ...


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR moves root-level $ref properties to an allOf combiner.  The JSON Schema spec says that when $ref is present, all other properties in that object must be ignored:

https://datatracker.ietf.org/doc/html/draft-wright-json-schema-00#section-7

Which, when the $ref is at the top of the schema, includes critical properties such as "id".  The allOf combiner will have the same validation behavior but without the potentially nasty side effects.

This will be a warning in an upcoming version of asdf, and an error at some point after that.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
