### PR TITLE
Fully specify the `patternProperties` values for the `wfi_img_photom` schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@
 - Remove the unused ``pixelarea-1.0.0`` schema, which was replaced by the
   ``reference_files/pixelarea-1.0.0`` schema. [#245]
 
+- Add further restrictions to the ``patternProperties`` keywords in the
+  ``wfi_img_photom`` schema. [#254]
 
 0.14.2 (2023-03-31)
 -------------------

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -26,16 +26,34 @@ properties:
             title: Surface brightness, in MJy/steradian
             anyOf:
               - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                properties:
+                  value:
+                    type: number
+                  unit:
+                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    enum: [MJy.sr**-1]
               - type: "null"
           uncertainty:
             title: Uncertainty of surface brightness, in MJy/steradian
             anyOf:
               - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                properties:
+                  value:
+                    type: number
+                  unit:
+                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    enum: [MJy.sr**-1]
               - type: "null"
           pixelareasr:
             title: Nominal pixel area, in steradian
             anyOf:
               - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                properties:
+                  value:
+                    type: number
+                  unit:
+                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    enum: [sr]
               - type: "null"
         required: [photmjsr, uncertainty, pixelareasr]
     additionalProperties: false


### PR DESCRIPTION
Part of the reason why the issue leading to spacetelescope/roman_datamodels#170 was discovered was that end users were attempting to set the modified values as arrays. These values are expected to be scalar quantities with a specific unit. This PR adds additional conditions on these values to exactly specify them to be scalar quantities with a given unit.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
