### PR TITLE
fix ground test docs schema list

### DIFF
--- a/docs/ground_tests.rst
+++ b/docs/ground_tests.rst
@@ -22,19 +22,19 @@ Tags
 
 .. asdf-autoschemas::
 
-#  fps/basic-1.0.0
-#  fps/cal_step-1.0.0
-#  fps/common-1.0.0
-#  fps/exposure-1.0.0
-#  fps/exposure_type-1.0.0
-#  fps/groundtest-1.0.0
-#  fps/guidestar-1.0.0
-#  fps/ref_file-1.0.0
-#  tvac/basic-1.0.0
-#  tvac/cal_step-1.0.0
-#  tvac/common-1.0.0
-#  tvac/exposure-1.0.0
-#  tvac/exposure_type-1.0.0
-#  tvac/groundtest-1.0.0
-#  tvac/guidestar-1.0.0
-#  tvac/ref_file-1.0.0
+  fps/basic-1.0.0
+  fps/cal_step-1.0.0
+  fps/common-1.0.0
+  fps/exposure-1.0.0
+  fps/exposure_type-1.0.0
+  fps/groundtest-1.0.0
+  fps/guidestar-1.0.0
+  fps/ref_file-1.0.0
+  tvac/basic-1.0.0
+  tvac/cal_step-1.0.0
+  tvac/common-1.0.0
+  tvac/exposure-1.0.0
+  tvac/exposure_type-1.0.0
+  tvac/groundtest-1.0.0
+  tvac/guidestar-1.0.0
+  tvac/ref_file-1.0.0


### PR DESCRIPTION
The schema list in the ground tests docs isn't rendering:
https://rad.readthedocs.io/en/latest/ground_tests.html

This PR fixes the formatting to allow them to render:
https://rad--447.org.readthedocs.build/en/447/ground_tests.html

Closes: https://github.com/spacetelescope/rad/issues/444

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [x] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
