### PR TITLE
RAD-168: Drop filepath_level_pnt5 from TVAC/FPS database schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Separated TVAC and FPS schemas into their own suite of files. [#414]
 
+- Removed filepath_level_pnt5 from TVAC/FPS database. [#422]
+
 
 0.19.4 (2024-05-08)
 -------------------

--- a/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/groundtest-1.0.0.yaml
@@ -63,9 +63,6 @@ properties:
   filepath_level_pnt5:
     title: L0.5 File Path
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filepath_level_pnt5]
   filename_l1a:
     title: L1A File Name
     type: string

--- a/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/groundtest-1.0.0.yaml
@@ -63,9 +63,6 @@ properties:
   filepath_level_pnt5:
     title: L0.5 File Path
     type: string
-    archive_catalog:
-      datatype: nvarchar(80)
-      destination: [WFICommon.filepath_level_pnt5]
   filename_l1a:
     title: L1A File Name
     type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-168](https://jira.stsci.edu/browse/RAD-168)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #417 

<!-- describe the changes comprising this PR here -->
This PR removes filepath_level_pnt5 from TVAC/FPS database.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
