### PR TITLE
Add resample step to cal_step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,10 @@
 
 - Fix invalid uri fragment in rad_schema. [#286]
 
-- Update the steps listed in ``cal_steps`` to reflect the currently implemented steps.
+- Update the steps listed in ``cal_step`` to reflect the currently implemented steps.
   The new additions are ``outlier_detection``, ``refpix``, ``sky_match``, and ``tweak_reg``. [#282]
+
+- Update the steps listed in ``cal_step`` with the ``resample`` step. [#295]
 
 0.16.0 (2023-06-26)
 -------------------

--- a/src/rad/resources/schemas/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/cal_step-1.0.0.yaml
@@ -104,7 +104,14 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.skymatch, GuideWindow.skymatch]
-propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
+  resample:
+    title: Resample Step
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.resample, GuideWindow.skymatch]
+propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg, resample]
 flowStyle: block
 required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, ramp_fit, saturation]
 additionalProperties: true


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
PR #282 missed adding the `resample` step to`cal_step-1.0.0`. This PR adds the missing `resample` keyword. 

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~ This adds a non-required field to `cal_step` which currently does not exist. Thus this cannot currently create any failures.
