### PR TITLE
switch tag keywords for external tags to wildcards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.19.1 (unreleased)
 -------------------
 
--
+- Convert tag keywords to wildcards for external tags. [#370]
+
 
 0.19.0 (2024-02-09)
 -------------------
@@ -12,7 +13,6 @@
 
 - Add wcs tag to wfi_image and wfi_mosaic schemas. [#351]
 
-- Convert tag keywords to wildcards for external tags. [#370]
 
 0.18.0 (2023-11-06)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 
 - Add wcs tag to wfi_image and wfi_mosaic schemas. [#351]
 
+- Convert tag keywords to wildcards for external tags. [#370]
+
 0.18.0 (2023-11-06)
 -------------------
 

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -36,7 +36,7 @@ properties:
     description: |
         This is a python date-time object that records the
         time at the start of the exposure in UTC.
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -49,7 +49,7 @@ properties:
     description: |
         This is a python date-time object that records the
         time at the middle of the exposure in UTC.
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -62,7 +62,7 @@ properties:
     description: |
         This is a python date-time object that records the
         time at the end of the exposure in UTC.
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -18,7 +18,7 @@ properties:
         properties:
           gw_start_time:
             title: UTC time at the start of the guide window exposure
-            tag: tag:stsci.edu:asdf/time/time-1.1.0
+            tag: tag:stsci.edu:asdf/time/time-1.*
             sdf:
               special_processing: VALUE_REQUIRED
               source:
@@ -28,7 +28,7 @@ properties:
               destination: [GuideWindow.gw_start_time]
           gw_end_time:
             title: UTC time at the end of the guide window exposure
-            tag: tag:stsci.edu:asdf/time/time-1.1.0
+            tag: tag:stsci.edu:asdf/time/time-1.*
             sdf:
               special_processing: VALUE_REQUIRED
               source:
@@ -48,7 +48,7 @@ properties:
               destination: [GuideWindow.gw_frame_readout_time]
           gw_function_start_time:
             title: Observatory UTC time at guider function start
-            tag: tag:stsci.edu:asdf/time/time-1.1.0
+            tag: tag:stsci.edu:asdf/time/time-1.*
             sdf:
               special_processing: VALUE_REQUIRED
               source:
@@ -58,7 +58,7 @@ properties:
               destination: [GuideWindow.gw_function_start_time]
           gw_function_end_time:
             title: Observatory UTC time at guider function end
-            tag: tag:stsci.edu:asdf/time/time-1.1.0
+            tag: tag:stsci.edu:asdf/time/time-1.*
             sdf:
               special_processing: VALUE_REQUIRED
               source:
@@ -208,40 +208,40 @@ properties:
     title: "Reconstituted and oriented pedestal frame GW images.
              Dimensions: num_frames, num_combined_resultants
              (or num_uncombined_resultants), num_reads, x, y"
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 5
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   signal_frames:
     title: "Reconstituted and oriented signal frames. Dimensions: num_frames,
             num_combined_resultants (or num_uncombined_resultants),
             num_reads, x, y"
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 5
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   amp33:
     title: "Amp 33 reference pixel data. Dimensions: num_frames,
             num_combined_resultants (or num_uncombined_resultants),
             num_reads, x, y"
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 5
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
 propertyOrder: [meta, pedestal_frames, signal_frames, amp33]
 flowStyle: block

--- a/src/rad/resources/schemas/individual_image_meta-1.0.0.yaml
+++ b/src/rad/resources/schemas/individual_image_meta-1.0.0.yaml
@@ -10,71 +10,71 @@ properties:
   basic:
     description: |
       Table of basic level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   aperture:
     description: |
       Table of aperture level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   cal_step:
     description: |
       Table of cal_step level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   coordinates:
     description: |
       Table of coordinates level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   ephemeris:
     description: |
       Table of ephemeris level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   exposure:
     description: |
       Table of exposure level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   guidestar:
     description: |
       Table of guidestar level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   instrument:
     description: |
       Table of instrument level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   observation:
     description: |
       Table of observation level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   photometry:
     description: |
       Table of photometry level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   pointing:
     description: |
       Table of pointing level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   program:
     description: |
       Table of program level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   ref_file:
     description: |
       Table of ref_file level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   target:
     description: |
       Table of target level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   velocity_aberration:
     description: |
       Table of velocity_aberration level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   visit:
     description: |
       Table of visit level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
   wcsinfo:
     description: |
       Table of wcsinfo level 2 metadata.
-    tag: tag:astropy.org:astropy/table/table-1.1.0
+    tag: tag:astropy.org:astropy/table/table-1.*
 flowStyle: block
 propertyOrder: [basic, aperture, cal_step, coordinates, ephemeris,
 exposure, guidestar, instrument, observation, photometry,

--- a/src/rad/resources/schemas/msos_stack-1.0.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.0.0.yaml
@@ -18,25 +18,25 @@ properties:
   data:
     title: Flux data
     value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
       datatype: float64
       ndim: 2
   uncertainty:
     title: uncertainty data
     value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
       datatype: float64
       ndim: 2
   mask:
     title: mask data
     value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
       datatype: uint8
       ndim: 2
   coverage:
     title: coverage data
     value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
       datatype: uint8
       ndim: 2
 propertyOrder: [meta, data, uncertainty, mask, coverage]

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -9,12 +9,12 @@ properties:
   conversion_megajanskys:
     title: Flux density (MJy/steradian) producing 1 cps
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["MJy.sr**-1"]
       - type: "null"
     archive_catalog:
@@ -23,12 +23,12 @@ properties:
   conversion_microjanskys:
     title: Flux density (uJy/arcsec2) producing 1 cps
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["uJy.arcsec**-2"]
       - type: "null"
     archive_catalog:
@@ -37,12 +37,12 @@ properties:
   pixelarea_steradians:
     title: Nominal pixel area in steradians
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["sr"]
       - type: "null"
     archive_catalog:
@@ -51,12 +51,12 @@ properties:
   pixelarea_arcsecsq:
     title: Nominal pixel area in arcsec^2
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["arcsec**2"]
       - type: "null"
     archive_catalog:
@@ -65,12 +65,12 @@ properties:
   conversion_megajanskys_uncertainty:
     title: Uncertainty in flux density conversion to MJy/steradians
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["MJy.sr**-1"]
       - type: "null"
     archive_catalog:
@@ -79,12 +79,12 @@ properties:
   conversion_microjanskys_uncertainty:
     title: Uncertainty in flux density conversion to uJy/arcsec2
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
         properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["uJy.arcsec**-2"]
       - type: "null"
     archive_catalog:

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -13,108 +13,108 @@ properties:
     $ref: common-1.0.0
   data:
     title: Science data, including the border reference pixels.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN", "electron"]
   pixeldq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 2
     datatype: uint32
   groupdq:
     title: 3-D data quality array (plane dq for each group)
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: uint8
   err:
     title: Error array containing the square root of the exposure-level combined variance
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN", "electron"]
   amp33:
     title: Amp 33 reference pixel data
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_left:
     title: Original border reference pixels, on left (from viewers perspective).
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
       datatype: float32
       ndim: 3
     unit:
-      tag: tag:astropy.org:astropy/units/unit-1.0.0
+      tag: tag:astropy.org:astropy/units/unit-1.*
       enum: ["DN"]
   border_ref_pix_right:
     title: Original border reference pixels, on right (from viewers perspective).
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_top:
     title: Original border reference pixels, on top.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_bottom:
     title: Original border reference pixels, on bottom.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   dq_border_ref_pix_left:
     title: DQ for border reference pixels, on left (from viewers perspective).
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_right:
     title: DQ for border reference pixels, on right (from viewers perspective).
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_top:
     title: DQ for border reference pixels, on top.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_bottom:
     title: DQ for border reference pixels, on bottom.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
 propertyOrder: [meta, data, pixeldq, groupdq, err, amp33, border_ref_pix_left,

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -13,96 +13,96 @@ properties:
     $ref: common-1.0.0
   slope:
     title: Segment-specific slope
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron / s"]
   sigslope:
     title: Sigma for segment-specific slope
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron / s"]
   yint:
     title: Segment-specific y-intercept
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron"]
   sigyint:
     title: Sigma for segment-specific y-intercept
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron"]
   pedestal:
     title: Pedestal array
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron"]
   weights:
     title: Weights for segment-specific fits
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
   crmag:
     title: Approximate CR magnitudes
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron"]
   var_poisson:
     title: Variance due to poisson noise for segment-specific slope
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron2 / s2"]
   var_rnoise:
     title: Variance due to read noise for segment-specific slope
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron2 / s2"]
 required: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,
            var_rnoise]

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -44,18 +44,18 @@ properties:
     description: |
        The dark current array represents the integrated number of counts
        due to the accumulation of dark current electrons in the pixels.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   dq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dark_slope:
@@ -64,25 +64,25 @@ properties:
        The dark current slope array represents the slope of the
        integrated number of counts due to the accumulation of dark
        current electrons in the pixels for slope fitting purposes.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN / s"]
   dark_slope_error:
     title: Uncertainty in dark current slope array
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN / s"]
 required: [meta, data, dq, dark_slope, dark_slope_error]
 flowStyle: block

--- a/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
@@ -19,11 +19,11 @@ properties:
             enum: [DISTORTION]
           input_units:
             title: Units of the detector coordinate inputs to this model.
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["pixel"]
           output_units:
             title: Output units of V2/V3 coordinates after the model is applied.
-            tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["arcsec"]
         required: [output_units, input_units]
       - $ref: ref_optical_element-1.0.0

--- a/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
@@ -20,17 +20,17 @@ properties:
       - $ref: ref_optical_element-1.0.0
   data:
     title: Flat data array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
   dq:
     title: Data quality array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   err:
     title: Error array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
 required: [meta, data, dq, err]

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -19,14 +19,14 @@ properties:
             enum: [GAIN]
   data:
     title: The detector gain map
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron / DN"]
 required: [meta, data]
 flowStyle: block

--- a/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
@@ -19,11 +19,11 @@ properties:
             enum: [INVERSELINEARITY]
           input_units:
             title: Units of the input to the inverse linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
           output_units:
             title: Units of the output of the inverse linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
         required: [output_units, input_units]
   coeffs:
@@ -32,13 +32,13 @@ properties:
       Contains the coefficients of a polynomial to add classic non-linearity
       to pixels. Both the input to and output from the polynomial are in units
       of DN. The coefficients have units that contain various powers of DN.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     # Dimensions: numcoeffs, ysize, xsize
     ndim: 3
   dq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
 required: [meta, coeffs, dq]

--- a/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
@@ -23,7 +23,7 @@ properties:
     description: |
       Reference kernel used for convolving with data in order to correct
       for interpixel capacitance
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
 required: [meta, data]

--- a/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
@@ -19,11 +19,11 @@ properties:
             enum: [LINEARITY]
           input_units:
             title: Units of the input to the linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
           output_units:
             title: Units of the output of the linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
         required: [output_units, input_units]
   coeffs:
@@ -33,13 +33,13 @@ properties:
       values for classic non-linearity. Both the input to and
       output from the polynomial are in units of DN. The coefficients
       have units that contain various powers of DN.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     # Dimensions: numcoeffs, ysize, xsize
     ndim: 3
   dq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
 required: [meta, coeffs, dq]

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -19,7 +19,7 @@ properties:
             enum: [MASK]
   dq:
     title: Data quality mask array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
 required: [meta, dq]

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -23,23 +23,23 @@ properties:
               pixelarea_steradians:
                 title: Nominal pixel area in steradians
                 anyOf:
-                  - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - tag: tag:stsci.edu:asdf/unit/quantity-1.*
                     properties:
                       datatype:
                         enum: ["float64"]
                       unit:
-                        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                        tag: tag:stsci.edu:asdf/unit/unit-1.*
                         enum: ["sr"]
                   - type: "null"
               pixelarea_arcsecsq:
                 title: Nominal pixel area in arcsec^2
                 anyOf:
-                  - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+                  - tag: tag:stsci.edu:asdf/unit/quantity-1.*
                     properties:
                       datatype:
                         enum: ["float64"]
                       unit:
-                        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                        tag: tag:stsci.edu:asdf/unit/unit-1.*
                         enum: ["arcsec**2"]
                   - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
@@ -47,7 +47,7 @@ properties:
       - $ref: ref_optical_element-1.0.0
   data:
     title: Pixel area array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
 required: [meta, data]

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -19,14 +19,14 @@ properties:
       - $ref: ref_exposure_type-1.0.0
   data:
     title: Read noise data array
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
 required: [meta, data]
 flowStyle: block

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -22,7 +22,7 @@ properties:
     type: string
   useafter:
     title: Use after date of the reference file
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
   telescope:
     title: Telescope data reference data is used to calibrate
     anyOf:

--- a/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
@@ -19,29 +19,29 @@ properties:
             enum: [REFPIX]
           input_units:
             title: Units of the input to the linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
           output_units:
             title: Units of the output of the linearity polynomial.
-            tag: tag:astropy.org:astropy/units/unit-1.0.0
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
         required: [output_units, input_units]
 
   gamma:
     title: Left column correction coefficients
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: complex128
     ndim: 2
 
   zeta:
     title: Right column correction coefficients
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: complex128
     ndim: 2
 
   alpha:
     title: Reference output correction coefficients
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: complex128
     ndim: 2
 

--- a/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
@@ -19,18 +19,18 @@ properties:
             enum: [SATURATION]
   data:
     title: Saturation threshold
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   dq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
 required: [meta, data, dq]

--- a/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
@@ -19,17 +19,17 @@ properties:
             enum: [BIAS]
   data:
     title: 2-D super-bias array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
   dq:
     title: 2-D data quality array for all planes
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   err:
     title: 2-D Error array
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
 required: [meta, data, dq, err]

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -27,34 +27,34 @@ properties:
           photmjsr:
             title: Surface brightness, in MJy/steradian
             anyOf:
-              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.*
                 properties:
                   value:
                     type: number
                   unit:
-                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    tag: tag:stsci.edu:asdf/unit/unit-1.*
                     enum: [MJy.sr**-1]
               - type: "null"
           uncertainty:
             title: Uncertainty of surface brightness, in MJy/steradian
             anyOf:
-              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.*
                 properties:
                   value:
                     type: number
                   unit:
-                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    tag: tag:stsci.edu:asdf/unit/unit-1.*
                     enum: [MJy.sr**-1]
               - type: "null"
           pixelareasr:
             title: Nominal pixel area, in steradian
             anyOf:
-              - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+              - tag: tag:stsci.edu:asdf/unit/quantity-1.*
                 properties:
                   value:
                     type: number
                   unit:
-                    tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+                    tag: tag:stsci.edu:asdf/unit/unit-1.*
                     enum: [sr]
               - type: "null"
         required: [photmjsr, uncertainty, pixelareasr]

--- a/src/rad/resources/schemas/visit-1.0.0.yaml
+++ b/src/rad/resources/schemas/visit-1.0.0.yaml
@@ -40,7 +40,7 @@ properties:
       destination: [ScienceCommon.visit_type, GuideWindow.visit_type]
   start_time:
     title: UTC visit start time
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -50,7 +50,7 @@ properties:
       destination: [ScienceCommon.visit_start_time, GuideWindow.visit_start_time]
   end_time:
     title: UTC visit end time
-    tag: tag:stsci.edu:asdf/time/time-1.1.0
+    tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -28,132 +28,132 @@ properties:
         required: [photometry, wcs]
   data:
     title: Science data, excluding border reference pixels.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron / s"]
   dq:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   err:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron / s"]
   var_poisson:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron2 / s2"]
   var_rnoise:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron2 / s2"]
   var_flat:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["electron2 / s2"]
   amp33:
     title: Amp 33 reference pixel data
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_left:
     title: Original border reference pixels, on left (from viewers perspective).
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_right:
     title: Original border reference pixels, on right (from viewers perspective).
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_top:
     title: Original border reference pixels, on top.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   border_ref_pix_bottom:
     title: Original border reference pixels, on bottom.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
   dq_border_ref_pix_left:
     title: DQ for border reference pixels, on left (from viewers perspective).
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_right:
     title: DQ for border reference pixels, on right (from viewers perspective).
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_top:
     title: DQ for border reference pixels, on top.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   dq_border_ref_pix_bottom:
     title: DQ for border reference pixels, on bottom.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 2
   cal_logs:

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -44,62 +44,62 @@ properties:
         required: [asn, basic, cal_step, photometry, program, resample, wcs, wcsinfo]
   data:
     title: Science data, excluding border reference pixels.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+        tag: tag:stsci.edu:asdf/unit/unit-1.*
         enum: ["MJy.sr**-1"]
   err:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+        tag: tag:stsci.edu:asdf/unit/unit-1.*
         enum: ["MJy.sr**-1"]
   context:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: uint32
     ndim: 3
   weight:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     datatype: float32
     ndim: 2
   var_poisson:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+        tag: tag:stsci.edu:asdf/unit/unit-1.*
         enum: ["MJy**2.sr**-2"]
   var_rnoise:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+        tag: tag:stsci.edu:asdf/unit/unit-1.*
         enum: ["MJy**2.sr**-2"]
   var_flat:
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         ndim: 2
       unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+        tag: tag:stsci.edu:asdf/unit/unit-1.*
         enum: ["MJy**2.sr**-2"]
   cal_logs:
     tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -16,31 +16,31 @@ properties:
     $ref: common-1.0.0
   data:
     title: Science data, including the border reference pixels.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
 
   amp33:
     title: Amp 33 reference pixel data.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: uint16
         ndim: 3
       unit:
-        tag: tag:astropy.org:astropy/units/unit-1.0.0
+        tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
 
   resultantdq:
     title: Optional 3-D data quality array (plane dq for each resultant)
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: uint8
 propertyOrder: [meta, data, amp33, resultantdq]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,15 +47,12 @@ def valid_tag_uris(manifest):
     uris = {t["tag_uri"] for t in manifest["tags"]}
     uris.update(
         [
-            "tag:stsci.edu:asdf/time/time-1.1.0",
-            "tag:stsci.edu:asdf/core/ndarray-1.0.0",
-            "tag:stsci.edu:asdf/unit/quantity-1.1.0",
-            "tag:stsci.edu:asdf/unit/unit-1.0.0",
-            "tag:astropy.org:astropy/units/unit-1.0.0",
-            "tag:astropy.org:astropy/table/table-1.1.0",
-            "tag:stsci.edu:gwcs/wcs-1.0.0",
-            "tag:stsci.edu:gwcs/wcs-1.1.0",
-            "tag:stsci.edu:gwcs/wcs-1.2.0",
+            "tag:stsci.edu:asdf/time/time-1.*",
+            "tag:stsci.edu:asdf/core/ndarray-1.*",
+            "tag:stsci.edu:asdf/unit/quantity-1.*",
+            "tag:stsci.edu:asdf/unit/unit-1.*",
+            "tag:astropy.org:astropy/units/unit-1.*",
+            "tag:astropy.org:astropy/table/table-1.*",
             "tag:stsci.edu:gwcs/wcs-*",
         ]
     )


### PR DESCRIPTION
This PR switches the `tag` keywords in the rad schemas to wildcard expressions for all tags outside of rad. For example:
https://github.com/spacetelescope/rad/blob/64cf407b88c1a369ca11d704f5af51347f7d9439/src/rad/resources/schemas/wfi_image-1.0.0.yaml#L34
is replaced by
```
 tag: tag:stsci.edu:asdf/core/ndarray-1.*
```
The use of the wildcard `*` means that any `ndarray` tag with a version starting with `1.` will be considered valid.

This change is needed for asdf standard 1.6.0 (the current development version and upcoming stable version) which contains an increase in the `ndarray` tag version (from `1.0.0` to `1.1.0`). Many other tags will also see version changes to comply with 1.6.0 (including `time`, `quantity`, etc).

The type of failure that this PR will avoid can be seen in the following example:
```python
import roman_datamodels.maker_util
n = roman_datamodels.maker_utils.mk_node(roman_datamodels.stnode.WfiImage)
m = roman_datamodels.datamodels.ImageModel(n)
m.save('foo.asdf', version='1.6.0')  # the version is provided here as the current default is 1.5.0
```
which results in an error:
```
ValidationError: mismatched tags, wanted 'tag:stsci.edu:asdf/time/time-1.1.0', got 'tag:stsci.edu:asdf/time/time-1.2.0'
```

Regression tests passed: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/598/pipeline/247

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
