### PR TITLE
RAD-132: Added optional dq array to Science Raw

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Updated minimum python version to 3.9. [#325]
 
+- Added optional dq array. [#328]
+
 0.17.1 (2023-08-03)
 -------------------
 

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -25,6 +25,11 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.0.0
         enum: ["DN"]
+  resultantdq:
+    title: Optional 3-D data quality array (plane dq for each resultant)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 3
+    datatype: uint8
   amp33:
     title: Amp 33 reference pixel data.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -36,7 +41,7 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.0.0
         enum: ["DN"]
-propertyOrder: [meta, data, amp33]
+propertyOrder: [meta, data, amp33, resultantdq]
 flowStyle: block
 required: [meta, data, amp33]
 ...

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -25,11 +25,7 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.0.0
         enum: ["DN"]
-  resultantdq:
-    title: Optional 3-D data quality array (plane dq for each resultant)
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
-    ndim: 3
-    datatype: uint8
+
   amp33:
     title: Amp 33 reference pixel data.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
@@ -41,6 +37,12 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.0.0
         enum: ["DN"]
+
+  resultantdq:
+    title: Optional 3-D data quality array (plane dq for each resultant)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    ndim: 3
+    datatype: uint8
 propertyOrder: [meta, data, amp33, resultantdq]
 flowStyle: block
 required: [meta, data, amp33]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-132](https://jira.stsci.edu/browse/RAD-132)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #304 

<!-- describe the changes comprising this PR here -->
This PR adds an optional dq array to the Raw Science schema for use in labelling dropouts.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
