### PR TITLE
Add archive_catalog field to ref_file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 0.18.0 (unreleased)
 -------------------
 
--
+- Added "archive_catalog" field to ref_file. [#303]
+
+- Added a prefix "s_" to the archive destination in "cal_step". [#303]
 
 0.17.0 (2023-07-27)
 -------------------

--- a/src/rad/resources/schemas/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/cal_step-1.0.0.yaml
@@ -12,105 +12,105 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.assign_wcs, GuideWindow.assign_wcs]
+      destination: [ScienceRefData.s_assign_wcs, GuideWindow.s_assign_wcs]
   flat_field:
     title: Flat Field Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.flat_field, GuideWindow.flat_field]
+      destination: [ScienceRefData.s_flat_field, GuideWindow.s_flat_field]
   dark:
     title: Dark Subtraction
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.dark, GuideWindow.dark]
+      destination: [ScienceRefData.s_dark, GuideWindow.s_dark]
   dq_init:
     title: Data Quality Mask Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.dq_init, GuideWindow.dq_init]
+      destination: [ScienceRefData.s_dq_init, GuideWindow.s_dq_init]
   jump:
     title: Jump Detection Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.jump, GuideWindow.jump]
+      destination: [ScienceRefData.s_jump, GuideWindow.s_jump]
   linearity:
     title: Linearity Correction
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.linearity, GuideWindow.linearity]
+      destination: [ScienceRefData.s_linearity, GuideWindow.s_linearity]
   photom:
     title: Photometry Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.photom, GuideWindow.photom]
+      destination: [ScienceRefData.s_photom, GuideWindow.s_photom]
   source_detection:
     title: Source Detection Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.source_detection, GuideWindow.source_detection]
+      destination: [ScienceRefData.s_source_detection, GuideWindow.s_source_detection]
   ramp_fit:
     title: Ramp Fitting
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.ramp_fit, GuideWindow.ramp_fit]
+      destination: [ScienceRefData.s_ramp_fit, GuideWindow.s_ramp_fit]
   refpix:
     title: Reference Pixel Correction
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.refpix, GuideWindow.refpix]
+      destination: [ScienceRefData.s_refpix, GuideWindow.s_refpix]
   saturation:
     title: Saturation Checking
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.saturation, GuideWindow.saturation]
+      destination: [ScienceRefData.s_saturation, GuideWindow.s_saturation]
   outlier_detection:
     title: outlier_detection
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.outlier_detection, GuideWindow.outlier_detection]
+      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection]
   tweakreg:
     title: Tweakreg step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.tweakreg, GuideWindow.tweak_reg]
+      destination: [ScienceRefData.s_tweakreg, GuideWindow.s_tweakreg]
   skymatch:
     title: Sky Match step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.skymatch, GuideWindow.skymatch]
+      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch]
   resample:
     title: Resample Step
     type: string
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.resample, GuideWindow.skymatch]
+      destination: [ScienceRefData.s_resample, GuideWindow.s_resample]
 propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg, resample]
 flowStyle: block
 required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, ramp_fit, saturation]

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -36,33 +36,63 @@ properties:
   dark:
     title: Dark reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_dark, GuideWindow.r_dark]
   distortion:
     title: Distortion reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_distortion, GuideWindow.r_distortion]
   mask:
     title: Mask reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_mask, GuideWindow.r_mask]
   flat:
     title: Flat reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_flat, GuideWindow.r_flat]
   gain:
     title: Gain reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_gain, GuideWindow.r_gain]
   readnoise:
     title: Read noise reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_readnoise, GuideWindow.r_readnoise]
   linearity:
     title: Linearity reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_linearity, GuideWindow.r_linearity]
   photom:
     title: Photometry reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_photom, GuideWindow.r_photom]
   area:
     title: Area reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_area, GuideWindow.r_area]
   saturation:
     title: Saturation reference file information
     type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_saturation, GuideWindow.r_saturation]
 
 flowStyle: block
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-nnnn](https://jira.stsci.edu/browse/RAD-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue with archiving the reference files and populating the archive catalog. Previously the `archive_catalog` field was missing from the `ref_file` schema which caused the names of the files to not be populated in the database. In addition, there's a name collision because `reftype` is used  in `cal_step` and `ref_file`. While this is OK for the science files because they are under different tags, in the archive they go in the same database, and so for example `ref_file.dark` and `cal_step.dark` both map to `dark`. To resolve the name collision the archive destination names were changed: the ones in `cal_step` were prefixed with `s`, and the ones in `ref_file` were prefixed with `r`.

Note that these changes do not affect data files and so no changes are needed in roman_datamodels.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
