### PR TITLE
RAD-171: Add statistics field to TVAC and FPS schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Separated TVAC and FPS schemas into their own suite of files. [#414]
 
+- Added statistics schemas to both FPS and TVAC. [#423]
+
 
 0.19.4 (2024-05-08)
 -------------------

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -329,6 +329,11 @@ tags:
   title: FPS Guidestar information
   description: |-
     FPS Guidestar information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/statistics-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/statistics-1.0.0
+  title: FPS Summary Statistics
+  description: |-
+    FPS Summary Statistics
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/ref_file-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
   title: FPS Calibration reference file names.
@@ -406,6 +411,11 @@ tags:
   title: TVAC Guidestar information
   description: |-
     TVAC Guidestar information
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/statistics-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/statistics-1.0.0
+  title: TVAC Summary Statistics
+  description: |-
+    TVAC Summary Statistics
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/ref_file-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
   title: TVAC Calibration reference file names.

--- a/src/rad/resources/schemas/fps/statistics-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/statistics-1.0.0.yaml
@@ -19,7 +19,7 @@ properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN / s"]
       - type: "null"
     sdf:
@@ -39,7 +39,7 @@ properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN / s"]
       - type: "null"
     sdf:
@@ -59,7 +59,7 @@ properties:
           datatype:
             enum: ["int32"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
       - type: "null"
     sdf:
@@ -79,7 +79,7 @@ properties:
           datatype:
             enum: ["int32"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
       - type: "null"
     sdf:

--- a/src/rad/resources/schemas/fps/statistics-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/statistics-1.0.0.yaml
@@ -1,0 +1,95 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/fps/statistics-1.0.0
+
+
+title: |
+  FPS Summary Statistics
+
+type: object
+properties:
+  mean_counts_per_sec:
+    title: Mean number of counts per second
+    description: |
+      Mean number of counts per second of the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["float64"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN / s"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFICommon.mean_counts_per_sec]
+  median_counts_per_sec:
+    title: Median number of counts per second
+    description: |
+      Median number of counts per second of the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["float64"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN / s"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFICommon.median_counts_per_sec]
+  max_counts:
+    title: Maximum number of counts
+    description: |
+      Maximum number of counts in the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["int32"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFICommon.max_counts]
+  min_counts:
+    title: Minimum number of counts
+    description: |
+      Minimum number of counts in the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["int32"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFICommon.min_counts]
+propertyOrder: [mean_counts_per_sec, median_counts_per_sec, max_counts, min_counts]
+flowStyle: block
+required: [mean_counts_per_sec, median_counts_per_sec, max_counts, min_counts]
+...

--- a/src/rad/resources/schemas/tvac/statistics-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/statistics-1.0.0.yaml
@@ -19,7 +19,7 @@ properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN / s"]
       - type: "null"
     sdf:
@@ -39,7 +39,7 @@ properties:
           datatype:
             enum: ["float64"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN / s"]
       - type: "null"
     sdf:
@@ -59,7 +59,7 @@ properties:
           datatype:
             enum: ["int32"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
       - type: "null"
     sdf:
@@ -79,7 +79,7 @@ properties:
           datatype:
             enum: ["int32"]
           unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            tag: tag:astropy.org:astropy/units/unit-1.*
             enum: ["DN"]
       - type: "null"
     sdf:

--- a/src/rad/resources/schemas/tvac/statistics-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/statistics-1.0.0.yaml
@@ -1,0 +1,95 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tvac/statistics-1.0.0
+
+
+title: |
+  TVAC Summary Statistics
+
+type: object
+properties:
+  mean_counts_per_sec:
+    title: Mean number of counts per second
+    description: |
+      Mean number of counts per second of the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["float64"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN / s"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFICommon.mean_counts_per_sec]
+  median_counts_per_sec:
+    title: Median number of counts per second
+    description: |
+      Median number of counts per second of the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["float64"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN / s"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFICommon.median_counts_per_sec]
+  max_counts:
+    title: Maximum number of counts
+    description: |
+      Maximum number of counts in the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["int32"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFICommon.max_counts]
+  min_counts:
+    title: Minimum number of counts
+    description: |
+      Minimum number of counts in the data cube
+    anyOf:
+      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+        properties:
+          datatype:
+            enum: ["int32"]
+          unit:
+            tag: tag:stsci.edu:asdf/unit/unit-1.*
+            enum: ["DN"]
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFICommon.min_counts]
+propertyOrder: [mean_counts_per_sec, median_counts_per_sec, max_counts, min_counts]
+flowStyle: block
+required: [mean_counts_per_sec, median_counts_per_sec, max_counts, min_counts]
+...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-171](https://jira.stsci.edu/browse/RAD-171)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #412 

<!-- describe the changes comprising this PR here -->
This PR adds a statistics schema to both FPS and TVAC.

**Checklist**
- [x] Schema changes discussed at RAD Review Board meeting
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
