### PR TITLE
TST: Use Python 3.12 stable

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -23,4 +23,3 @@ jobs:
         - macos: py39-xdist
         - macos: py310-xdist
         - linux: py312-xdist-devdeps
-          python-version: "3.12-dev"


### PR DESCRIPTION
Python 3.12 is released.