### PR TITLE
Bugfix for `inverse_linearity-1.0.0` `reftype`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@
 
 - Fix minor discrepancies found when looking over the schemas. [#267]
 
+
+- Bugfix for ``inverse_linearity-1.0.0``'s ``reftype`` so that it is CRDS
+  compatible. [#272]
+
 0.15.0 (2023-05-12)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dynamic = ['version']
 test = [
     'pytest>=4.6.0',
     'pytest-doctestplus>=0.11.1',
+    'crds>=11.16.16',
 ]
 docs = [
     'sphinx',

--- a/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
@@ -14,7 +14,7 @@ properties:
         properties:
           reftype:
             type: string
-            enum: [INVERSE-LINEARITY]
+            enum: [INVERSELINEARITY]
           input_units:
             title: Units of the input to the inverse linearity polynomial.
             tag: tag:astropy.org:astropy/units/unit-1.0.0

--- a/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
@@ -14,7 +14,7 @@ properties:
         properties:
           reftype:
             type: string
-            enum: [INVERSE_LINEARITY]
+            enum: [INVERSE-LINEARITY]
           input_units:
             title: Units of the input to the inverse linearity polynomial.
             tag: tag:astropy.org:astropy/units/unit-1.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ import asdf
 import pytest
 import yaml
 
+MANIFEST = yaml.safe_load(asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"])
+
 
 @pytest.fixture(scope="session")
 def manifest():
-    return yaml.safe_load(asdf.get_config().resource_manager["asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0"])
+    return MANIFEST


### PR DESCRIPTION
Resolves [RAD-126](https://jira.stsci.edu/browse/RAD-126)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #271

<!-- describe the changes comprising this PR here -->
This updates the `reftype` in the `inverse_linearity-1.0.0` schema to be compatible with CRDS. Additionally, it adds tests to the test suite to ensure future `reftype` values are CRDS compatible. 

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests (spacetelescope/roman_datamodels#195)
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-devdeps/299/
