### PR TITLE
RAD-164: Hotfix Of Exposure and Guidestar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
-0.20.0 (unreleased)
+0.19.2 (unreleased)
 -------------------
 
--
+- Duplicated the keywords from base_exposure to exposure and similarly for base_guidestar and guidestar. [#406]
 
 0.19.1 (2024-04-04)
 -------------------

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -7,255 +7,426 @@ id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0
 title: |
   Exposure Information
 
-allOf:
-  - $ref: asdf://stsci.edu/datamodels/roman/schemas/base_exposure-1.0.0
-  - type: object
-    properties:
-      id:
-        title: Visit Exposure ID
-        description: |
-          The matching exposure ID for a given visit ID.
+type: object
+properties:
+  type:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination: [WFIExposure.exposure_type, GuideWindow.exposure_type, WFICommon.exposure_type]
+  start_time:
+    title: Exposure Start Time (UTC)
+    description: |
+      The UTC time at the beginning of the exposure.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_start_time, GuideWindow.exposure_start_time, WFICommon.exposure_start_time]
+  ngroups:
+    title: Number of Resultants
+    description: |
+      The number of resultant frames in this exposure that were transmitted to
+      the ground. The number of integrations of WFI data is always 1.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_ngroups, GuideWindow.exposure_ngroups, WFICommon.exposure_ngroups]
+  nframes:
+    title: Number of Reads
+    description: |
+      This is the number of science frames that are combined to produce a resultant frame.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_nframes, GuideWindow.exposure_nframes, WFICommon.exposure_nframes]
+  data_problem:
+    title: Data Problem
+    description: |
+      A flag indicating an issue with science telemetry.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_data_problem, GuideWindow.exposure_data_problem, WFICommon.exposure_data_problem]
+  frame_divisor:
+    title: Frame Divisor
+    description: |
+      The number of reads averaged to calculate a resultant. Value depends on
+      the readout pattern used from the MultiAccum table.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_frame_divisor, GuideWindow.exposure_frame_divisor, WFICommon.exposure_frame_divisor]
+  groupgap:
+    title: Number of Frames Dropped Between Resultants
+    description:
+      The number of reads that are dropped, or not used to calculate a
+      resultant.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_groupgap, GuideWindow.exposure_groupgap, WFICommon.exposure_groupgap]
+  frame_time:
+    title: Time Between Reads (s)
+    description: |
+      The amount of time elapsed between the end of one read and the beginning
+      of the next.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_frame_time, GuideWindow.exposure_frame_time, WFICommon.exposure_frame_time]
+  group_time:
+    title: Time Between Resultants (s)
+    description: |
+      The time that is the sum of the reads that are used to construct a
+      resultant. This will depend on the MA table being used.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_group_time, GuideWindow.exposure_group_time, WFICommon.exposure_group_time]
+  exposure_time:
+    title: Exposure Time (s)
+    description: |
+      The time between the start of the first Reset/Read Science Frame of an
+      Exposure and the completion of the final Read Only Science Frame of that
+      Exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_time, GuideWindow.exposure_time, WFICommon.exposure_time]
+  ma_table_name:
+    title: MA Table Name
+    description: |
+      The name of the MultiAccum table used for this exposure, as defined in the
+      Project Reference Database.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination: [WFIExposure.ma_table_name, GuideWindow.ma_table_name, WFICommon.ma_table_name]
+  ma_table_number:
+    title: MA Table Number
+    description: |
+      The number of the MultiAccum table used for this exposure. Used in
+      matching exposures to their corresponding calibration data.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]
+  read_pattern:
+    title: Read Pattern
+    description: |
+      Enumeration of detector reads to resultants making up the L1 data
+      downlinked from the observatory.
+    type: array
+    items:
+      type: array
+      items:
         type: integer
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: int
-          destination: [WFIExposure.exposure_id, GuideWindow.exposure_id,
-                        SourceCatalog.exposure_id]
-      mid_time:
-        title: Exposure Mid Time (UTC)
-        description: |
-          The UTC time at the midpoint of the exposure.
-        tag: tag:stsci.edu:asdf/time/time-1.*
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: datetime2
-          destination: [WFIExposure.exposure_mid_time, GuideWindow.exposure_mid_time,
-                        SourceCatalog.exposure_mid_time]
-      end_time:
-        title: Exposure End Time (UTC)
-        description: |
-          The UTC time at the end of the exposure.
-        tag: tag:stsci.edu:asdf/time/time-1.*
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: datetime2
-          destination: [WFIExposure.exposure_end_time, GuideWindow.exposure_end_time,
-                        SourceCatalog.exposure_end_time]
-      start_time_mjd:
-        title: MJD Start Time (d)
-        description: |
-          The date, in MJD, at the beginning of this exposure. Used in the archive
-          catalog for multi-mission matching.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_start_time_mjd, GuideWindow.exposure_start_time_mjd,
-                        SourceCatalog.exposure_start_time_mjd]
-      mid_time_mjd:
-        title: MJD Mid Time (d)
-        description: |
-          The date, in MJD, at the midpoint of this exposure. Used in the archive
-          catalog for multi-mission matching.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_mid_time_mjd, GuideWindow.exposure_mid_time_mjd,
-                        SourceCatalog.exposure_mid_time_mjd]
-      end_time_mjd:
-        title: MJD End Time (d)
-        description: |
-          The date, in MJD, at the end of this exposure. Used in the archive catalog
-          for multi-mission matching.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_end_time_mjd, GuideWindow.exposure_end_time_mjd,
-                        SourceCatalog.exposure_end_time_mjd]
-      start_time_tdb:
-        title: TDB Start Time (d)
-        description: |
-          The date, in TDB (Barycentric Dynamical Time), at the beginning of this
-          exposure.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_start_time_tdb, GuideWindow.exposure_start_time_tdb,
-                        SourceCatalog.exposure_start_time_tdb]
-      mid_time_tdb:
-        title: TDB Mid Time (d)
-        description: |
-          The date, in TDB (Barycentric Dynamical Time), at the midpoint of this
-          exposure.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_mid_time_tdb, GuideWindow.exposure_mid_time_tdb,
-                        SourceCatalog.exposure_mid_time_tdb]
-      end_time_tdb:
-        title: TDB End Time (d)
-        description: |
-          The date, in TDB (Barycentric Dynamical Time), at the end of this
-          exposure.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_end_time_tdb, GuideWindow.exposure_end_time_tdb,
-                        SourceCatalog.exposure_end_time_tdb]
-      sca_number:
-        title: SCA Number
-        description: |
-          The number of the detector on the Sensor Chip Assembly used for this
-          exposure.
-        type: integer
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: int
-          destination: [WFIExposure.exposure_sca_number, GuideWindow.exposure_sca_number,
-                        SourceCatalog.exposure_sca_number]
-      gain_factor:
-        title: Gain Factor
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_gain_factor, GuideWindow.exposure_gain_factor,
-                        SourceCatalog.exposure_gain_factor]
-      integration_time:
-        title: Effective Integration Time (s)
-        description:
-          The effective amount of time that the sensor was exposed to the sky.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_integration_time, GuideWindow.exposure_integration_time,
-                        SourceCatalog.exposure_integration_time]
-      elapsed_exposure_time:
-        title: Elapsed Exposure Time (s)
-        description: |
-          The amount of time elapsed between an exposure's first and last science
-          reads.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.elapsed_exposure_time, GuideWindow.elapsed_exposure_time,
-                        SourceCatalog.elapsed_exposure_time]
-      effective_exposure_time:
-        title: Effective Exposure Time (s)
-        description: |
-          The amount of time during which the detector actually collected photons
-          during an exposure.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.effective_exposure_time, GuideWindow.effective_exposure_time,
-                        SourceCatalog.effective_exposure_time]
-      duration:
-        title: Exposure Duration (s)
-        description: |
-          The amount of time dedicated to a exposure, including any overhead, time
-          spent on dropped frames, and so on.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.exposure_duration, GuideWindow.exposure_duration,
-                        SourceCatalog.exposure_duration]
-      level0_compressed:
-        title: Level 0 Compression
-        description: |
-          A flag indicating that the exposure has data that was decompressed by the
-          ground system.
-        type: boolean
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: nchar(1)
-          destination: [WFIExposure.exposure_level0_compressed, GuideWindow.exposure_level0_compressed,
-                        SourceCatalog.exposure_level0_compressed]
-      truncated:
-        title: Truncated MA Table
-        description: |
-          A flag indicating whether the MA table was truncated.
-        type: boolean
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: nchar(1)
-          destination: [WFIExposure.exposure_truncated,
-                        SourceCatalog.exposure_truncated]
-    required: [id,
-              mid_time, end_time,
-              start_time_mjd, mid_time_mjd, end_time_mjd,
-              start_time_tdb, mid_time_tdb, end_time_tdb,
-              sca_number,
-              gain_factor, integration_time, elapsed_exposure_time,
-              effective_exposure_time, duration,
-              level0_compressed]
-    propertyOrder: [id,
-              mid_time, end_time,
-              start_time_mjd, mid_time_mjd, end_time_mjd,
-              start_time_tdb, mid_time_tdb, end_time_tdb,
-              sca_number,
-              gain_factor, integration_time, elapsed_exposure_time,
-              effective_exposure_time, duration,
-              level0_compressed, truncated]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(3500)
+      destination: [WFIExposure.read_pattern, GuideWindow.read_pattern, WFICommon.read_pattern]
+  id:
+    title: Visit Exposure ID
+    description: |
+      The matching exposure ID for a given visit ID.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_id, GuideWindow.exposure_id,
+                    SourceCatalog.exposure_id]
+  mid_time:
+    title: Exposure Mid Time (UTC)
+    description: |
+      The UTC time at the midpoint of the exposure.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_mid_time, GuideWindow.exposure_mid_time,
+                    SourceCatalog.exposure_mid_time]
+  end_time:
+    title: Exposure End Time (UTC)
+    description: |
+      The UTC time at the end of the exposure.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_end_time, GuideWindow.exposure_end_time,
+                    SourceCatalog.exposure_end_time]
+  start_time_mjd:
+    title: MJD Start Time (d)
+    description: |
+      The date, in MJD, at the beginning of this exposure. Used in the archive
+      catalog for multi-mission matching.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_start_time_mjd, GuideWindow.exposure_start_time_mjd,
+                    SourceCatalog.exposure_start_time_mjd]
+  mid_time_mjd:
+    title: MJD Mid Time (d)
+    description: |
+      The date, in MJD, at the midpoint of this exposure. Used in the archive
+      catalog for multi-mission matching.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_mid_time_mjd, GuideWindow.exposure_mid_time_mjd,
+                    SourceCatalog.exposure_mid_time_mjd]
+  end_time_mjd:
+    title: MJD End Time (d)
+    description: |
+      The date, in MJD, at the end of this exposure. Used in the archive catalog
+      for multi-mission matching.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_end_time_mjd, GuideWindow.exposure_end_time_mjd,
+                    SourceCatalog.exposure_end_time_mjd]
+  start_time_tdb:
+    title: TDB Start Time (d)
+    description: |
+      The date, in TDB (Barycentric Dynamical Time), at the beginning of this
+      exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_start_time_tdb, GuideWindow.exposure_start_time_tdb,
+                    SourceCatalog.exposure_start_time_tdb]
+  mid_time_tdb:
+    title: TDB Mid Time (d)
+    description: |
+      The date, in TDB (Barycentric Dynamical Time), at the midpoint of this
+      exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_mid_time_tdb, GuideWindow.exposure_mid_time_tdb,
+                    SourceCatalog.exposure_mid_time_tdb]
+  end_time_tdb:
+    title: TDB End Time (d)
+    description: |
+      The date, in TDB (Barycentric Dynamical Time), at the end of this
+      exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_end_time_tdb, GuideWindow.exposure_end_time_tdb,
+                    SourceCatalog.exposure_end_time_tdb]
+  sca_number:
+    title: SCA Number
+    description: |
+      The number of the detector on the Sensor Chip Assembly used for this
+      exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_sca_number, GuideWindow.exposure_sca_number,
+                    SourceCatalog.exposure_sca_number]
+  gain_factor:
+    title: Gain Factor
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_gain_factor, GuideWindow.exposure_gain_factor,
+                    SourceCatalog.exposure_gain_factor]
+  integration_time:
+    title: Effective Integration Time (s)
+    description:
+      The effective amount of time that the sensor was exposed to the sky.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_integration_time, GuideWindow.exposure_integration_time,
+                    SourceCatalog.exposure_integration_time]
+  elapsed_exposure_time:
+    title: Elapsed Exposure Time (s)
+    description: |
+      The amount of time elapsed between an exposure's first and last science
+      reads.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.elapsed_exposure_time, GuideWindow.elapsed_exposure_time,
+                    SourceCatalog.elapsed_exposure_time]
+  effective_exposure_time:
+    title: Effective Exposure Time (s)
+    description: |
+      The amount of time during which the detector actually collected photons
+      during an exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.effective_exposure_time, GuideWindow.effective_exposure_time,
+                    SourceCatalog.effective_exposure_time]
+  duration:
+    title: Exposure Duration (s)
+    description: |
+      The amount of time dedicated to a exposure, including any overhead, time
+      spent on dropped frames, and so on.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_duration, GuideWindow.exposure_duration,
+                    SourceCatalog.exposure_duration]
+  level0_compressed:
+    title: Level 0 Compression
+    description: |
+      A flag indicating that the exposure has data that was decompressed by the
+      ground system.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_level0_compressed, GuideWindow.exposure_level0_compressed,
+                    SourceCatalog.exposure_level0_compressed]
+  truncated:
+    title: Truncated MA Table
+    description: |
+      A flag indicating whether the MA table was truncated.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_truncated,
+                    SourceCatalog.exposure_truncated]
+required: [type, start_time,
+           ngroups, nframes, data_problem,
+           frame_divisor, groupgap, frame_time, group_time, exposure_time,
+           ma_table_name, ma_table_number, read_pattern, id,
+          mid_time, end_time,
+          start_time_mjd, mid_time_mjd, end_time_mjd,
+          start_time_tdb, mid_time_tdb, end_time_tdb,
+          sca_number,
+          gain_factor, integration_time, elapsed_exposure_time,
+          effective_exposure_time, duration,
+          level0_compressed]
+propertyOrder: [type, start_time,
+           ngroups, nframes, data_problem,
+           frame_divisor, groupgap, frame_time, group_time, exposure_time,
+           ma_table_name, ma_table_number, read_pattern, id,
+          mid_time, end_time,
+          start_time_mjd, mid_time_mjd, end_time_mjd,
+          start_time_tdb, mid_time_tdb, end_time_tdb,
+          sca_number,
+          gain_factor, integration_time, elapsed_exposure_time,
+          effective_exposure_time, duration,
+          level0_compressed, truncated]
 flowStyle: block
 ...

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -5,237 +5,367 @@ id: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.0.0
 
 title: Guide Star Window Information
 
-allOf:
-  - $ref: asdf://stsci.edu/datamodels/roman/schemas/base_guidestar-1.0.0
-  - type: object
-    properties:
-      gs_id:
-        title: Guide Star Identifier from Guide Star Catalog
-        description: |
-          Identification of the guide star from the guide star catalog.
-        type: string
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: nvarchar(20)
-          destination: [WFIExposure.gs_id, GuideWindow.gs_id]
-      gs_catalog_version:
-        title: Version of the Guide Star Catalog
-        description: |
-          Version identifier of the guide star catalog used for the observation.
-        type: string
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: nvarchar(20)
-          destination: [WFIExposure.gs_catalog_version]
-      gs_ra:
-        title: Guide Star Right Ascension (deg)
-        description: |
-          Right ascension of the guide star from the guide star catalog in units of
-          degrees.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ra, GuideWindow.gs_ra]
-      gs_dec:
-        title: Guide Star Declination (deg)
-        description: |
-          Declination of the guide star from the guide star catalog in units of
-          degrees.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_dec, GuideWindow.gs_dec]
-      gs_ura:
-        title: Guide Star Right Ascension Uncertainty (deg)
-        description: |
-          Uncertainty in the guide star right ascension from the guide star catalog
-          in units of degrees.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ura, GuideWindow.gs_ura]
-      gs_udec:
-        title: Guide Star Declination Uncertainty (deg)
-        description: |
-          Uncertainty in the guide star declination from the guide star catalog in
-          units of degrees.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_udec, GuideWindow.gs_udec]
-      gs_mag:
-        title: Guide Star Instrumental Magnitude
-        description: |
-          Predicted instrumental magnitude of the guide star from the guide star
-          catalog.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_mag, GuideWindow.gs_mag]
-      gs_umag:
-        title: Guide Star Instrumental Magnitude Uncertainty
-        description: |
-          Uncertainty in the predicted instrumental magnitude of the guide star from
-          the guide star catalog.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_umag, GuideWindow.gs_umag]
-      gs_ctd_x:
-        title: Guide Star Centroid X Position (arcsec)
-        description: |
-          Centroid of the guide star position longa the X axis of the guider ideal
-          frame measured in units of arcseconds.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ctd_x, GuideWindow.gs_ctd_x]
-      gs_ctd_y:
-        title: Guide Star Centroid Y Position (arcsec)
-        description: |
-          Centroid of the guide star position along the Y axis of the guider ideal
-          frame measured in units of arcseconds.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ctd_y, GuideWindow.gs_ctd_y]
-      gs_ctd_ux:
-        title: Guide Star Centroid X Position Uncertainty (arcsec)
-        description: |
-          Uncertainty in the centroid of the guide star position along the X axis of
-          the guider ideal frame measured in units of arcseconds
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ctd_ux, GuideWindow.gs_ctd_ux]
-      gs_ctd_uy:
-        title: Guide Star Centroid Y Position Uncertainty (arcsec)
-        description: |
-          Uncertainty in the centroid of the guide star position along the Y axis of
-          the guider ideal frame measured in units of arcseconds.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_ctd_uy, GuideWindow.gs_ctd_uy]
-      gs_epoch:
-        title: Guide Star Coordinates Epoch
-        description: |
-          Epoch of the celestial coordinates of the guide star.
-        type: string
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: nvarchar(10)
-          destination: [WFIExposure.gs_epoch, GuideWindow.gs_epoch]
-      gs_mura:
-        title: Proper Motion of the Guide Star Right Ascension (mas / yr)
-        description: |
-          Proper motion of the guide star in right ascension from the guide star
-          catalog measured in units of milli-arcseconds per year.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_mura, GuideWindow.gs_mura]
-      gs_mudec:
-        title: Proper Motion of the Guide Star Declination (mas / yr)
-        description: |
-          Proper motion of the guide star in declination from the guide star catalog
-          measured in units of milli-arcseconds per year.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_mudec, GuideWindow.gs_mudec]
-      gs_para:
-        title: Guide Star Annual Parallax
-        description: |
-          Annual parallax of the guide star from the guide star catalog.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_para, GuideWindow.gs_para]
-      gs_pattern_error:
-        title: Guide Star Centroid RMS
-        description: |
-          RMS of the guide star position in the tracking guide windows from the Fine
-          Attitude Correction Estimate (FACE) information. The FACE information
-          determines the error across the guiding pattern using all centroid
-          measurements.
-        type: number
-        sdf:
-          special_processing: VALUE_REQUIRED
-          source:
-            origin: TBD
-        archive_catalog:
-          datatype: float
-          destination: [WFIExposure.gs_pattern_error, GuideWindow.gs_pattern_error]
-    propertyOrder: [gs_id, gs_catalog_version, gs_ra, gs_dec,
-                  gs_ura, gs_udec, gs_mag, gs_umag,
-                  gs_ctd_x, gs_ctd_y, gs_ctd_ux, gs_ctd_uy,
-                  gs_epoch, gs_mura, gs_mudec, gs_para, gs_pattern_error]
-    required: [gs_id, gs_catalog_version, gs_ra, gs_dec,
+type: object
+properties:
+  gw_id:
+    title: Guide Star Window Identifier
+    description: |
+      Identification of the Guide Star Window.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.gw_id, GuideWindow.gw_id, WFICommon.gw_id]
+  gw_fgs_mode:
+    $ref: guidewindow_modes-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(18)
+      destination: [WFIExposure.gw_fgs_mode, GuideWindow.gw_fgs_mode, WFICommon.gw_fgs_mode]
+  data_start:
+    title: Guide Data Start Time (MJD)
+    description: |
+      Start time of the guide window data taken for this exposure as a Modified
+      Julian Date.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.data_start, GuideWindow.data_start, WFICommon.data_start]
+  data_end:
+    title: Guide Data End Time (MJD)
+    description: |
+      End time of the guide window data taken for this exposure as a Modified
+      Julian Date.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.data_end, GuideWindow.data_end, WFICommon.data_end]
+  gw_window_xstart:
+    title: Guide Window X Start Position (pixels)
+    description: |
+      Minimum X position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xstart, WFICommon.gw_window_xstart]
+  gw_window_ystart:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Minimum Y position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ystart, WFICommon.gw_window_ystart]
+  gw_window_xstop:
+    title: Guide Window X Stop Position (pixels)
+    description: |
+      Maximum X position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xstop, WFICommon.gw_window_xstop]
+  gw_window_ystop:
+    title: Guide Window Y Stop Position (pixels)
+    description: |
+      Maximum Y position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ystop, WFICommon.gw_window_ystop]
+  gw_window_xsize:
+    title: Guide Window Size in the X Direction (pixels)
+    description: |
+      Size of a single tracking guide window in this exposure measured along the
+      X axis in units of pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xsize, WFICommon.gw_window_xsize]
+  gw_window_ysize:
+    title: Guide Window Size in the Y Direction (pixels)
+    description: |
+      Size of a single tracking guide window in this exposure measured along the
+      Y axis in units of pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ysize, WFICommon.gw_window_ysize]
+  gs_id:
+    title: Guide Star Identifier from Guide Star Catalog
+    description: |
+      Identification of the guide star from the guide star catalog.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.gs_id, GuideWindow.gs_id]
+  gs_catalog_version:
+    title: Version of the Guide Star Catalog
+    description: |
+      Version identifier of the guide star catalog used for the observation.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.gs_catalog_version]
+  gs_ra:
+    title: Guide Star Right Ascension (deg)
+    description: |
+      Right ascension of the guide star from the guide star catalog in units of
+      degrees.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ra, GuideWindow.gs_ra]
+  gs_dec:
+    title: Guide Star Declination (deg)
+    description: |
+      Declination of the guide star from the guide star catalog in units of
+      degrees.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_dec, GuideWindow.gs_dec]
+  gs_ura:
+    title: Guide Star Right Ascension Uncertainty (deg)
+    description: |
+      Uncertainty in the guide star right ascension from the guide star catalog
+      in units of degrees.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ura, GuideWindow.gs_ura]
+  gs_udec:
+    title: Guide Star Declination Uncertainty (deg)
+    description: |
+      Uncertainty in the guide star declination from the guide star catalog in
+      units of degrees.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_udec, GuideWindow.gs_udec]
+  gs_mag:
+    title: Guide Star Instrumental Magnitude
+    description: |
+      Predicted instrumental magnitude of the guide star from the guide star
+      catalog.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_mag, GuideWindow.gs_mag]
+  gs_umag:
+    title: Guide Star Instrumental Magnitude Uncertainty
+    description: |
+      Uncertainty in the predicted instrumental magnitude of the guide star from
+      the guide star catalog.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_umag, GuideWindow.gs_umag]
+  gs_ctd_x:
+    title: Guide Star Centroid X Position (arcsec)
+    description: |
+      Centroid of the guide star position longa the X axis of the guider ideal
+      frame measured in units of arcseconds.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ctd_x, GuideWindow.gs_ctd_x]
+  gs_ctd_y:
+    title: Guide Star Centroid Y Position (arcsec)
+    description: |
+      Centroid of the guide star position along the Y axis of the guider ideal
+      frame measured in units of arcseconds.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ctd_y, GuideWindow.gs_ctd_y]
+  gs_ctd_ux:
+    title: Guide Star Centroid X Position Uncertainty (arcsec)
+    description: |
+      Uncertainty in the centroid of the guide star position along the X axis of
+      the guider ideal frame measured in units of arcseconds
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ctd_ux, GuideWindow.gs_ctd_ux]
+  gs_ctd_uy:
+    title: Guide Star Centroid Y Position Uncertainty (arcsec)
+    description: |
+      Uncertainty in the centroid of the guide star position along the Y axis of
+      the guider ideal frame measured in units of arcseconds.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_ctd_uy, GuideWindow.gs_ctd_uy]
+  gs_epoch:
+    title: Guide Star Coordinates Epoch
+    description: |
+      Epoch of the celestial coordinates of the guide star.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.gs_epoch, GuideWindow.gs_epoch]
+  gs_mura:
+    title: Proper Motion of the Guide Star Right Ascension (mas / yr)
+    description: |
+      Proper motion of the guide star in right ascension from the guide star
+      catalog measured in units of milli-arcseconds per year.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_mura, GuideWindow.gs_mura]
+  gs_mudec:
+    title: Proper Motion of the Guide Star Declination (mas / yr)
+    description: |
+      Proper motion of the guide star in declination from the guide star catalog
+      measured in units of milli-arcseconds per year.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_mudec, GuideWindow.gs_mudec]
+  gs_para:
+    title: Guide Star Annual Parallax
+    description: |
+      Annual parallax of the guide star from the guide star catalog.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_para, GuideWindow.gs_para]
+  gs_pattern_error:
+    title: Guide Star Centroid RMS
+    description: |
+      RMS of the guide star position in the tracking guide windows from the Fine
+      Attitude Correction Estimate (FACE) information. The FACE information
+      determines the error across the guiding pattern using all centroid
+      measurements.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.gs_pattern_error, GuideWindow.gs_pattern_error]
+propertyOrder: [gw_id, gw_fgs_mode,
+           data_start, data_end, gw_window_xstart,
+           gw_window_ystart, gw_window_xstop, gw_window_ystop, gw_window_xsize,
+           gw_window_ysize,
+           gs_id, gs_catalog_version, gs_ra, gs_dec,
               gs_ura, gs_udec, gs_mag, gs_umag,
               gs_ctd_x, gs_ctd_y, gs_ctd_ux, gs_ctd_uy,
               gs_epoch, gs_mura, gs_mudec, gs_para, gs_pattern_error]
-
+required: [gw_id, gw_fgs_mode,
+           data_start, data_end, gw_window_xstart,
+           gw_window_ystart, gw_window_xstop, gw_window_ystop, gw_window_xsize,
+           gw_window_ysize,
+           gs_id, gs_catalog_version, gs_ra, gs_dec,
+          gs_ura, gs_udec, gs_mag, gs_umag,
+          gs_ctd_x, gs_ctd_y, gs_ctd_ux, gs_ctd_uy,
+          gs_epoch, gs_mura, gs_mudec, gs_para, gs_pattern_error]
 flowStyle: block
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-164](https://jira.stsci.edu/browse/RAD-164)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #404 

<!-- describe the changes comprising this PR here -->
This PR duplicates the keywords from `base_exposure` to `exposure` and similarly for `base_guidestar` and `guidestar`. This is a temporary fix until a more permanent resolution can be found (Issue #405).

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
