### PR TITLE
Ref links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,3 +159,6 @@ def setup(app):
 asdf_schema_path = "../src/rad/resources"
 # This is the prefix common to all schema IDs in this repository
 asdf_schema_standard_prefix = "schemas"
+asdf_schema_reference_mappings = [
+    ("asdf://stsci.edu/datamodels/roman/tags/", "https://rad.readthedocs.io/en/latest/generated/schemas/"),
+]


### PR DESCRIPTION
This PR configures `sphinx-asdf` to create links to other rad schemas when a `tag` is encountered in the schema.

For example, the current `wfi_image` schema contains a `tag` to `photometry`:
https://rad.readthedocs.io/en/latest/generated/schemas/wfi_image-1.0.0.html
However this link is currently invalid (pointing to `asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0.html`). [With this PR](https://rad--379.org.readthedocs.build/en/379/generated/schemas/wfi_image-1.0.0.html) the link now points to:
https://rad.readthedocs.io/en/latest/generated/schemas/photometry-1.0.0.html

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
