### PR TITLE
Add entry to schemas to indicate Datamodel object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 - Add schema ``refpix-1.0.0`` as a schema for the reference pixel correction's
   reference file. [#270]
 
+- Add keyword to indicate if and which datamodel the schema describes. [#278]
+
 0.15.0 (2023-05-12)
 -------------------
 

--- a/src/rad/resources/schemas/associations-1.0.0.yaml
+++ b/src/rad/resources/schemas/associations-1.0.0.yaml
@@ -5,6 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/associations-1.0.0
 
 title: Association table data model
 
+datamodel_name: AssociationsModel
 
 type: object
 properties:

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -4,6 +4,9 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.0.0
 
 title: Guide window information
+
+datamodel_name: GuidewindowModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/rad_schema-1.0.0.yaml
+++ b/src/rad/resources/schemas/rad_schema-1.0.0.yaml
@@ -12,6 +12,11 @@ allOf:
   - $ref: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
   - type: object
     properties:
+      datamodel_name:
+        description: |-
+          The name of the datamodel that this schema describes.
+        type: string
+
       sdf:
         description: |-
           Documents source of this attribute's value when level 1

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.0.0
 
 title: Ramp schema
 
+datamodel_name: RampModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.0.0
 
 title: Ramp fit output schema
 
+datamodel_name: RampFitOutputModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
 
 title: Dark reference schema
 
+datamodel_name: DarkRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.0.0
 
 title: Distortion reference schema
 
+datamodel_name: DistortionRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.0.0
 
 title: Flat reference schema
 
+datamodel_name: FlatRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
 
 title: Gain reference schema
 
+datamodel_name: GainRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverse_linearity-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverse_linearity-
 
 title: Inverse linearity correction reference schema
 
+datamodel_name: InverseLinearityRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.0.0
 
 title: IPC kernel reference schema
 
+datamodel_name: IpcRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.0.0
 
 title: Linearity correction  reference schema
 
+datamodel_name: LinearityRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -5,6 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
 
 title: DQ Mask reference schema
 
+datamodel_name: MaskRefModel
 
 type: object
 properties:

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.0.0
 
 title: Pixel area reference schema
 
+datamodel_name: PixelareaRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
 
 title: Read noise reference schema
 
+datamodel_name: ReadnoiseRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.0.0
 
 title: Reference Pixel Correction Reference Schema
 
+datamodel_name: RefpixRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.0.0
 
 title: Saturation reference schema
 
+datamodel_name: SaturationRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.0.0
 
 title: Super-bias reference schema
 
+datamodel_name: SuperbiasRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -5,6 +5,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0
 
 title: WFI imaging photometric flux conversion data model
 
+datamodel_name: WfiImgPhotomRefModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -6,6 +6,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.0.0
 title: |
   The schema for WFI Level 2 images.
 
+datamodel_name: ImageModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -6,6 +6,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.0.0
 title: |
   The schema for WFI Level 3 mosaics.
 
+datamodel_name: MosaicModel
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -6,6 +6,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.0.0
 title: |
   The schema for Level 1 WFI science data (both imaging and spectrographic).
 
+datamodel_name: ScienceRawModel
+
 type: object
 properties:
   meta:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently, it can be slightly annoying to determine which schema represents the top-level schema for a given datamodel. This is because the datamodel name does not always precisely map back to the tag_uri, schema_uri, or schema name for the top-level schema, though in most cases it does but there is not a single consistent pattern among all such maps. For example

- The [`wfi_image-1.0.0` schema ](https://github.com/spacetelescope/rad/blob/main/src/rad/resources/schemas/wfi_image-1.0.0.yaml) maps to the [`ImageModel`](https://github.com/spacetelescope/roman_datamodels/blob/a271364d530e35c1b3580fdc414e417f44620c53/src/roman_datamodels/datamodels.py#L327-L328)
- While the [`ramp-1.0.0` schema](https://github.com/spacetelescope/rad/blob/main/src/rad/resources/schemas/ramp-1.0.0.yaml) maps to the [`RampModel`](https://github.com/spacetelescope/roman_datamodels/blob/a271364d530e35c1b3580fdc414e417f44620c53/src/roman_datamodels/datamodels.py#L335-L369)
(the `Wfi` prefix has been removed).

Moreover, not all tagged schemas correspond to a datamodel.

The this creates three issues:

1. It makes it annoying (there are multiple patterns to try) to search RAD for the corresponding schema to one's datamodel.
2. There is no way to definitively test that each datamodel does map back to a given schema.
3. There is no way to test that a datamodel exists for each of the top-level schemas. 

A simple solution for this is to define an optional keyword to the schemas which indicates the name of the datamodel which the schema is intended to be the top-level schema. This keyword would both:

1. Indicate which schemas correspond as top-level schemas to some datamodel. Meaning one can assemble the full data-structure for all the different ASDF files using only information contained naturally within RAD.
2. Enable exact matching between datamodels and their top-level schema. Meaning there is now a uniform search term for RAD and roman_datamodels and we can create tests that ensure all the indented datamodels do in fact exist.

This pull request adds the keyword `datamodel_name`,  which is defined by the meta-schema to point at a string, which is intended to be the name of the datamodel in question. For example if one wanted to indicate a schema corresponded to the `FooModel`, one would add:
```yaml
datamodel_name: FooModel
```
as a primary key (like `title`) to the schema in question. This keyword is not required, so only schemas which are intended to be top-level need to add it.

Note that I am not convinced `datamodel_name` is the best keyword to use; however, it explicitly indicates its purpose (the name of a datamodel) and I have serious doubts that we would ever need to actually add a data field to one of our files under that name. Thus I am open to better keyword names.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- ~[ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~ (This makes no changes to anything touching `romancal` at the moment.)
