### PR TITLE
Make var_flat optional in L3 files.

### DIFF
--- a/changes/462.feature.rst
+++ b/changes/462.feature.rst
@@ -1,0 +1,1 @@
+remove var_flat from list of required mosaic attributes

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -123,6 +123,6 @@ properties:
 propertyOrder: [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat,
                 cal_logs]
 flowStyle: block
-required: [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat,
+required: [meta, data, context, err, weight, var_poisson, var_rnoise,
            cal_logs]
 ...


### PR DESCRIPTION
Currently var_flat is optional in individual exposures and required in mosaics.  This doesn't make very much sense, since var_flat cannot be populated in mosaics if it doesn't exist in the individual exposures.  This PR removes var_flat from the list of required attributes in the mosaic metadata.

## Tasks
- [X] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.