### PR TITLE
Turn off milestone checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# automatically requests pull request reviews for files matching the given pattern; the last match takes precendence
+# automatically requests pull request reviews for files matching the given pattern; the last match takes precedence
 
 *       @spacetelescope/rad-maintainers @WilliamJamieson
 # Add Kim, Kimberly DuPrie <kduprie@stsci.edu>, add jbrookens@stsci.edu

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,4 +21,5 @@ jobs:
       uses: pllim/action-check_astropy_changelog@main
       env:
         CHANGELOG_FILENAME: CHANGES.rst
+        CHECK_MILESTONE: false
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 - Add ``distortion`` keyword option to the list of reference files, so that the ``distortion``
   reference file can be properly allowed in by the ``ref_file-1.0.0`` schema. [#237]
 
+- Changelog CI workflow has been added. [#240]
+
 0.14.2 (2023-03-31)
 -------------------
 


### PR DESCRIPTION
The changelog CI currently really wants us to set milestones on our PRs. While adding milestones is technically best practice in this case, the reality of the actual development here is that we don't do this.

This PR turns off milestone checking in for our changelog.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
