### PR TITLE
RAD-91: Updates velocity_aberration descriptions

### DIFF
--- a/changes/476.misc.rst
+++ b/changes/476.misc.rst
@@ -1,0 +1,1 @@
+Update velocity_aberration descriptions and keywords

--- a/src/rad/resources/schemas/velocity_aberration-1.0.0.yaml
+++ b/src/rad/resources/schemas/velocity_aberration-1.0.0.yaml
@@ -6,10 +6,11 @@ id: asdf://stsci.edu/datamodels/roman/schemas/velocity_aberration-1.0.0
 title: Velocity Aberration Correction Information
 type: object
 properties:
-  ra_offset:
-    title: Velocity Aberration RA Offset (degree)
+  ra_reference:
+    title: Velocity Aberrated Reference Right Ascension (deg)
     description: |
-      Right ascension offset for velocity aberration in degrees.
+      Reference position right ascension corrected for
+      velocity aberration in units of degrees.
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -17,11 +18,12 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: float
-      destination: [WFIExposure.ra_offset, GuideWindow.ra_offset]
-  dec_offset:
-    title: Velocity Aberration Dec Offset (degree)
+      destination: [WFIExposure.ra_reference, GuideWindow.ra_reference]
+  dec_reference:
+    title: Velocity Aberrated Reference Declination (deg)
     description: |
-      Declination offset for velocity aberration in degrees.
+      Reference position declination corrected for velocity
+      aberration in units of degrees.
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -29,11 +31,12 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: float
-      destination: [WFIExposure.dec_offset, GuideWindow.dec_offset]
+      destination: [WFIExposure.dec_reference, GuideWindow.dec_reference]
   scale_factor:
-    title: Velocity Aberration Scale Factor
+    title: Velocity Aberration Correction Scale Factor
     description: |
-      Velocity aberration scale factor.
+      Scale factor used for the correction of the velocity
+      aberration.
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -43,6 +46,6 @@ properties:
       datatype: float
       destination: [WFIExposure.scale_factor, GuideWindow.scale_factor]
 flowStyle: block
-propertyOrder: [ra_offset, dec_offset, scale_factor]
-required: [ra_offset, dec_offset, scale_factor]
+propertyOrder: [ra_reference, dec_reference, scale_factor]
+required: [ra_reference, dec_reference, scale_factor]
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-91](https://jira.stsci.edu/browse/RAD-91)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #190 

<!-- describe the changes comprising this PR here -->
This PR updates velocity_aberration descriptions and keywords

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [x] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [x] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
