### PR TITLE
Add missing unit enforcements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Require all the new ``cal_step`` steps to be present in the ``cal_step`` schema. [#301]
 
+- Add missing unit enforcements to various schemas. [#300]
+
 0.17.0 (2023-07-27)
 -------------------
 

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -10,6 +10,10 @@ properties:
     title: Flux density (MJy/steradian) producing 1 cps
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["MJy.sr**-1"]
       - type: "null"
     archive_catalog:
       datatype: float
@@ -18,6 +22,10 @@ properties:
     title: Flux density (uJy/arcsec2) producing 1 cps
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["uJy.arcsec**-2"]
       - type: "null"
     archive_catalog:
       datatype: float
@@ -26,6 +34,10 @@ properties:
     title: Nominal pixel area in steradians
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["sr"]
       - type: "null"
     archive_catalog:
       datatype: float
@@ -34,6 +46,10 @@ properties:
     title: Nominal pixel area in arcsec^2
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["arcsec**2"]
       - type: "null"
     archive_catalog:
       datatype: float
@@ -42,14 +58,22 @@ properties:
     title: Uncertainty in flux density conversion to MJy/steradians
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["MJy.sr**-1"]
       - type: "null"
     archive_catalog:
       datatype: float
       destination: [ScienceCommon.conversion_megajanskys_uncertainty]
   conversion_microjanskys_uncertainty:
-    title: Uncertainty in flux density conversion to uJy/steradians
+    title: Uncertainty in flux density conversion to uJy/arcsec2
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        properties:
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            enum: ["uJy.arcsec**-2"]
       - type: "null"
     archive_catalog:
       datatype: float

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -11,6 +11,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["MJy.sr**-1"]
@@ -23,6 +25,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["uJy.arcsec**-2"]
@@ -35,6 +39,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["sr"]
@@ -47,6 +53,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["arcsec**2"]
@@ -59,6 +67,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["MJy.sr**-1"]
@@ -71,6 +81,8 @@ properties:
     anyOf:
       - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
         properties:
+          datatype:
+            enum: ["float64"]
           unit:
             tag: tag:stsci.edu:asdf/unit/unit-1.0.0
             enum: ["uJy.arcsec**-2"]

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -24,11 +24,19 @@ properties:
                 title: Nominal pixel area in steradians
                 anyOf:
                   - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                    properties:
+                      unit:
+                        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                        enum: ["sr"]
                   - type: "null"
               pixelarea_arcsecsq:
                 title: Nominal pixel area in arcsec^2
                 anyOf:
                   - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                    properties:
+                      unit:
+                        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                        enum: ["arcsec**2"]
                   - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
         required: [photometry]

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -25,6 +25,8 @@ properties:
                 anyOf:
                   - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
                     properties:
+                      datatype:
+                        enum: ["float64"]
                       unit:
                         tag: tag:stsci.edu:asdf/unit/unit-1.0.0
                         enum: ["sr"]
@@ -34,6 +36,8 @@ properties:
                 anyOf:
                   - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
                     properties:
+                      datatype:
+                        enum: ["float64"]
                       unit:
                         tag: tag:stsci.edu:asdf/unit/unit-1.0.0
                         enum: ["arcsec**2"]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds enforcement of the units specified by descriptions of keywords, but which were not enforced by the schemas.

closes #268

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
