### PR TITLE
fix uri fragment in rad_schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.17.0 (unreleased)
+-------------------
+
+- Fix invalid uri fragment in rad_schema. [#286]
+
 0.16.0 (2023-06-26)
 -------------------
 

--- a/src/rad/resources/schemas/rad_schema-1.0.0.yaml
+++ b/src/rad/resources/schemas/rad_schema-1.0.0.yaml
@@ -99,7 +99,7 @@ allOf:
         additionalProperties:
           anyOf:
             - $ref: "#"
-            - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
+            - $ref: "http://json-schema.org/draft-04/schema#/definitions/stringArray"
       allOf:
         $ref: "#/definitions/schemaArray"
       anyOf:


### PR DESCRIPTION
This uri fragment in rad_schema is invalid:
https://github.com/spacetelescope/rad/blob/97baad66112ee72ac31ac8da52b2a19e55efd401/src/rad/resources/schemas/rad_schema-1.0.0.yaml#L102
we were getting away with this because python jsonschema < 4.18 was less strict.

See https://github.com/asdf-format/asdf-standard/pull/373 for similar changes in asdf-standard.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
