### PR TITLE
Temporarily make source detection optional in cal_logs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@
 
 - Add schema for source detection. [#215]
 
+- Temporarily make source detection optional in cal_logs. [#224]
+
 
 
 0.14.1 (2023-01-31)

--- a/src/rad/resources/schemas/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/cal_step-1.0.0.yaml
@@ -78,6 +78,6 @@ properties:
       destination: [ScienceRefData.saturation]
 propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, ramp_fit, saturation]
 flowStyle: block
-required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, ramp_fit, saturation]
+required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, ramp_fit, saturation]
 additionalProperties: true
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-116](https://jira.stsci.edu/browse/RAD-116)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #223 

<!-- describe the changes comprising this PR here -->
This PR temporarily makes the source detection step in cal_logs optional, to minimize regression test file recreation.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
