### PR TITLE
Remove use of `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.15.0 (unreleased)
+-------------------
+
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning`` s. [#231]
+
 0.14.2 (2023-03-31)
 -------------------
 
@@ -22,7 +28,7 @@
 - Add database team to Code Owners file [#227]
 
 - update CodeOwners file [#230]
-  
+
 
 0.14.1 (2023-01-31)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dynamic = ['version']
 [project.optional-dependencies]
 test = [
     'pytest>=4.6.0',
-    'pytest-openfiles>=0.5.0',
     'pytest-doctestplus>=0.11.1',
 ]
 docs = [
@@ -65,10 +64,13 @@ minversion = 4.6
 doctest_plus = true
 doctest_rst = true
 text_file_format = 'rst'
-addopts = '--show-capture=no --open-files'
+addopts = '--show-capture=no'
 testpaths = [
     'tests',
     'src/rad/resources/schemas',
+]
+filterwarnings = [
+    "error::ResourceWarning",
 ]
 asdf_schema_tests_enabled = 'true'
 asdf_schema_skip_tests = 'src/rad/resources/schemas/rad_schema-1.0.0.yaml'


### PR DESCRIPTION
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
