### PR TITLE
RAD-169: Drop filename_l1a and filename_pnt5 from database for TVAC and FPS schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Separated TVAC and FPS schemas into their own suite of files. [#414]
 
+- Removed the db entries for filename_l1a and filename_pnt5 in TVAC and FPS schemas. [#421]
+
 
 0.19.4 (2024-05-08)
 -------------------

--- a/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
@@ -57,9 +57,6 @@ properties:
   filename_pnt5:
     title: L0.5 File Name
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filename_pnt5]
   filepath_level_pnt5:
     title: L0.5 File Path
     type: string
@@ -69,9 +66,6 @@ properties:
   filename_l1a:
     title: L1A File Name
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filename_l1a]
   detector_id:
     title: SCA Identifier
     type: string

--- a/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
@@ -57,9 +57,6 @@ properties:
   filename_pnt5:
     title: L0.5 File Name
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filename_pnt5]
   filepath_level_pnt5:
     title: L0.5 File Path
     type: string
@@ -69,9 +66,6 @@ properties:
   filename_l1a:
     title: L1A File Name
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filename_l1a]
   detector_id:
     title: SCA Identifier
     type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-169](https://jira.stsci.edu/browse/RAD-169)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #416 

<!-- describe the changes comprising this PR here -->
This PR removed the db entries for filename_l1a and filename_pnt5 in TVAC and FPS schemas

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
