### PR TITLE
Add missing distortion keyword to `ref_file`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.15.0 (unreleased)
+-------------------
+
+- Add ``distortion`` keyword to ``ref_file-1.0.0`` schema. [#234]
+
 0.14.2 (2023-03-31)
 -------------------
 
@@ -22,7 +27,7 @@
 - Add database team to Code Owners file [#227]
 
 - update CodeOwners file [#230]
-  
+
 
 0.14.1 (2023-01-31)
 -------------------

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -37,6 +37,9 @@ properties:
   dark:
     title: Dark reference file information
     type: string
+  distortion:
+    title: Distortion reference file information
+    type: string
   mask:
     title: Mask reference file information
     type: string


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
In spacetelescope/roman_datamodels#151 it was found that the `distortion` keyword is missing from `ref_file-1.0.0`, see https://github.com/spacetelescope/roman_datamodels/issues/151#issuecomment-1507581477 for details.

This PR adds the `distortion` keyword to `ref_file`.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
