### PR TITLE
switch to sphinx-rtd-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,6 @@ from pathlib import Path
 
 # Ensure documentation examples are deterministically random.
 import numpy
-import stsci_rtd_theme
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
@@ -106,8 +105,7 @@ version = ".".join(release.split(".")[:2])
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. To override the custom theme, set this to the
 # name of a builtin theme or the name of a custom theme in html_theme_path.
-html_theme = "stsci_rtd_theme"
-html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
 
 html_static_path = ["_static"]
 

--- a/docs/creating.rst
+++ b/docs/creating.rst
@@ -31,7 +31,7 @@ you should have a clear idea of the following:
 
         * Which fields will be primitive data types like ``int``, ``float``,
           ``str``, or ``bool``. In JSON-schema these will be ``integer``,
-            ``number``, ``string``, and ``boolean`` respectively.
+          ``number``, ``string``, and ``boolean`` respectively.
 
         * Which fields will require using an ASDF tag to reference another
           schema corresponding to a non-primitive type. In particular, you need

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ docs = [
     'sphinx',
     'sphinx-asdf>=0.1.3',
     'sphinx-astropy',
+    'sphinx-rtd-theme',
     'astropy>=5.0.4',
     'graphviz',
     'matplotlib',
     'docutils',
-    'stsci-rtd-theme',
     'tomli; python_version <"3.11"',
     'importlib-metadata',
 ]


### PR DESCRIPTION
To match the theme used for romancal:
https://github.com/spacetelescope/romancal/blob/6417cf25b0dea81063041c69e470198152282d7a/pyproject.toml#L47

This PR switches the docs sphinx theme to sphinx-rtd-theme.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
