### PR TITLE
Install dev wheels properly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,16 +19,16 @@ description =
     cov: with coverage
     xdist: using parallel processing
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 extras =
     test
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-commands_pre =
-    devdeps: pip install numpy>=0.0.dev0 git+https://github.com/astropy/astropy.git -U --upgrade-strategy eager
-    pip freeze
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
 commands =
+    pip freeze
     pytest \
     xdist: -n auto \
     cov: --cov --cov-report=term-missing --cov-report=xml \


### PR DESCRIPTION
You can simplify dev wheel install and you can install astropy dev from wheel. You don't need commands_pre. Come to think of it, you should also really test with scipy dev but I'll leave that up to you.