### PR TITLE
RAD-165: Separate TVAC and FPS Schemas from Main

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.19.4 (unreleased)
 -------------------
 
-
+- Separated TVAC and FPS schemas into their own suite of files. [#414]
 
 0.19.3 (2024-04-25)
 -------------------

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -303,12 +303,6 @@ tags:
   title: Telescope used to acquire the data
   description: |-
     Telescope used to acquire the data
-# SSC data models
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.0.0
-  title: MSOS Stack Level 3 Schema
-  description: |-
-    Level 3 schema for SSC's MSOS stack products
 # FPS Schemas
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0
@@ -317,75 +311,75 @@ tags:
     FPS test data
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/cal_step-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/cal_step-1.0.0
-  title: Level 2 Calibration Step status information
+  title: FPS Level 2 Calibration Step status information
   description: |-
-    Level 2 Calibration Step status information
+    FPS Level 2 Calibration Step status information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/exposure-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure-1.0.0
-  title: Exposure information
+  title: FPS Exposure information
   description: |-
-    Exposure information
+    FPS Exposure information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/groundtest-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/groundtest-1.0.0
-  title: Ground Test Information
+  title: FPS Ground Test Information
   description: |-
-    Ground test description.    
+    FPS Ground test description.    
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/guidestar-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/guidestar-1.0.0
-  title: Guidestar information
+  title: FPS Guidestar information
   description: |-
-    Guidestar information
+    FPS Guidestar information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/ref_file-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
-  title: Calibration reference file names.
+  title: FPS Calibration reference file names.
   description: |-
-    Calibration reference file names.
+    FPS Calibration reference file names.
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/wfi_mode-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_mode-1.0.0
-  title: Roman WFI Instrument Mode
+  title: FPS Roman WFI Instrument Mode
   description: |-
-    Roman WFI Instrument
+    FPS Roman WFI Instrument
 # FPS Tagged Scalars
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/calibration_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/calibration_software_version-1.0.0
-  title: Calibration software version
+  title: FPS Calibration software version
   description: |-
-    Calibration software version number
+    FPS Calibration software version number
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/filename-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/filename-1.0.0
-  title: Name of the file
+  title: FPS Name of the file
   description: |-
-    Name of the file
+    FPS Name of the file
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/file_date-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/file_date-1.0.0
-  title: Date this file was created (UTC)
+  title: FPS Date this file was created (UTC)
   description: |-
-    Date this file was created (UTC)
+    FPS Date this file was created (UTC)
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/model_type-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/model_type-1.0.0
-  title: Type of data model
+  title: FPS Type of data model
   description: |-
-    Type of data model
+    FPS Type of data model
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/origin-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/origin-1.0.0
-  title: Organization responsible for creating file
+  title: FPS Organization responsible for creating file
   description: |-
-    Organization responsible for creating file
+    FPS Organization responsible for creating file
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/prd_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/prd_software_version-1.0.0
-  title: S&OC PRD version number used in data processing
+  title: FPS S&OC PRD version number used in data processing
   description: |-
-    S&OC PRD version number used in data processing
+    FPS S&OC PRD version number used in data processing
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/sdf_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/sdf_software_version-1.0.0
-  title: SDF software version number
+  title: FPS SDF software version number
   description: |-
-    SDF software version number
+    FPS SDF software version number
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/telescope-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/telescope-1.0.0
-  title: Telescope used to acquire the data
+  title: FPS Telescope used to acquire the data
   description: |-
-    Telescope used to acquire the data
+    FPS Telescope used to acquire the data
 # TVAC Schemas
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac-1.0.0
@@ -394,73 +388,80 @@ tags:
     TVAC test data
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/cal_step-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/cal_step-1.0.0
-  title: Level 2 Calibration Step status information
+  title: TVAC Level 2 Calibration Step status information
   description: |-
-    Level 2 Calibration Step status information
+    TVAC Level 2 Calibration Step status information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/exposure-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure-1.0.0
-  title: Exposure information
+  title: TVAC Exposure information
   description: |-
-    Exposure information
+    TVAC Exposure information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/groundtest-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/groundtest-1.0.0
-  title: Ground Test Information
+  title: TVAC Ground Test Information
   description: |-
-    Ground test description.    
+    TVAC Ground test description.    
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/guidestar-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidestar-1.0.0
-  title: Guidestar information
+  title: TVAC Guidestar information
   description: |-
-    Guidestar information
+    TVAC Guidestar information
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/ref_file-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
-  title: Calibration reference file names.
+  title: TVAC Calibration reference file names.
   description: |-
-    Calibration reference file names.
+    TVAC Calibration reference file names.
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/wfi_mode-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0
-  title: Roman WFI Instrument Mode
+  title: TVAC Roman WFI Instrument Mode
   description: |-
-    Roman WFI Instrument
+    TVAC Roman WFI Instrument
 # TVAC Tagged Scalars
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/calibration_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0
-  title: Calibration software version
+  title: TVAC Calibration software version
   description: |-
-    Calibration software version number
+    TVAC Calibration software version number
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/filename-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/filename-1.0.0
-  title: Name of the file
+  title: TVAC Name of the file
   description: |-
-    Name of the file
+    TVAC Name of the file
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/file_date-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/file_date-1.0.0
-  title: Date this file was created (UTC)
+  title: TVAC Date this file was created (UTC)
   description: |-
-    Date this file was created (UTC)
+    TVAC Date this file was created (UTC)
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/model_type-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/model_type-1.0.0
-  title: Type of data model
+  title: TVAC Type of data model
   description: |-
-    Type of data model
+    TVAC Type of data model
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/origin-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/origin-1.0.0
-  title: Organization responsible for creating file
+  title: TVAC Organization responsible for creating file
   description: |-
-    Organization responsible for creating file
+    TVAC Organization responsible for creating file
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/prd_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/prd_software_version-1.0.0
-  title: S&OC PRD version number used in data processing
+  title: TVAC S&OC PRD version number used in data processing
   description: |-
-    S&OC PRD version number used in data processing
+    TVAC S&OC PRD version number used in data processing
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/sdf_software_version-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0
-  title: SDF software version number
+  title: TVAC SDF software version number
   description: |-
-    SDF software version number
+    TVAC SDF software version number
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/telescope-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/telescope-1.0.0
-  title: Telescope used to acquire the data
+  title: TVAC Telescope used to acquire the data
   description: |-
-    Telescope used to acquire the data
+    TVAC Telescope used to acquire the data
+# SSC data models
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.0.0
+  title: TVAC MSOS Stack Level 3 Schema
+  description: |-
+    TVAC Level 3 schema for SSC's MSOS stack products
 ...
+ 

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -464,4 +464,3 @@ tags:
   description: |-
     Level 3 schema for SSC's MSOS stack products
 ...
-

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -460,8 +460,8 @@ tags:
 # SSC data models
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.0.0
-  title: TVAC MSOS Stack Level 3 Schema
+  title: MSOS Stack Level 3 Schema
   description: |-
-    TVAC Level 3 schema for SSC's MSOS stack products
+    Level 3 schema for SSC's MSOS stack products
 ...
  

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -155,37 +155,6 @@ tags:
   title: Mosaic WCS parameters
   description: |-
     Mosaic WCS parameters
-# Ground Modules
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/base_exposure-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/base_exposure-1.0.0
-  title: Exposure information
-  description: |-
-    Ground test exposure information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/base_guidestar-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/base_guidestar-1.0.0
-  title: Guidestar information
-  description: |-
-    Guidestar information
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/groundtest-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/groundtest-1.0.0
-  title: Ground Test Information
-  description: |-
-    Ground test description.
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac_groundtest-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac_groundtest-1.0.0
-  title: TVAC Ground Test Information
-  description: |-
-    TVAC ground test description.
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0
-  title: FPS schema
-  description: |-
-    FPS test data
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac-1.0.0
-  title: TVAC schema
-  description: |-
-    TVAC test data
 # Reference Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
@@ -340,4 +309,158 @@ tags:
   title: MSOS Stack Level 3 Schema
   description: |-
     Level 3 schema for SSC's MSOS stack products
+# FPS Schemas
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0
+  title: FPS schema
+  description: |-
+    FPS test data
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/cal_step-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/cal_step-1.0.0
+  title: Level 2 Calibration Step status information
+  description: |-
+    Level 2 Calibration Step status information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/exposure-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure-1.0.0
+  title: Exposure information
+  description: |-
+    Exposure information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/groundtest-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/groundtest-1.0.0
+  title: Ground Test Information
+  description: |-
+    Ground test description.    
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/guidestar-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/guidestar-1.0.0
+  title: Guidestar information
+  description: |-
+    Guidestar information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/ref_file-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
+  title: Calibration reference file names.
+  description: |-
+    Calibration reference file names.
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/wfi_mode-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_mode-1.0.0
+  title: Roman WFI Instrument Mode
+  description: |-
+    Roman WFI Instrument
+# FPS Tagged Scalars
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/calibration_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/calibration_software_version-1.0.0
+  title: Calibration software version
+  description: |-
+    Calibration software version number
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/filename-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/filename-1.0.0
+  title: Name of the file
+  description: |-
+    Name of the file
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/file_date-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/file_date-1.0.0
+  title: Date this file was created (UTC)
+  description: |-
+    Date this file was created (UTC)
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/model_type-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/model_type-1.0.0
+  title: Type of data model
+  description: |-
+    Type of data model
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/origin-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/origin-1.0.0
+  title: Organization responsible for creating file
+  description: |-
+    Organization responsible for creating file
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/prd_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/prd_software_version-1.0.0
+  title: S&OC PRD version number used in data processing
+  description: |-
+    S&OC PRD version number used in data processing
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/sdf_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/sdf_software_version-1.0.0
+  title: SDF software version number
+  description: |-
+    SDF software version number
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/telescope-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/telescope-1.0.0
+  title: Telescope used to acquire the data
+  description: |-
+    Telescope used to acquire the data
+# TVAC Schemas
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac-1.0.0
+  title: TVAC schema
+  description: |-
+    TVAC test data
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/cal_step-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/cal_step-1.0.0
+  title: Level 2 Calibration Step status information
+  description: |-
+    Level 2 Calibration Step status information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/exposure-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure-1.0.0
+  title: Exposure information
+  description: |-
+    Exposure information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/groundtest-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/groundtest-1.0.0
+  title: Ground Test Information
+  description: |-
+    Ground test description.    
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/guidestar-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidestar-1.0.0
+  title: Guidestar information
+  description: |-
+    Guidestar information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/ref_file-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
+  title: Calibration reference file names.
+  description: |-
+    Calibration reference file names.
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/wfi_mode-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0
+  title: Roman WFI Instrument Mode
+  description: |-
+    Roman WFI Instrument
+# TVAC Tagged Scalars
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/calibration_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0
+  title: Calibration software version
+  description: |-
+    Calibration software version number
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/filename-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/filename-1.0.0
+  title: Name of the file
+  description: |-
+    Name of the file
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/file_date-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/file_date-1.0.0
+  title: Date this file was created (UTC)
+  description: |-
+    Date this file was created (UTC)
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/model_type-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/model_type-1.0.0
+  title: Type of data model
+  description: |-
+    Type of data model
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/origin-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/origin-1.0.0
+  title: Organization responsible for creating file
+  description: |-
+    Organization responsible for creating file
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/prd_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/prd_software_version-1.0.0
+  title: S&OC PRD version number used in data processing
+  description: |-
+    S&OC PRD version number used in data processing
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/sdf_software_version-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0
+  title: SDF software version number
+  description: |-
+    SDF software version number
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/telescope-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/telescope-1.0.0
+  title: Telescope used to acquire the data
+  description: |-
+    Telescope used to acquire the data
 ...

--- a/src/rad/resources/schemas/fps-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps-1.0.0.yaml
@@ -14,11 +14,11 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/ground_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/common-1.0.0
       - type: object
         properties:
           groundtest:
-            tag: asdf://stsci.edu/datamodels/roman/tags/groundtest-1.0.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/fps/groundtest-1.0.0
         required: [groundtest]
 
   data:

--- a/src/rad/resources/schemas/fps/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/basic-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/basic-1.0.0
 
-title: Basic Information
+title: FPS Basic Information
 
 type: object
 properties:

--- a/src/rad/resources/schemas/fps/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/basic-1.0.0.yaml
@@ -1,0 +1,58 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/basic-1.0.0
+
+title: Basic Information
+
+type: object
+properties:
+  # Meta Variables
+  calibration_software_version:
+    title: Calibration Software Version Number
+    description: |
+      The version number of the calibration software used in processing this
+      file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/calibration_software_version-1.0.0
+  filename:
+    title: File Name
+    description: |
+      The auto-generated name of this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/filename-1.0.0
+  file_date:
+    title: File Creation Date
+    description: |
+      The date and time this file was created.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/file_date-1.0.0
+  model_type:
+    title: Data Model Type
+    description: |
+      The type of data model contained in this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/model_type-1.0.0
+  origin:
+    title: Institution / Organization Name
+    description: |
+      The name of the institution or organization responsible for creating this
+      file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/origin-1.0.0
+  prd_software_version:
+    title: SOC PRD Version Number
+    description: |
+      The Science Operations Center (SOC) Project Reference Database (PRD)
+      version number used in generating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/prd_software_version-1.0.0
+  sdf_software_version:
+    title: SDF Version Number
+    description: |
+      The version number of the Science Data Formatting (SDF) software used in
+      generating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/sdf_software_version-1.0.0
+  telescope:
+    title: Telescope Name
+    description: |
+      The name of the telescope used to acquire the data.
+    tag: asdf://stsci.edu/datamodels/roman/tags/fps/telescope-1.0.0
+required: [calibration_software_version, filename, file_date,
+           model_type, origin, prd_software_version,
+           sdf_software_version, telescope]
+...

--- a/src/rad/resources/schemas/fps/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/cal_step-1.0.0.yaml
@@ -1,0 +1,167 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/cal_step-1.0.0
+
+title: Level 2 Calibration Status
+type: object
+properties:
+  assign_wcs:
+    title: Assign WCS Step
+    description: |
+      Step in ROMANCAL that assigns a World Coordinate System (WCS) object to a
+      science image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_assign_wcs, GuideWindow.s_assign_wcs, WFICommon.s_assign_wcs]
+  flat_field:
+    title: Flat Fielding Step
+    descroption: |
+      Step in ROMANCAL in which a science image is flat-fielded, whereby each
+      detector pixel is calibrated to give the same signal for the same
+      illumination, given its specific response. This is achieved using a
+      flatfield reference image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flat_field, GuideWindow.s_flat_field, WFICommon.s_flat_field]
+  dark:
+    title: Dark Current Subtraction Step
+    description: |
+      Step in ROMANCAL performing the dark current correction by subtracting
+      dark current reference data from science data.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dark, GuideWindow.s_dark, WFICommon.s_dark]
+  dq_init:
+    title: Initialization of the Data Quality Extension Step
+    description: |
+      Step in ROMANCAL in which the pixeldq attribute of the input data model
+      using the MASK reference file is initialized.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dq_init, GuideWindow.s_dq_init, WFICommon.s_dq_init]
+  flux:
+    title: Flux Scale Application Step
+    description: |
+      Step in ROMANCAL which applies the scaling factors determined in the Photom calibrations step.
+      The data are converted from DN/s to MJy/sr.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flux, GuideWindow.s_flux, WFICommon.s_flux]
+  jump:
+    title: Cosmic Rays and Jump Detection Step
+    description: |
+      Step in ROMANCAL which performs a search for jumps in values in ramp that
+      may be associated with cosmic rays.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_jump, GuideWindow.s_jump, WFICommon.s_jump]
+  linearity:
+    title: Linearity Correction Step
+    description: |
+      Step in ROMANCAL which performs a correction for the classical non-linear
+      detector response.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_linearity, GuideWindow.s_linearity, WFICommon.s_linearity]
+  photom:
+    title: Photometric Calibration Step
+    description: |
+      Step in ROMANCAL that adds photometric calibrations to the metadata of a
+      data product.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_photom, GuideWindow.s_photom, WFICommon.s_photom]
+  source_detection:
+    title: Source Detection Step
+    description: |
+      Step in ROMANCAL to detect point sources in an image and catalog them.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_source_detection, GuideWindow.s_source_detection, WFICommon.s_source_detection]
+  ramp_fit:
+    title: Ramp Fit Step
+    description: |
+      Step in ROMANCAL to fit the counts versus time with a straight line and
+      thus estimate the count rate for each pixel.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_ramp_fit, GuideWindow.s_ramp_fit, WFICommon.s_ramp_fit]
+  refpix:
+    title: Reference Pixel Correction Step
+    description: |
+      Step in ROMANCAL that corrects for additional signal from electronics
+      contributing to (e.g. 1/f noise) using the reference pixels.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_refpix, GuideWindow.s_refpix, WFICommon.s_refpix]
+  saturation:
+    title: Saturation Identification Step
+    description: |
+      Step in ROMANCAL which sets pixel flags to label that a pixel is at or
+      above the saturation threshold. As part of this step, pixels that are zero
+      or negative are also flagged.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_saturation, GuideWindow.s_saturation, WFICommon.s_saturation]
+  outlier_detection:
+    title: Outlier Detection Step
+    description: |
+      Step in ROMANCAL which detects and flags outliers in a science image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection, WFICommon.s_outlier_detection]
+  tweakreg:
+    title: Tweakreg step
+    description: |
+      Step in ROMANCAL that compares positions of point-like sources with
+      coordinates from a Gaia catalog, and, if necessary, corrects an image's
+      World Coordinate System alignment.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_tweakreg, GuideWindow.s_tweakreg, WFICommon.s_tweakreg]
+  skymatch:
+    title: Sky Matching for Combining Overlapping Images Step
+    description: |
+      Step in ROMANCAL that computes sky background values of each input image
+      and derives scalings to equalize overlapping regions.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFICommon.s_skymatch]
+propertyOrder: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, photom, source_detection,
+                outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
+flowStyle: block
+required: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, outlier_detection, photom,
+           source_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
+additionalProperties: true
+...

--- a/src/rad/resources/schemas/fps/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/cal_step-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/cal_step-1.0.0
 
-title: Level 2 Calibration Status
+title: FPS Level 2 Calibration Status
 type: object
 properties:
   assign_wcs:

--- a/src/rad/resources/schemas/fps/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/common-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/common-1.0.0
 
-title: Common metadata properties
+title: FPS Common metadata properties
 
 allOf:
 # Meta Variables

--- a/src/rad/resources/schemas/fps/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/common-1.0.0.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/common-1.0.0
+
+title: Common metadata properties
+
+allOf:
+# Meta Variables
+- $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/basic-1.0.0
+- type: object
+  properties:
+    # Meta Objects
+    cal_step:
+      tag: asdf://stsci.edu/datamodels/roman/tags/fps/cal_step-1.0.0
+    exposure:
+      tag: asdf://stsci.edu/datamodels/roman/tags/fps/exposure-1.0.0
+    guidestar:
+      tag: asdf://stsci.edu/datamodels/roman/tags/fps/guidestar-1.0.0
+    instrument:
+      tag: asdf://stsci.edu/datamodels/roman/tags/fps/wfi_mode-1.0.0
+    ref_file:
+      tag: asdf://stsci.edu/datamodels/roman/tags/fps/ref_file-1.0.0
+    hdf5_meta:
+      title: Original Raw HDF5 metadata
+      type: object
+    hdf5_telemetry:
+      title: Original Raw HDF5 telemetry keywords
+      type: string
+    gw_meta:
+      title: Guide Window HDF5 metadata
+      type: object
+  required: [cal_step, exposure, guidestar, instrument, ref_file,
+             hdf5_meta, hdf5_telemetry, gw_meta]
+...

--- a/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure-1.0.0
 
 
 title: |
-  Base Exposure Information
+  FPS Base Exposure Information
 
 type: object
 properties:

--- a/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
@@ -1,0 +1,188 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure-1.0.0
+
+
+title: |
+  Base Exposure Information
+
+type: object
+properties:
+  type:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure_type-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination: [WFIExposure.exposure_type, GuideWindow.exposure_type, WFICommon.exposure_type]
+  start_time:
+    title: Exposure Start Time (UTC)
+    description: |
+      The UTC time at the beginning of the exposure.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_start_time, GuideWindow.exposure_start_time, WFICommon.exposure_start_time]
+  ngroups:
+    title: Number of Resultants
+    description: |
+      The number of resultant frames in this exposure that were transmitted to
+      the ground. The number of integrations of WFI data is always 1.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_ngroups, GuideWindow.exposure_ngroups, WFICommon.exposure_ngroups]
+  nframes:
+    title: Number of Reads
+    description: |
+      This is the number of science frames that are combined to produce a resultant frame.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_nframes, GuideWindow.exposure_nframes, WFICommon.exposure_nframes]
+  data_problem:
+    title: Data Problem
+    description: |
+      A flag indicating an issue with science telemetry.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_data_problem, GuideWindow.exposure_data_problem, WFICommon.exposure_data_problem]
+  frame_divisor:
+    title: Frame Divisor
+    description: |
+      The number of reads averaged to calculate a resultant. Value depends on
+      the readout pattern used from the MultiAccum table.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_frame_divisor, GuideWindow.exposure_frame_divisor, WFICommon.exposure_frame_divisor]
+  groupgap:
+    title: Number of Frames Dropped Between Resultants
+    description:
+      The number of reads that are dropped, or not used to calculate a
+      resultant.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_groupgap, GuideWindow.exposure_groupgap, WFICommon.exposure_groupgap]
+  frame_time:
+    title: Time Between Reads (s)
+    description: |
+      The amount of time elapsed between the end of one read and the beginning
+      of the next.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_frame_time, GuideWindow.exposure_frame_time, WFICommon.exposure_frame_time]
+  group_time:
+    title: Time Between Resultants (s)
+    description: |
+      The time that is the sum of the reads that are used to construct a
+      resultant. This will depend on the MA table being used.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_group_time, GuideWindow.exposure_group_time, WFICommon.exposure_group_time]
+  exposure_time:
+    title: Exposure Time (s)
+    description: |
+      The time between the start of the first Reset/Read Science Frame of an
+      Exposure and the completion of the final Read Only Science Frame of that
+      Exposure.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_time, GuideWindow.exposure_time, WFICommon.exposure_time]
+  ma_table_name:
+    title: MA Table Name
+    description: |
+      The name of the MultiAccum table used for this exposure, as defined in the
+      Project Reference Database.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination: [WFIExposure.ma_table_name, GuideWindow.ma_table_name, WFICommon.ma_table_name]
+  ma_table_number:
+    title: MA Table Number
+    description: |
+      The number of the MultiAccum table used for this exposure. Used in
+      matching exposures to their corresponding calibration data.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]
+  read_pattern:
+    title: Read Pattern
+    description: |
+      Enumeration of detector reads to resultants making up the L1 data
+      downlinked from the observatory.
+    type: array
+    items:
+      type: array
+      items:
+        type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(3500)
+      destination: [WFIExposure.read_pattern, GuideWindow.read_pattern, WFICommon.read_pattern]
+propertyOrder: [type, start_time,
+           ngroups, nframes, data_problem,
+           frame_divisor, groupgap, frame_time, group_time, exposure_time,
+           ma_table_name, ma_table_number, read_pattern]
+flowStyle: block
+required: [type, start_time,
+           ngroups, nframes, data_problem,
+           frame_divisor, groupgap, frame_time, group_time, exposure_time,
+           ma_table_name, ma_table_number, read_pattern]
+...

--- a/src/rad/resources/schemas/fps/exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/exposure_type-1.0.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure_type-1.0.0
+
+# Helper file to enumerate viewing modes for exposure and ref_exposure
+title: Exposure Type
+description: |
+  The type of the WFI exposure. Imaging mode science observations have type
+  "WFI_IMAGE," while spectroscopic mode science observations may be either
+  "WFI_GRISM" or "WFI_PRISM" depending on the chosen optical element. Other
+  values are related to internal calibrations and engineering observations.
+
+type: string
+enum:
+  - WFI_IMAGE
+  - WFI_GRISM
+  - WFI_PRISM
+  - WFI_DARK
+  - WFI_FLAT
+  - WFI_WFSC
+...

--- a/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/groundtest-1.0.0
 
-title: Ground Test Information
+title: FPS Ground Test Information
 type: object
 properties:
   test_name:

--- a/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/groundtest-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/groundtest-1.0.0
 
 title: Ground Test Information
 type: object

--- a/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/guidestar-1.0.0
 
-title: Base Guide star window information
+title: FPS Base Guide star window information
 type: object
 properties:
   gw_id:

--- a/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/base_guidestar-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/guidestar-1.0.0
 
 title: Base Guide star window information
 type: object

--- a/src/rad/resources/schemas/fps/guidewindow_modes-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidewindow_modes-1.0.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/guidewindow_modes-1.0.0
+
+# Helper file to enumerate guide window modes for guidestar and guidewindow
+
+title: Guide Window Modes
+description: |
+  An enumerated collection of available guidestar and guidewindow modes.
+type: string
+enum:
+  - WIM-ACQ
+  - WIM-TRACK
+  - WSM-ACQ-1
+  - WSM-ACQ-2
+  - WSM-TRACK
+  - DEFOCUSED-MODERATE
+  - DEFOCUSED-LARGE
+...

--- a/src/rad/resources/schemas/fps/guidewindow_modes-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidewindow_modes-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/fps/guidewindow_modes-1.0.0
 
 # Helper file to enumerate guide window modes for guidestar and guidewindow
 
-title: Guide Window Modes
+title: FPS Guide Window Modes
 description: |
   An enumerated collection of available guidestar and guidewindow modes.
 type: string

--- a/src/rad/resources/schemas/fps/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/ref_file-1.0.0.yaml
@@ -1,0 +1,129 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
+
+title: Reference File Information
+type: object
+properties:
+  crds:
+    title: Calibration Reference Data System Parameters
+    description: |
+      Calibration Reference Data System Parameters
+    type: object
+    properties:
+      sw_version:
+        title: CRDS File Version
+        description: |
+          Version of Calibration Reference Data System (CRDS) file selection software.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_software_version, WFIMosaic.crds_software_version,
+                        GuideWindow.crds_software_version, WFICommon.crds_software_version]
+
+      context_used:
+        title: CRDS Context
+        description: |
+          CRDS context (.pmap) used to select ref files.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_context_used, WFIMosaic.crds_context_used,
+                        GuideWindow.crds_context_used, WFICommon.crds_context_used]
+  dark:
+    title: Dark Reference File Information
+    description: |
+      Reference file used to correct for the dark current contribution to
+      science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_dark, GuideWindow.r_dark, WFICommon.r_dark]
+  distortion:
+    title: Distortion Reference File Information
+    description: |
+      Information about the distortion reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_distortion, GuideWindow.r_distortion, WFICommon.r_distortion]
+  mask:
+    title: Mask Reference File Information
+    description: |
+      Information about the mask reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_mask, GuideWindow.r_mask, WFICommon.r_mask]
+  flat:
+    title: Flat Reference File Information
+    description: |
+      Information about the flat reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_flat, GuideWindow.r_flat, WFICommon.r_flat]
+  gain:
+    title: Gain Reference Rile Information
+    description: |
+      Information about the gain reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_gain, GuideWindow.r_gain, WFICommon.r_gain]
+  readnoise:
+    title: Read Noise Reference Rile Information
+    description: |
+      Information about the read noise reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_readnoise, GuideWindow.r_readnoise, WFICommon.r_readnoise]
+  linearity:
+    title: Linearity Reference File Information
+    description: |
+      Information about the linearity reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_linearity, GuideWindow.r_linearity, WFICommon.r_linearity]
+  photom:
+    title: Photometry Reference File Information
+    description: |
+      Information about the photometry reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_photom, GuideWindow.r_photom, WFICommon.r_photom]
+  area:
+    title: Area Reference File Information
+    description: |
+      Information about the area reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_area, GuideWindow.r_area, WFICommon.r_area]
+  saturation:
+    title: Saturation Reference File Information
+    description: |
+      Information about the saturation reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_saturation, GuideWindow.r_saturation, WFICommon.r_saturation]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/ref_file-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
 
-title: Reference File Information
+title: FPS Reference File Information
 type: object
 properties:
   crds:

--- a/src/rad/resources/schemas/fps/tagged_scalars/calibration_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/calibration_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/calibration_software_version-1.0.0
+
+title: Calibration Software Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.calibration_software_version, GuideWindow.calibration_software_version,
+                WFICommon.calibration_software_version, WFIMosaic.calibration_software_version,
+                SourceCatalog.calibration_software_version, SegmentationMap.calibration_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/calibration_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/calibration_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/calibration_software_version-1.0.0
 
-title: Calibration Software Version Number
+title: FPS Calibration Software Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/fps/tagged_scalars/file_date-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/file_date-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/file_date-1.0.0
+
+title: File Creation Date
+
+allOf:
+  - $ref: http://stsci.edu/schemas/asdf/time/time-1.1.0
+
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: datetime2
+  destination: [WFIExposure.filedate, GuideWindow.filedate, WFICommon.filedate, WFIMosaic.filedate,
+                SourceCatalog.filedate, SegmentationMap.filedate]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/file_date-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/file_date-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/file_date-1.0.0
 
-title: File Creation Date
+title: FPS File Creation Date
 
 allOf:
   - $ref: http://stsci.edu/schemas/asdf/time/time-1.1.0

--- a/src/rad/resources/schemas/fps/tagged_scalars/filename-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/filename-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/filename-1.0.0
 
-title: File Name
+title: FPS File Name
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/fps/tagged_scalars/filename-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/filename-1.0.0.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/filename-1.0.0
+
+title: File Name
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.filename, WFIMosaic.filename, GuideWindow.filename, WFICommon.filename,
+                SourceCatalog.filename, SegmentationMap.filename]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/model_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/model_type-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/model_type-1.0.0
 
-title: Data Model Type
+title: FPS Data Model Type
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/fps/tagged_scalars/model_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/model_type-1.0.0.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/model_type-1.0.0
+
+title: Data Model Type
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(50)
+  destination: [WFIExposure.model_type, GuideWindow.model_type, WFICommon.model_type, WFIMosaic.model_type,
+                SourceCatalog.model_type, SegmentationMap.model_type]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/origin-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/origin-1.0.0
 
-title: Institution / Organization Name
+title: FPS Institution / Organization Name
 
 type: string
 enum: ["STSCI", "IPAC/SSC"]

--- a/src/rad/resources/schemas/fps/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/origin-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/origin-1.0.0
+
+title: Institution / Organization Name
+
+type: string
+enum: ["STSCI", "IPAC/SSC"]
+
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(15)
+  destination: [WFIExposure.origin, GuideWindow.origin, WFICommon.origin, WFIMosaic.origin,
+                SourceCatalog.origin, SegmentationMap.origin]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/prd_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/prd_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/prd_software_version-1.0.0
 
-title: SOC PRD Version Number
+title: FPS SOC PRD Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/fps/tagged_scalars/prd_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/prd_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/prd_software_version-1.0.0
+
+title: SOC PRD Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.prd_software_version, GuideWindow.prd_software_version,
+                WFICommon.prd_software_version, WFIMosaic.prd_software_version,
+                SourceCatalog.prd_software_version, SegmentationMap.prd_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/sdf_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/sdf_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/sdf_software_version-1.0.0
+
+title: SDF Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.sdf_software_version, GuideWindow.sdf_software_version,
+                WFICommon.sdf_software_version, WFIMosaic.sdf_software_version,
+                SourceCatalog.sdf_software_version, SegmentationMap.sdf_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/sdf_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/sdf_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/sdf_software_version-1.0.0
 
-title: SDF Version Number
+title: FPS SDF Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/fps/tagged_scalars/telescope-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/telescope-1.0.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/telescope-1.0.0
+
+title: Telescope Name
+
+type: string
+enum: [ROMAN]
+
+archive_catalog:
+  datatype: nvarchar(5)
+  destination: [WFIExposure.telescope, WFIMosaic.telescope, GuideWindow.telescope, WFICommon.telescope,
+                SourceCatalog.telescope, SegmentationMap.telescope]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/fps/tagged_scalars/telescope-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/tagged_scalars/telescope-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/telescope-1.0.0
 
-title: Telescope Name
+title: FPS Telescope Name
 
 type: string
 enum: [ROMAN]

--- a/src/rad/resources/schemas/fps/wfi_detector-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_detector-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_detector-1.0.0
 
 # Helper file to enumerate detectors for wfi_mode and ref_detector
 
-title: WFI Detector Name
+title: FPS WFI Detector Name
 type: string
 enum:
   - WFI01

--- a/src/rad/resources/schemas/fps/wfi_detector-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_detector-1.0.0.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_detector-1.0.0
+
+# Helper file to enumerate detectors for wfi_mode and ref_detector
+
+title: WFI Detector Name
+type: string
+enum:
+  - WFI01
+  - WFI02
+  - WFI03
+  - WFI04
+  - WFI05
+  - WFI06
+  - WFI07
+  - WFI08
+  - WFI09
+  - WFI10
+  - WFI11
+  - WFI12
+  - WFI13
+  - WFI14
+  - WFI15
+  - WFI16
+  - WFI17
+  - WFI18
+...

--- a/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
@@ -4,7 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_mode-1.0.0
 
 
-title: WFI Observing Configuration
+title: FPS WFI Observing Configuration
 type: object
 properties:
   name:

--- a/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
@@ -1,0 +1,50 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_mode-1.0.0
+
+
+title: WFI Observing Configuration
+type: object
+properties:
+  name:
+    title: Instrument Used to Acquire the Data
+    description: |
+      Instrument used to acquire the data.
+    type: string
+    enum: [WFI]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination: [WFIExposure.instrument_name, GuideWindow.instrument_name, WFICommon.instrument_name]
+  detector:
+    title: WFI Detector
+    description: |
+      WFI detector used to take the data.
+    $ref: wfi_detector-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
+  optical_element:
+    title: WFI Optical Element
+    description: |
+      WFI optical element used to take the data.
+    $ref: wfi_optical_element-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.optical_element, GuideWindow.optical_element, WFICommon.optical_element]
+propertyOrder: [detector, optical_element, name]
+flowStyle: block
+required: [detector, optical_element, name]
+...

--- a/src/rad/resources/schemas/fps/wfi_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_optical_element-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_optical_element-1.0.0
 
 # Helper file to enumerate filters for wfi_mode and ref_optical_element
 
-title: Optical Element
+title: FPS Optical Element
 description: |
   Name of the filter element used. See the RDox Optical Element page for more
   details on available optical elements and their properties.

--- a/src/rad/resources/schemas/fps/wfi_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_optical_element-1.0.0.yaml
@@ -1,0 +1,25 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_optical_element-1.0.0
+
+# Helper file to enumerate filters for wfi_mode and ref_optical_element
+
+title: Optical Element
+description: |
+  Name of the filter element used. See the RDox Optical Element page for more
+  details on available optical elements and their properties.
+type: string
+enum:
+  - F062
+  - F087
+  - F106
+  - F129
+  - F146
+  - F158
+  - F184
+  - F213
+  - GRISM
+  - PRISM
+  - DARK
+...

--- a/src/rad/resources/schemas/tvac-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac-1.0.0.yaml
@@ -14,11 +14,11 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/ground_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/common-1.0.0
       - type: object
         properties:
           groundtest:
-            tag: asdf://stsci.edu/datamodels/roman/tags/tvac_groundtest-1.0.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/tvac/groundtest-1.0.0
         required: [groundtest]
 
   data:

--- a/src/rad/resources/schemas/tvac/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/basic-1.0.0.yaml
@@ -1,0 +1,58 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/basic-1.0.0
+
+title: Basic Information
+
+type: object
+properties:
+  # Meta Variables
+  calibration_software_version:
+    title: Calibration Software Version Number
+    description: |
+      The version number of the calibration software used in processing this
+      file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/calibration_software_version-1.0.0
+  filename:
+    title: File Name
+    description: |
+      The auto-generated name of this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/filename-1.0.0
+  file_date:
+    title: File Creation Date
+    description: |
+      The date and time this file was created.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/file_date-1.0.0
+  model_type:
+    title: Data Model Type
+    description: |
+      The type of data model contained in this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/model_type-1.0.0
+  origin:
+    title: Institution / Organization Name
+    description: |
+      The name of the institution or organization responsible for creating this
+      file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/origin-1.0.0
+  prd_software_version:
+    title: SOC PRD Version Number
+    description: |
+      The Science Operations Center (SOC) Project Reference Database (PRD)
+      version number used in generating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/prd_software_version-1.0.0
+  sdf_software_version:
+    title: SDF Version Number
+    description: |
+      The version number of the Science Data Formatting (SDF) software used in
+      generating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/sdf_software_version-1.0.0
+  telescope:
+    title: Telescope Name
+    description: |
+      The name of the telescope used to acquire the data.
+    tag: asdf://stsci.edu/datamodels/roman/tags/tvac/telescope-1.0.0
+required: [calibration_software_version, filename, file_date,
+           model_type, origin, prd_software_version,
+           sdf_software_version, telescope]
+...

--- a/src/rad/resources/schemas/tvac/basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/basic-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/basic-1.0.0
 
-title: Basic Information
+title: TVAC Basic Information
 
 type: object
 properties:

--- a/src/rad/resources/schemas/tvac/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/cal_step-1.0.0.yaml
@@ -1,0 +1,167 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/cal_step-1.0.0
+
+title: Level 2 Calibration Status
+type: object
+properties:
+  assign_wcs:
+    title: Assign WCS Step
+    description: |
+      Step in ROMANCAL that assigns a World Coordinate System (WCS) object to a
+      science image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_assign_wcs, GuideWindow.s_assign_wcs, WFICommon.s_assign_wcs]
+  flat_field:
+    title: Flat Fielding Step
+    descroption: |
+      Step in ROMANCAL in which a science image is flat-fielded, whereby each
+      detector pixel is calibrated to give the same signal for the same
+      illumination, given its specific response. This is achieved using a
+      flatfield reference image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flat_field, GuideWindow.s_flat_field, WFICommon.s_flat_field]
+  dark:
+    title: Dark Current Subtraction Step
+    description: |
+      Step in ROMANCAL performing the dark current correction by subtracting
+      dark current reference data from science data.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dark, GuideWindow.s_dark, WFICommon.s_dark]
+  dq_init:
+    title: Initialization of the Data Quality Extension Step
+    description: |
+      Step in ROMANCAL in which the pixeldq attribute of the input data model
+      using the MASK reference file is initialized.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dq_init, GuideWindow.s_dq_init, WFICommon.s_dq_init]
+  flux:
+    title: Flux Scale Application Step
+    description: |
+      Step in ROMANCAL which applies the scaling factors determined in the Photom calibrations step.
+      The data are converted from DN/s to MJy/sr.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flux, GuideWindow.s_flux, WFICommon.s_flux]
+  jump:
+    title: Cosmic Rays and Jump Detection Step
+    description: |
+      Step in ROMANCAL which performs a search for jumps in values in ramp that
+      may be associated with cosmic rays.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_jump, GuideWindow.s_jump, WFICommon.s_jump]
+  linearity:
+    title: Linearity Correction Step
+    description: |
+      Step in ROMANCAL which performs a correction for the classical non-linear
+      detector response.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_linearity, GuideWindow.s_linearity, WFICommon.s_linearity]
+  photom:
+    title: Photometric Calibration Step
+    description: |
+      Step in ROMANCAL that adds photometric calibrations to the metadata of a
+      data product.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_photom, GuideWindow.s_photom, WFICommon.s_photom]
+  source_detection:
+    title: Source Detection Step
+    description: |
+      Step in ROMANCAL to detect point sources in an image and catalog them.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_source_detection, GuideWindow.s_source_detection, WFICommon.s_source_detection]
+  ramp_fit:
+    title: Ramp Fit Step
+    description: |
+      Step in ROMANCAL to fit the counts versus time with a straight line and
+      thus estimate the count rate for each pixel.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_ramp_fit, GuideWindow.s_ramp_fit, WFICommon.s_ramp_fit]
+  refpix:
+    title: Reference Pixel Correction Step
+    description: |
+      Step in ROMANCAL that corrects for additional signal from electronics
+      contributing to (e.g. 1/f noise) using the reference pixels.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_refpix, GuideWindow.s_refpix, WFICommon.s_refpix]
+  saturation:
+    title: Saturation Identification Step
+    description: |
+      Step in ROMANCAL which sets pixel flags to label that a pixel is at or
+      above the saturation threshold. As part of this step, pixels that are zero
+      or negative are also flagged.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_saturation, GuideWindow.s_saturation, WFICommon.s_saturation]
+  outlier_detection:
+    title: Outlier Detection Step
+    description: |
+      Step in ROMANCAL which detects and flags outliers in a science image.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection, WFICommon.s_outlier_detection]
+  tweakreg:
+    title: Tweakreg step
+    description: |
+      Step in ROMANCAL that compares positions of point-like sources with
+      coordinates from a Gaia catalog, and, if necessary, corrects an image's
+      World Coordinate System alignment.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_tweakreg, GuideWindow.s_tweakreg, WFICommon.s_tweakreg]
+  skymatch:
+    title: Sky Matching for Combining Overlapping Images Step
+    description: |
+      Step in ROMANCAL that computes sky background values of each input image
+      and derives scalings to equalize overlapping regions.
+    type: string
+    enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFICommon.s_skymatch]
+propertyOrder: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, photom, source_detection,
+                outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
+flowStyle: block
+required: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, outlier_detection, photom,
+           source_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
+additionalProperties: true
+...

--- a/src/rad/resources/schemas/tvac/cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/cal_step-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/cal_step-1.0.0
 
-title: Level 2 Calibration Status
+title: TVAC Level 2 Calibration Status
 type: object
 properties:
   assign_wcs:

--- a/src/rad/resources/schemas/tvac/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/common-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/common-1.0.0
 
-title: Common metadata properties
+title: TVAC Common metadata properties
 
 allOf:
 # Meta Variables

--- a/src/rad/resources/schemas/tvac/common-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/common-1.0.0.yaml
@@ -1,26 +1,26 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ground_common-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/common-1.0.0
 
 title: Common metadata properties
 
 allOf:
 # Meta Variables
-- $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+- $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/basic-1.0.0
 - type: object
   properties:
     # Meta Objects
     cal_step:
-      tag: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/tvac/cal_step-1.0.0
     exposure:
-      tag: asdf://stsci.edu/datamodels/roman/tags/base_exposure-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/tvac/exposure-1.0.0
     guidestar:
-      tag: asdf://stsci.edu/datamodels/roman/tags/base_guidestar-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/tvac/guidestar-1.0.0
     instrument:
-      tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/tvac/wfi_mode-1.0.0
     ref_file:
-      tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.0.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/tvac/ref_file-1.0.0
     hdf5_meta:
       title: Original Raw HDF5 metadata
       type: object

--- a/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/base_exposure-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure-1.0.0
 
 
 title: |
@@ -10,7 +10,7 @@ title: |
 type: object
 properties:
   type:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure_type-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure-1.0.0
 
 
 title: |
-  Base Exposure Information
+  TVAC Base Exposure Information
 
 type: object
 properties:

--- a/src/rad/resources/schemas/tvac/exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/exposure_type-1.0.0.yaml
@@ -4,7 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure_type-1.0.0
 
 # Helper file to enumerate viewing modes for exposure and ref_exposure
-title: Exposure Type
+title: TVAC Exposure Type
 description: |
   The type of the WFI exposure. Imaging mode science observations have type
   "WFI_IMAGE," while spectroscopic mode science observations may be either

--- a/src/rad/resources/schemas/tvac/exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/exposure_type-1.0.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure_type-1.0.0
+
+# Helper file to enumerate viewing modes for exposure and ref_exposure
+title: Exposure Type
+description: |
+  The type of the WFI exposure. Imaging mode science observations have type
+  "WFI_IMAGE," while spectroscopic mode science observations may be either
+  "WFI_GRISM" or "WFI_PRISM" depending on the chosen optical element. Other
+  values are related to internal calibrations and engineering observations.
+
+type: string
+enum:
+  - WFI_IMAGE
+  - WFI_GRISM
+  - WFI_PRISM
+  - WFI_DARK
+  - WFI_FLAT
+  - WFI_WFSC
+...

--- a/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tvac_groundtest-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/groundtest-1.0.0
 
 title: TVAC Ground Test Information
 type: object

--- a/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidestar-1.0.0
 
-title: Base Guide star window information
+title: TVAC Base Guide star window information
 type: object
 properties:
   gw_id:

--- a/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
@@ -1,0 +1,144 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidestar-1.0.0
+
+title: Base Guide star window information
+type: object
+properties:
+  gw_id:
+    title: Guide Star Window Identifier
+    description: |
+      Identification of the Guide Star Window.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.gw_id, GuideWindow.gw_id, WFICommon.gw_id]
+  gw_fgs_mode:
+    $ref: guidewindow_modes-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(18)
+      destination: [WFIExposure.gw_fgs_mode, GuideWindow.gw_fgs_mode, WFICommon.gw_fgs_mode]
+  data_start:
+    title: Guide Data Start Time (MJD)
+    description: |
+      Start time of the guide window data taken for this exposure as a Modified
+      Julian Date.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.data_start, GuideWindow.data_start, WFICommon.data_start]
+  data_end:
+    title: Guide Data End Time (MJD)
+    description: |
+      End time of the guide window data taken for this exposure as a Modified
+      Julian Date.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.data_end, GuideWindow.data_end, WFICommon.data_end]
+  gw_window_xstart:
+    title: Guide Window X Start Position (pixels)
+    description: |
+      Minimum X position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xstart, WFICommon.gw_window_xstart]
+  gw_window_ystart:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Minimum Y position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ystart, WFICommon.gw_window_ystart]
+  gw_window_xstop:
+    title: Guide Window X Stop Position (pixels)
+    description: |
+      Maximum X position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xstop, WFICommon.gw_window_xstop]
+  gw_window_ystop:
+    title: Guide Window Y Stop Position (pixels)
+    description: |
+      Maximum Y position in the science coordinate frame of all tracking guide
+      windows in this exposure measured in pixels
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ystop, WFICommon.gw_window_ystop]
+  gw_window_xsize:
+    title: Guide Window Size in the X Direction (pixels)
+    description: |
+      Size of a single tracking guide window in this exposure measured along the
+      X axis in units of pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_xsize, WFICommon.gw_window_xsize]
+  gw_window_ysize:
+    title: Guide Window Size in the Y Direction (pixels)
+    description: |
+      Size of a single tracking guide window in this exposure measured along the
+      Y axis in units of pixels.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.gw_window_ysize, WFICommon.gw_window_ysize]
+
+propertyOrder: [gw_id, gw_fgs_mode,
+               data_start, data_end, gw_window_xstart,
+               gw_window_ystart, gw_window_xstop, gw_window_ystop, gw_window_xsize,
+               gw_window_ysize]
+flowStyle: block
+required: [gw_id, gw_fgs_mode,
+           data_start, data_end, gw_window_xstart,
+           gw_window_ystart, gw_window_xstop, gw_window_ystop, gw_window_xsize,
+           gw_window_ysize]
+...

--- a/src/rad/resources/schemas/tvac/guidewindow_modes-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidewindow_modes-1.0.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidewindow_modes-1.0.0
+
+# Helper file to enumerate guide window modes for guidestar and guidewindow
+
+title: Guide Window Modes
+description: |
+  An enumerated collection of available guidestar and guidewindow modes.
+type: string
+enum:
+  - WIM-ACQ
+  - WIM-TRACK
+  - WSM-ACQ-1
+  - WSM-ACQ-2
+  - WSM-TRACK
+  - DEFOCUSED-MODERATE
+  - DEFOCUSED-LARGE
+...

--- a/src/rad/resources/schemas/tvac/guidewindow_modes-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidewindow_modes-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidewindow_modes-1.0.0
 
 # Helper file to enumerate guide window modes for guidestar and guidewindow
 
-title: Guide Window Modes
+title: TVAC Guide Window Modes
 description: |
   An enumerated collection of available guidestar and guidewindow modes.
 type: string

--- a/src/rad/resources/schemas/tvac/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/ref_file-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
 
-title: Reference File Information
+title: TVAC Reference File Information
 type: object
 properties:
   crds:

--- a/src/rad/resources/schemas/tvac/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/ref_file-1.0.0.yaml
@@ -1,0 +1,129 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
+
+title: Reference File Information
+type: object
+properties:
+  crds:
+    title: Calibration Reference Data System Parameters
+    description: |
+      Calibration Reference Data System Parameters
+    type: object
+    properties:
+      sw_version:
+        title: CRDS File Version
+        description: |
+          Version of Calibration Reference Data System (CRDS) file selection software.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_software_version, WFIMosaic.crds_software_version,
+                        GuideWindow.crds_software_version, WFICommon.crds_software_version]
+
+      context_used:
+        title: CRDS Context
+        description: |
+          CRDS context (.pmap) used to select ref files.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_context_used, WFIMosaic.crds_context_used,
+                        GuideWindow.crds_context_used, WFICommon.crds_context_used]
+  dark:
+    title: Dark Reference File Information
+    description: |
+      Reference file used to correct for the dark current contribution to
+      science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_dark, GuideWindow.r_dark, WFICommon.r_dark]
+  distortion:
+    title: Distortion Reference File Information
+    description: |
+      Information about the distortion reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_distortion, GuideWindow.r_distortion, WFICommon.r_distortion]
+  mask:
+    title: Mask Reference File Information
+    description: |
+      Information about the mask reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_mask, GuideWindow.r_mask, WFICommon.r_mask]
+  flat:
+    title: Flat Reference File Information
+    description: |
+      Information about the flat reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_flat, GuideWindow.r_flat, WFICommon.r_flat]
+  gain:
+    title: Gain Reference Rile Information
+    description: |
+      Information about the gain reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_gain, GuideWindow.r_gain, WFICommon.r_gain]
+  readnoise:
+    title: Read Noise Reference Rile Information
+    description: |
+      Information about the read noise reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_readnoise, GuideWindow.r_readnoise, WFICommon.r_readnoise]
+  linearity:
+    title: Linearity Reference File Information
+    description: |
+      Information about the linearity reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_linearity, GuideWindow.r_linearity, WFICommon.r_linearity]
+  photom:
+    title: Photometry Reference File Information
+    description: |
+      Information about the photometry reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_photom, GuideWindow.r_photom, WFICommon.r_photom]
+  area:
+    title: Area Reference File Information
+    description: |
+      Information about the area reference file used with the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_area, GuideWindow.r_area, WFICommon.r_area]
+  saturation:
+    title: Saturation Reference File Information
+    description: |
+      Information about the saturation reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_saturation, GuideWindow.r_saturation, WFICommon.r_saturation]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0
 
-title: Calibration Software Version Number
+title: TVAC Calibration Software Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0
+
+title: Calibration Software Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.calibration_software_version, GuideWindow.calibration_software_version,
+                WFICommon.calibration_software_version, WFIMosaic.calibration_software_version,
+                SourceCatalog.calibration_software_version, SegmentationMap.calibration_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/file_date-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/file_date-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/file_date-1.0.0
+
+title: File Creation Date
+
+allOf:
+  - $ref: http://stsci.edu/schemas/asdf/time/time-1.1.0
+
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: datetime2
+  destination: [WFIExposure.filedate, GuideWindow.filedate, WFICommon.filedate, WFIMosaic.filedate,
+                SourceCatalog.filedate, SegmentationMap.filedate]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/file_date-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/file_date-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/file_date-1.0.0
 
-title: File Creation Date
+title: TVAC File Creation Date
 
 allOf:
   - $ref: http://stsci.edu/schemas/asdf/time/time-1.1.0

--- a/src/rad/resources/schemas/tvac/tagged_scalars/filename-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/filename-1.0.0.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/filename-1.0.0
+
+title: File Name
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.filename, WFIMosaic.filename, GuideWindow.filename, WFICommon.filename,
+                SourceCatalog.filename, SegmentationMap.filename]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/model_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/model_type-1.0.0.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/model_type-1.0.0
+
+title: Data Model Type
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(50)
+  destination: [WFIExposure.model_type, GuideWindow.model_type, WFICommon.model_type, WFIMosaic.model_type,
+                SourceCatalog.model_type, SegmentationMap.model_type]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/model_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/model_type-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/model_type-1.0.0
 
-title: Data Model Type
+title: TVAC Data Model Type
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/tvac/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/origin-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/origin-1.0.0
+
+title: Institution / Organization Name
+
+type: string
+enum: ["STSCI", "IPAC/SSC"]
+
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(15)
+  destination: [WFIExposure.origin, GuideWindow.origin, WFICommon.origin, WFIMosaic.origin,
+                SourceCatalog.origin, SegmentationMap.origin]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/origin-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/origin-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/origin-1.0.0
 
-title: Institution / Organization Name
+title: TVAC Institution / Organization Name
 
 type: string
 enum: ["STSCI", "IPAC/SSC"]

--- a/src/rad/resources/schemas/tvac/tagged_scalars/prd_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/prd_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/prd_software_version-1.0.0
 
-title: SOC PRD Version Number
+title: TVAC SOC PRD Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/tvac/tagged_scalars/prd_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/prd_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/prd_software_version-1.0.0
+
+title: SOC PRD Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.prd_software_version, GuideWindow.prd_software_version,
+                WFICommon.prd_software_version, WFIMosaic.prd_software_version,
+                SourceCatalog.prd_software_version, SegmentationMap.prd_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0
 
-title: SDF Version Number
+title: TVAC SDF Version Number
 type: string
 sdf:
   special_processing: VALUE_REQUIRED

--- a/src/rad/resources/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0
+
+title: SDF Version Number
+type: string
+sdf:
+  special_processing: VALUE_REQUIRED
+  source:
+    origin: TBD
+archive_catalog:
+  datatype: nvarchar(120)
+  destination: [WFIExposure.sdf_software_version, GuideWindow.sdf_software_version,
+                WFICommon.sdf_software_version, WFIMosaic.sdf_software_version,
+                SourceCatalog.sdf_software_version, SegmentationMap.sdf_software_version]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/telescope-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/telescope-1.0.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/telescope-1.0.0
+
+title: Telescope Name
+
+type: string
+enum: [ROMAN]
+
+archive_catalog:
+  datatype: nvarchar(5)
+  destination: [WFIExposure.telescope, WFIMosaic.telescope, GuideWindow.telescope, WFICommon.telescope,
+                SourceCatalog.telescope, SegmentationMap.telescope]
+
+flowStyle: block
+...

--- a/src/rad/resources/schemas/tvac/tagged_scalars/telescope-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/tagged_scalars/telescope-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/telescope-1.0.0
 
-title: Telescope Name
+title: TVAC Telescope Name
 
 type: string
 enum: [ROMAN]

--- a/src/rad/resources/schemas/tvac/wfi_detector-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_detector-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_detector-1.0.0
 
 # Helper file to enumerate detectors for wfi_mode and ref_detector
 
-title: WFI Detector Name
+title: TVAC WFI Detector Name
 type: string
 enum:
   - WFI01

--- a/src/rad/resources/schemas/tvac/wfi_detector-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_detector-1.0.0.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_detector-1.0.0
+
+# Helper file to enumerate detectors for wfi_mode and ref_detector
+
+title: WFI Detector Name
+type: string
+enum:
+  - WFI01
+  - WFI02
+  - WFI03
+  - WFI04
+  - WFI05
+  - WFI06
+  - WFI07
+  - WFI08
+  - WFI09
+  - WFI10
+  - WFI11
+  - WFI12
+  - WFI13
+  - WFI14
+  - WFI15
+  - WFI16
+  - WFI17
+  - WFI18
+...

--- a/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
@@ -4,7 +4,7 @@ $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0
 
 
-title: WFI Observing Configuration
+title: TVAC WFI Observing Configuration
 type: object
 properties:
   name:

--- a/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
@@ -1,0 +1,50 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0
+
+
+title: WFI Observing Configuration
+type: object
+properties:
+  name:
+    title: Instrument Used to Acquire the Data
+    description: |
+      Instrument used to acquire the data.
+    type: string
+    enum: [WFI]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination: [WFIExposure.instrument_name, GuideWindow.instrument_name, WFICommon.instrument_name]
+  detector:
+    title: WFI Detector
+    description: |
+      WFI detector used to take the data.
+    $ref: wfi_detector-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
+  optical_element:
+    title: WFI Optical Element
+    description: |
+      WFI optical element used to take the data.
+    $ref: wfi_optical_element-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.optical_element, GuideWindow.optical_element, WFICommon.optical_element]
+propertyOrder: [detector, optical_element, name]
+flowStyle: block
+required: [detector, optical_element, name]
+...

--- a/src/rad/resources/schemas/tvac/wfi_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_optical_element-1.0.0.yaml
@@ -1,0 +1,25 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_optical_element-1.0.0
+
+# Helper file to enumerate filters for wfi_mode and ref_optical_element
+
+title: Optical Element
+description: |
+  Name of the filter element used. See the RDox Optical Element page for more
+  details on available optical elements and their properties.
+type: string
+enum:
+  - F062
+  - F087
+  - F106
+  - F129
+  - F146
+  - F158
+  - F184
+  - F213
+  - GRISM
+  - PRISM
+  - DARK
+...

--- a/src/rad/resources/schemas/tvac/wfi_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_optical_element-1.0.0.yaml
@@ -5,7 +5,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_optical_element-1.0.0
 
 # Helper file to enumerate filters for wfi_mode and ref_optical_element
 
-title: Optical Element
+title: TVAC Optical Element
 description: |
   Name of the filter element used. See the RDox Optical Element page for more
   details on available optical elements and their properties.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -30,5 +30,9 @@ def test_manifest_entries(entry):
     # Check the URIs
     assert entry["tag_uri"].startswith("asdf://stsci.edu/datamodels/roman/tags/")
     uri_suffix = entry["tag_uri"].split("asdf://stsci.edu/datamodels/roman/tags/")[-1]
-    assert entry["schema_uri"].endswith(uri_suffix)
-    assert entry["schema_uri"].startswith("asdf://stsci.edu/datamodels/roman/schemas/")
+    # Remove tagged scalars from the uri string
+    schema_uri = entry["schema_uri"]
+    if "tagged_scalars" in schema_uri.split("/"):
+        schema_uri = schema_uri.replace("tagged_scalars/","")
+    assert schema_uri.endswith(uri_suffix)
+    assert schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -33,6 +33,6 @@ def test_manifest_entries(entry):
     # Remove tagged scalars from the uri string
     schema_uri = entry["schema_uri"]
     if "tagged_scalars" in schema_uri.split("/"):
-        schema_uri = schema_uri.replace("tagged_scalars/","")
+        schema_uri = schema_uri.replace("tagged_scalars/", "")
     assert schema_uri.endswith(uri_suffix)
     assert schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-165](https://jira.stsci.edu/browse/RAD-165)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #407 

<!-- describe the changes comprising this PR here -->
This PR creates a suite of separate TVAC and FPS schemas to freeze them and keep them separate from main development. NOTE: archive catalog targets need updating, which I will split out into another ticket.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://github.com/spacetelescope/roman_datamodels/pull/344/files
