### PR TITLE
BOT: Changelog check has moved

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check change log entry
-      uses: pllim/action-check_astropy_changelog@main
+      uses: scientific-python/action-check-changelogfile@6087eddce1d684b0132be651a4dad97699513113  # 0.2
       env:
         CHANGELOG_FILENAME: CHANGES.rst
         CHECK_MILESTONE: false

--- a/README.md
+++ b/README.md
@@ -92,4 +92,3 @@ installed too:
 Need other useful packages in your development environment?
 
     pip install ipython pytest-xdist
-


### PR DESCRIPTION
Changelog check has moved upstream to Scientific Python. Trust me because I am the original author of the bot and I moved it during Scipy 2023 conference.

xref https://github.com/scientific-python/action-check-changelogfile/issues/4

**Checklist**

Your checklist is irrelevant here. This does not need a change log (otherwise it would be too meta).