### PR TITLE
RAD-149: Split cal_step into L2 & L3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@
 
 - Add attributes under the ``basic`` schema to ``WfiMosaic.meta``. [#390]
 
+- Split cal_step into L2 and L3 versions. [#397]
+
 
 0.19.0 (2024-02-09)
 -------------------

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -33,7 +33,6 @@ Tags
     associations-1.0.0
     basic-1.0.0
     cal_logs-1.0.0
-    cal_step-1.0.0
     common-1.0.0
     coordinates-1.0.0
     ephemeris-1.0.0
@@ -43,6 +42,8 @@ Tags
     guidewindow_modes-1.0.0
     guidewindow-1.0.0
     individual_image_meta-1.0.0
+    l2_cal_step-1.0.0
+    l3_cal_step-1.0.0
     mosaic_associations-1.0.0
     mosaic_basic-1.0.0
     mosaic_wcsinfo-1.0.0

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -115,11 +115,16 @@ tags:
   title: Guidestar information
   description: |-
     Guidestar information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/cal_step-1.0.0
-  title: Calibration Step status information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l2_cal_step-1.0.0
+  title: Level 2 Calibration Step status information
   description: |-
-    Calibration Step status information
+    Level 2 Calibration Step status information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l3_cal_step-1.0.0
+  title: Level 3 Calibration Step status information
+  description: |-
+    Level 3 Calibration Step status information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/resample-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/resample-1.0.0
   title: Resample information

--- a/src/rad/resources/schemas/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/common-1.0.0.yaml
@@ -16,7 +16,7 @@ allOf:
       tag: asdf://stsci.edu/datamodels/roman/tags/aperture-1.0.0
     cal_step:
       title: Tracker of Calibration Pipeline Steps
-      tag: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.0.0
     coordinates:
       title: Name Of The Coordinate Reference Frame
       tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0

--- a/src/rad/resources/schemas/ground_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/ground_common-1.0.0.yaml
@@ -12,7 +12,7 @@ allOf:
   properties:
     # Meta Objects
     cal_step:
-      tag: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.0.0
     exposure:
       tag: asdf://stsci.edu/datamodels/roman/tags/base_exposure-1.0.0
     guidestar:

--- a/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/cal_step-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l2_cal_step-1.0.0
 
-title: Calibration Status
+title: Level 2 Calibration Status
 type: object
 properties:
   assign_wcs:
@@ -148,19 +148,10 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFICommon.s_skymatch]
-  resample:
-    title: Resampling Input Data onto a Regular Grid Step
-    description: |
-      Step in ROMANCAL which resamples each input 2D image based on its WCS and
-      WCS distortion information on a grid that allows the combination of
-      multiple resampled images into a single, undistorted product.
-    type: string
-    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
-    archive_catalog:
-      datatype: nvarchar(15)
-      destination: [ScienceRefData.s_resample, GuideWindow.s_resample, WFICommon.s_resample]
-propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection, outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg, resample]
+propertyOrder: [assign_wcs, flat_field, dark, dq_init, jump, linearity, photom, source_detection,
+                outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
 flowStyle: block
-required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, outlier_detection, photom, source_detection, ramp_fit, refpix, resample, saturation, skymatch, tweakreg]
+required: [assign_wcs, flat_field, dark, dq_init, jump, linearity, outlier_detection, photom,
+           source_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
 additionalProperties: true
 ...

--- a/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l3_cal_step-1.0.0
+
+title: Level 3 Calibration Status
+type: object
+properties:
+  outlier_detection:
+    title: Outlier Detection Step
+    description: |
+      Step in ROMANCAL which detects and flags outliers in a science image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection, WFICommon.s_outlier_detection]
+  skymatch:
+    title: Sky Matching for Combining Overlapping Images Step
+    description: |
+      Step in ROMANCAL that computes sky background values of each input image
+      and derives scalings to equalize overlapping regions.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFICommon.s_skymatch]
+  resample:
+    title: Resampling Input Data onto a Regular Grid Step
+    description: |
+      Step in ROMANCAL which resamples each input 2D image based on its WCS and
+      WCS distortion information on a grid that allows the combination of
+      multiple resampled images into a single, undistorted product.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_resample, GuideWindow.s_resample, WFICommon.s_resample]
+propertyOrder: [outlier_detection, skymatch, resample]
+flowStyle: block
+required: [outlier_detection, resample, skymatch]
+additionalProperties: true
+...

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -22,7 +22,7 @@ properties:
           basic:
             tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.0.0
           cal_step:
-            tag: asdf://stsci.edu/datamodels/roman/tags/cal_step-1.0.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.0.0
           coordinates:
             tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
           individual_image_meta:

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -27,7 +27,6 @@ properties:
       unit:
         tag: tag:astropy.org:astropy/units/unit-1.*
         enum: ["DN"]
-
   amp33:
     title: Amplifier 33 Reference Pixel Data (DN)
     description: |


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-149](https://jira.stsci.edu/browse/RAD-149)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #363 

<!-- describe the changes comprising this PR here -->
This PR splits the cal_step schema into L2 and L3 versions.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/693/
