### PR TITLE
RAD-136 Add Slope and Error to Dark

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.17.2 (unreleased)
 -------------------
 
--
+- Added Slope and Error to Dark reference schema. [#323]
 
 0.17.1 (2023-08-03)
 -------------------

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -69,7 +69,33 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.0.0
         enum: ["DN"]
+  dark_slope:
+    title: Dark current slope array
+    description: |
+       The dark current slope array represents the slope of the
+       integrated number of counts due to the accumulation of dark
+       current electrons in the pixels for slope fitting purposes.
+    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    properties:
+      value:
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 2
+      unit:
+        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        enum: ["DN / s"]
+  dark_slope_error:
+    title: Uncertainty in dark current slope array
+    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    properties:
+      value:
+        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        datatype: float32
+        ndim: 2
+      unit:
+        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        enum: ["DN / s"]
 required: [meta, data, dq, err]
 flowStyle: block
-propertyOrder: [meta, data, dq, err]
+propertyOrder: [meta, data, dq, err, dark_slope, dark_slope_error]
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-136](https://jira.stsci.edu/browse/RAD-136)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #318 

<!-- describe the changes comprising this PR here -->
This PR addresses adding slope and slope error to the dark reference file for use in the ramp fitting step. 

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/408/
