### PR TITLE
RAD-162: Remove GuideWindow and Ref tables from cal_step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.19.4 (unreleased)
 -------------------
 
-
+- This PR removes reference file and guidewindow db tables from cal_step schemas. [#420]
 
 0.19.3 (2024-04-25)
 -------------------

--- a/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
@@ -15,7 +15,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_assign_wcs]
+      destination: [ScienceRefData.s_assign_wcs]
   flat_field:
     title: Flat Fielding Step
     descroption: |
@@ -27,7 +27,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_flat_field]
+      destination: [ScienceRefData.s_flat_field]
   dark:
     title: Dark Current Subtraction Step
     description: |
@@ -37,7 +37,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_dark]
+      destination: [ScienceRefData.s_dark]
   dq_init:
     title: Initialization of the Data Quality Extension Step
     description: |
@@ -47,7 +47,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_dq_init]
+      destination: [ScienceRefData.s_dq_init]
   flux:
     title: Flux Scale Application Step
     description: |
@@ -57,7 +57,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_flux]
+      destination: [ScienceRefData.s_flux]
   jump:
     title: Cosmic Rays and Jump Detection Step
     description: |
@@ -67,7 +67,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_jump]
+      destination: [ScienceRefData.s_jump]
   linearity:
     title: Linearity Correction Step
     description: |
@@ -77,7 +77,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_linearity]
+      destination: [ScienceRefData.s_linearity]
   photom:
     title: Photometric Calibration Step
     description: |
@@ -87,7 +87,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_photom]
+      destination: [ScienceRefData.s_photom]
   source_detection:
     title: Source Detection Step
     description: |
@@ -96,7 +96,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_source_detection]
+      destination: [ScienceRefData.s_source_detection]
   ramp_fit:
     title: Ramp Fit Step
     description: |
@@ -106,7 +106,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_ramp_fit]
+      destination: [ScienceRefData.s_ramp_fit]
   refpix:
     title: Reference Pixel Correction Step
     description: |
@@ -116,7 +116,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_refpix]
+      destination: [ScienceRefData.s_refpix]
   saturation:
     title: Saturation Identification Step
     description: |
@@ -127,7 +127,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_saturation]
+      destination: [ScienceRefData.s_saturation]
   outlier_detection:
     title: Outlier Detection Step
     description: |
@@ -136,7 +136,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_outlier_detection]
+      destination: [ScienceRefData.s_outlier_detection]
   tweakreg:
     title: Tweakreg step
     description: |
@@ -147,7 +147,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_tweakreg]
+      destination: [ScienceRefData.s_tweakreg]
   skymatch:
     title: Sky Matching for Combining Overlapping Images Step
     description: |
@@ -157,7 +157,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIExposure.s_skymatch]
+      destination: [ScienceRefData.s_skymatch]
 propertyOrder: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, photom, source_detection,
                 outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
 flowStyle: block

--- a/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l2_cal_step-1.0.0.yaml
@@ -15,7 +15,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_assign_wcs, GuideWindow.s_assign_wcs, WFICommon.s_assign_wcs]
+      destination: [WFIExposure.s_assign_wcs]
   flat_field:
     title: Flat Fielding Step
     descroption: |
@@ -27,7 +27,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_flat_field, GuideWindow.s_flat_field, WFICommon.s_flat_field]
+      destination: [WFIExposure.s_flat_field]
   dark:
     title: Dark Current Subtraction Step
     description: |
@@ -37,7 +37,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_dark, GuideWindow.s_dark, WFICommon.s_dark]
+      destination: [WFIExposure.s_dark]
   dq_init:
     title: Initialization of the Data Quality Extension Step
     description: |
@@ -47,7 +47,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_dq_init, GuideWindow.s_dq_init, WFICommon.s_dq_init]
+      destination: [WFIExposure.s_dq_init]
   flux:
     title: Flux Scale Application Step
     description: |
@@ -57,7 +57,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_flux, GuideWindow.s_flux, WFICommon.s_flux]
+      destination: [WFIExposure.s_flux]
   jump:
     title: Cosmic Rays and Jump Detection Step
     description: |
@@ -67,7 +67,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_jump, GuideWindow.s_jump, WFICommon.s_jump]
+      destination: [WFIExposure.s_jump]
   linearity:
     title: Linearity Correction Step
     description: |
@@ -77,7 +77,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_linearity, GuideWindow.s_linearity, WFICommon.s_linearity]
+      destination: [WFIExposure.s_linearity]
   photom:
     title: Photometric Calibration Step
     description: |
@@ -87,7 +87,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_photom, GuideWindow.s_photom, WFICommon.s_photom]
+      destination: [WFIExposure.s_photom]
   source_detection:
     title: Source Detection Step
     description: |
@@ -96,7 +96,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_source_detection, GuideWindow.s_source_detection, WFICommon.s_source_detection]
+      destination: [WFIExposure.s_source_detection]
   ramp_fit:
     title: Ramp Fit Step
     description: |
@@ -106,7 +106,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_ramp_fit, GuideWindow.s_ramp_fit, WFICommon.s_ramp_fit]
+      destination: [WFIExposure.s_ramp_fit]
   refpix:
     title: Reference Pixel Correction Step
     description: |
@@ -116,7 +116,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_refpix, GuideWindow.s_refpix, WFICommon.s_refpix]
+      destination: [WFIExposure.s_refpix]
   saturation:
     title: Saturation Identification Step
     description: |
@@ -127,7 +127,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_saturation, GuideWindow.s_saturation, WFICommon.s_saturation]
+      destination: [WFIExposure.s_saturation]
   outlier_detection:
     title: Outlier Detection Step
     description: |
@@ -136,7 +136,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection, WFICommon.s_outlier_detection]
+      destination: [WFIExposure.s_outlier_detection]
   tweakreg:
     title: Tweakreg step
     description: |
@@ -147,7 +147,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_tweakreg, GuideWindow.s_tweakreg, WFICommon.s_tweakreg]
+      destination: [WFIExposure.s_tweakreg]
   skymatch:
     title: Sky Matching for Combining Overlapping Images Step
     description: |
@@ -157,7 +157,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFICommon.s_skymatch]
+      destination: [WFIExposure.s_skymatch]
 propertyOrder: [assign_wcs, flat_field, flux, dark, dq_init, jump, linearity, photom, source_detection,
                 outlier_detection, ramp_fit, refpix, saturation, skymatch, tweakreg]
 flowStyle: block

--- a/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
@@ -15,7 +15,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_flux, GuideWindow.s_flux, WFIMosaic.s_flux]
+      destination: [WFIMosaic.s_flux]
   outlier_detection:
     title: Outlier Detection Step
     description: |
@@ -24,7 +24,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_outlier_detection, GuideWindow.s_outlier_detection, WFIMosaic.s_outlier_detection]
+      destination: [WFIMosaic.s_outlier_detection]
   skymatch:
     title: Sky Matching for Combining Overlapping Images Step
     description: |
@@ -34,7 +34,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_skymatch, GuideWindow.s_skymatch, WFIMosaic.s_skymatch]
+      destination: [WFIMosaic.s_skymatch]
   resample:
     title: Resampling Input Data onto a Regular Grid Step
     description: |
@@ -45,7 +45,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [ScienceRefData.s_resample, GuideWindow.s_resample, WFIMosaic.s_resample]
+      destination: [WFIMosaic.s_resample]
 propertyOrder: [flux, outlier_detection, skymatch, resample]
 flowStyle: block
 required: [flux, outlier_detection, resample, skymatch]

--- a/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
+++ b/src/rad/resources/schemas/l3_cal_step-1.0.0.yaml
@@ -15,7 +15,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIMosaic.s_flux]
+      destination: [ScienceRefData.s_flux]
   outlier_detection:
     title: Outlier Detection Step
     description: |
@@ -24,7 +24,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIMosaic.s_outlier_detection]
+      destination: [ScienceRefData.s_outlier_detection]
   skymatch:
     title: Sky Matching for Combining Overlapping Images Step
     description: |
@@ -34,7 +34,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIMosaic.s_skymatch]
+      destination: [ScienceRefData.s_skymatch]
   resample:
     title: Resampling Input Data onto a Regular Grid Step
     description: |
@@ -45,7 +45,7 @@ properties:
     enum: ['N/A', 'COMPLETE', 'SKIPPED', 'INCOMPLETE']
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [WFIMosaic.s_resample]
+      destination: [ScienceRefData.s_resample]
 propertyOrder: [flux, outlier_detection, skymatch, resample]
 flowStyle: block
 required: [flux, outlier_detection, resample, skymatch]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-162](https://jira.stsci.edu/browse/RAD-162)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #400 

<!-- describe the changes comprising this PR here -->
This PR removes reference file and guidewindow db tables from cal_step schemas.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
