### PR TITLE
Add archive_meta keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 
 - Fix the URIs for ``inverselinearity`` and add consistency checks for names/uris. [#296]
 
+- Add ``archive_meta`` keyword for the MAST archive to encode information specific
+  to the archive's needs. [#279]
+
 0.16.0 (2023-06-26)
 -------------------
 

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -7,6 +7,8 @@ title: Guide window information
 
 datamodel_name: GuidewindowModel
 
+archive_meta: None
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/rad_schema-1.0.0.yaml
+++ b/src/rad/resources/schemas/rad_schema-1.0.0.yaml
@@ -17,6 +17,12 @@ allOf:
           The name of the datamodel that this schema describes.
         type: string
 
+      archive_meta:
+        description: |-
+          Metadata to aide the archive in determining how to handle
+          a given file.
+        type: string
+
       sdf:
         description: |-
           Documents source of this attribute's value when level 1

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -7,6 +7,7 @@ title: |
   The schema for WFI Level 2 images.
 
 datamodel_name: ImageModel
+archive_meta: None
 
 type: object
 properties:

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -8,6 +8,8 @@ title: |
 
 datamodel_name: MosaicModel
 
+archive_meta: None
+
 type: object
 properties:
   meta:

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -8,6 +8,8 @@ title: |
 
 datamodel_name: ScienceRawModel
 
+archive_meta: None
+
 type: object
 properties:
   meta:


### PR DESCRIPTION
This PR adds an archive_meta keyword to the file-level schemas relevant to the archive. Currently, this keyword does not carry any information other than marking the schemas; however, discussions of how to structure this information are still on-going. This information will be added in follow-on pull requests.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
