### PR TITLE
RCAL-800: Create the flux step schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@
 
 - Add attributes under the ``basic`` schema to ``WfiMosaic.meta``. [#390]
 
+- Create the flux step schema. [#395]
+
 
 0.19.0 (2024-02-09)
 -------------------

--- a/src/rad/resources/schemas/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/cal_step-1.0.0.yaml
@@ -48,6 +48,16 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_dq_init, GuideWindow.s_dq_init, WFICommon.s_dq_init]
+  flux:
+    title: Flux Scale Application Step
+    description: |
+      Step in ROMANCAL which applies the scaling factors determined in the Photom calibrations step.
+      The data are converted from DN/s to MJy/sr.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flux, GuideWindow.s_flux, WFICommon.s_flux]
   jump:
     title: Cosmic Rays and Jump Detection Step
     description: |
@@ -159,8 +169,8 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_resample, GuideWindow.s_resample, WFICommon.s_resample]
-propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg, resample]
+propertyOrder: [assign_wcs, flat_field, dark, dq_init, flux, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg, resample]
 flowStyle: block
-required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, outlier_detection, photom, source_detection, ramp_fit, refpix, resample, saturation, skymatch, tweakreg]
+required: [assign_wcs, flat_field, dark, dq_init, flux, jump, linearity, outlier_detection, photom, source_detection, ramp_fit, refpix, resample, saturation, skymatch, tweakreg]
 additionalProperties: true
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-800](https://jira.stsci.edu/browse/RAD-800)

Related PRs:
- [roman_datamodel#332](https://github.com/spacetelescope/roman_datamodels/pull/332)
- [romancal#1160](https://github.com/spacetelescope/romancal/pull/1160)

<!-- describe the changes comprising this PR here -->
This PR completes the schema setup for the new romancal FluxStep by adding it to the `cal_step` schema.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
