### PR TITLE
RAD-133: Expanded origin db string length.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Removed ``err`` array from dark schema. [#324]
 
+- Expanded origin db string length. [#326]
+
 0.17.1 (2023-08-03)
 -------------------
 

--- a/src/rad/resources/schemas/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/tagged_scalars/origin-1.0.0.yaml
@@ -13,7 +13,7 @@ sdf:
   source:
     origin: TBD
 archive_catalog:
-  datatype: nvarchar(5)
+  datatype: nvarchar(15)
   destination: [ScienceCommon.origin]
 
 flowStyle: block


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-133](https://jira.stsci.edu/browse/RAD-133)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #315 

<!-- describe the changes comprising this PR here -->
This PR expands the origin max character length in the archive catalog section.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
