### PR TITLE
RAD-119 Update program to be a string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.15.0 (unreleased)
 -------------------
 
+- Update program to be a string to match association code [#255]
+
 - Update guide star id, add catalog version, and add science file name [#258]
 
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -42,7 +42,7 @@ properties:
       source:
         origin: TBD
     archive_catalog:
-      datatype: smallint
+      datatype: int
       destination: [ScienceCommon.program, GuideWindow.program]
   execution_plan:
     title: Execution plan within the program, defined range is 1..99; included in obs_id and

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -36,14 +36,13 @@ properties:
       destination: [ScienceCommon.visit_id, GuideWindow.visit_id]
   program:
     title: Program number, defined range is 1..18445; included in obs_id and visit_id as 'PPPPP'.
-    type: integer
+    type: string
     sdf:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [ScienceCommon.program, GuideWindow.program]
+      datatype: nvarchar(5)
+      destination: [ScienceCommon.program, GuideWondow.program]
   execution_plan:
     title: Execution plan within the program, defined range is 1..99; included in obs_id and
            visit_id as 'CC'.

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -41,8 +41,9 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-      datatype: nvarchar(5)
-      destination: [ScienceCommon.program, GuideWondow.program]
+    archive_catalog:
+      datatype: smallint
+      destination: [ScienceCommon.program, GuideWindow.program]
   execution_plan:
     title: Execution plan within the program, defined range is 1..99; included in obs_id and
            visit_id as 'CC'.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-119](https://jira.stsci.edu/browse/RAD-119)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #251 

<!-- describe the changes comprising this PR here -->
This PR updates the program to be a string to match association code.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/

pytest tests/
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/rad
configfile: pyproject.toml
plugins: remotedata-0.4.0, hypothesis-6.75.1, asdf-2.15.0, mock-3.10.0, filter-subpackage-0.1.2, astropy-header-0.2.2, doctestplus-0.12.1, astropy-0.10.0, cov-4.0.0, ci-watson-0.6.1, openfiles-0.5.0, arraydiff-0.5.0
collected 397 items

tests/test_integration.py ..........................................................                                                                [ 14%]
tests/test_manifest.py .                                                                                                                            [ 14%]
tests/test_schemas.py ............................................................................................................................. [ 46%]
................................................................................................................................................... [ 83%]
..................................................................                                                                                  [100%]

=================================================================== 397 passed in 2.52s
