### PR TITLE
RAD-86: Update exposure and program attributes information

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       args: ["--py38-plus"]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.6.7'
+  rev: 'v0.6.8'
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/changes/478.misc.rst
+++ b/changes/478.misc.rst
@@ -1,0 +1,1 @@
+Update exposure and program attributes information

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -87,7 +87,7 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: int
-      destination: [WFIExposure.exposure_ngroups, GuideWindow.exposure_ngroups, WFICommon.exposure_ngroups]
+      destination: [WFIExposure.exposure_nresultants, GuideWindow.exposure_nresultants, WFICommon.exposure_nresultants]
   data_problem:
     title: Data Problem
     description: |

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -155,7 +155,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: TBD
+        origin: PSS:dms_visit.multi_accum_table_name
     maxLength: 50
     archive_catalog:
       datatype: nvarchar(50)
@@ -171,7 +171,7 @@ properties:
     sdf:
       special_processing: VALUE_REQUIRED
       source:
-        origin: TBD
+        origin: PSS:observation_specification.multi_accum_table_number
     archive_catalog:
       datatype: smallint
       destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -22,7 +22,13 @@ properties:
   start_time:
     title: Exposure Start Time (UTC)
     description: |
-      The UTC time at the beginning of the exposure.
+      The UTC time at the beginning of the exposure. The
+      time is serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
     tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
@@ -31,170 +37,16 @@ properties:
     archive_catalog:
       datatype: datetime2
       destination: [WFIExposure.exposure_start_time, GuideWindow.exposure_start_time, WFICommon.exposure_start_time]
-  ngroups:
-    title: Number of Resultants
-    description: |
-      The number of resultant frames in this exposure that were transmitted to
-      the ground. The number of integrations of WFI data is always 1.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [WFIExposure.exposure_ngroups, GuideWindow.exposure_ngroups, WFICommon.exposure_ngroups]
-  nframes:
-    title: Number of Reads
-    description: |
-      This is the number of science frames that are combined to produce a resultant frame.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [WFIExposure.exposure_nframes, GuideWindow.exposure_nframes, WFICommon.exposure_nframes]
-  data_problem:
-    title: Data Problem
-    description: |
-      A flag indicating an issue with science telemetry.
-    type: boolean
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: nchar(1)
-      destination: [WFIExposure.exposure_data_problem, GuideWindow.exposure_data_problem, WFICommon.exposure_data_problem]
-  frame_divisor:
-    title: Frame Divisor
-    description: |
-      The number of reads averaged to calculate a resultant. Value depends on
-      the readout pattern used from the MultiAccum table.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [WFIExposure.exposure_frame_divisor, GuideWindow.exposure_frame_divisor, WFICommon.exposure_frame_divisor]
-  groupgap:
-    title: Number of Frames Dropped Between Resultants
-    description:
-      The number of reads that are dropped, or not used to calculate a
-      resultant.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [WFIExposure.exposure_groupgap, GuideWindow.exposure_groupgap, WFICommon.exposure_groupgap]
-  frame_time:
-    title: Time Between Reads (s)
-    description: |
-      The amount of time elapsed between the end of one read and the beginning
-      of the next.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_frame_time, GuideWindow.exposure_frame_time, WFICommon.exposure_frame_time]
-  group_time:
-    title: Time Between Resultants (s)
-    description: |
-      The time that is the sum of the reads that are used to construct a
-      resultant. This will depend on the MA table being used.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_group_time, GuideWindow.exposure_group_time, WFICommon.exposure_group_time]
-  exposure_time:
-    title: Exposure Time (s)
-    description: |
-      The time between the start of the first Reset/Read Science Frame of an
-      Exposure and the completion of the final Read Only Science Frame of that
-      Exposure.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_time, GuideWindow.exposure_time, WFICommon.exposure_time]
-  ma_table_name:
-    title: MA Table Name
-    description: |
-      The name of the MultiAccum table used for this exposure, as defined in the
-      Project Reference Database.
-    type: string
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    maxLength: 50
-    archive_catalog:
-      datatype: nvarchar(50)
-      destination: [WFIExposure.ma_table_name, GuideWindow.ma_table_name, WFICommon.ma_table_name]
-  ma_table_number:
-    title: MA Table Number
-    description: |
-      The number of the MultiAccum table used for this exposure. Used in
-      matching exposures to their corresponding calibration data.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: smallint
-      destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]
-  read_pattern:
-    title: Read Pattern
-    description: |
-      Enumeration of detector reads to resultants making up the L1 data
-      downlinked from the observatory.
-    type: array
-    items:
-      type: array
-      items:
-        type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: nvarchar(3500)
-      destination: [WFIExposure.read_pattern, GuideWindow.read_pattern, WFICommon.read_pattern]
-  id:
-    title: Visit Exposure ID
-    description: |
-      The matching exposure ID for a given visit ID.
-    type: integer
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: int
-      destination: [WFIExposure.exposure_id, GuideWindow.exposure_id,
-                    SourceCatalog.exposure_id]
   mid_time:
     title: Exposure Mid Time (UTC)
     description: |
-      The UTC time at the midpoint of the exposure.
+      The UTC time at the midpoint of the exposure. The time
+      is serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
     tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
@@ -207,7 +59,13 @@ properties:
   end_time:
     title: Exposure End Time (UTC)
     description: |
-      The UTC time at the end of the exposure.
+      The UTC time at the end of the exposure. The time is
+      serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
     tag: tag:stsci.edu:asdf/time/time-1.*
     sdf:
       special_processing: VALUE_REQUIRED
@@ -217,95 +75,11 @@ properties:
       datatype: datetime2
       destination: [WFIExposure.exposure_end_time, GuideWindow.exposure_end_time,
                     SourceCatalog.exposure_end_time]
-  start_time_mjd:
-    title: MJD Start Time (d)
+  nresultants:
+    title: Number of Resultants
     description: |
-      The date, in MJD, at the beginning of this exposure. Used in the archive
-      catalog for multi-mission matching.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_start_time_mjd, GuideWindow.exposure_start_time_mjd,
-                    SourceCatalog.exposure_start_time_mjd]
-  mid_time_mjd:
-    title: MJD Mid Time (d)
-    description: |
-      The date, in MJD, at the midpoint of this exposure. Used in the archive
-      catalog for multi-mission matching.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_mid_time_mjd, GuideWindow.exposure_mid_time_mjd,
-                    SourceCatalog.exposure_mid_time_mjd]
-  end_time_mjd:
-    title: MJD End Time (d)
-    description: |
-      The date, in MJD, at the end of this exposure. Used in the archive catalog
-      for multi-mission matching.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_end_time_mjd, GuideWindow.exposure_end_time_mjd,
-                    SourceCatalog.exposure_end_time_mjd]
-  start_time_tdb:
-    title: TDB Start Time (d)
-    description: |
-      The date, in TDB (Barycentric Dynamical Time), at the beginning of this
-      exposure.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_start_time_tdb, GuideWindow.exposure_start_time_tdb,
-                    SourceCatalog.exposure_start_time_tdb]
-  mid_time_tdb:
-    title: TDB Mid Time (d)
-    description: |
-      The date, in TDB (Barycentric Dynamical Time), at the midpoint of this
-      exposure.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_mid_time_tdb, GuideWindow.exposure_mid_time_tdb,
-                    SourceCatalog.exposure_mid_time_tdb]
-  end_time_tdb:
-    title: TDB End Time (d)
-    description: |
-      The date, in TDB (Barycentric Dynamical Time), at the end of this
-      exposure.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_end_time_tdb, GuideWindow.exposure_end_time_tdb,
-                    SourceCatalog.exposure_end_time_tdb]
-  sca_number:
-    title: SCA Number
-    description: |
-      The number of the detector on the Sensor Chip Assembly used for this
-      exposure.
+      The number of resultant frames in this exposure that
+      were transmitted to the ground.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -313,37 +87,26 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: int
-      destination: [WFIExposure.exposure_sca_number, GuideWindow.exposure_sca_number,
-                    SourceCatalog.exposure_sca_number]
-  gain_factor:
-    title: Gain Factor
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_gain_factor, GuideWindow.exposure_gain_factor,
-                    SourceCatalog.exposure_gain_factor]
-  integration_time:
-    title: Effective Integration Time (s)
-    description:
-      The effective amount of time that the sensor was exposed to the sky.
-    type: number
-    sdf:
-      special_processing: VALUE_REQUIRED
-      source:
-        origin: TBD
-    archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_integration_time, GuideWindow.exposure_integration_time,
-                    SourceCatalog.exposure_integration_time]
-  elapsed_exposure_time:
-    title: Elapsed Exposure Time (s)
+      destination: [WFIExposure.exposure_ngroups, GuideWindow.exposure_ngroups, WFICommon.exposure_ngroups]
+  data_problem:
+    title: Data Problem
     description: |
-      The amount of time elapsed between an exposure's first and last science
-      reads.
+      A boolean flag representing if the science telemetry
+      indicate a problem with the data.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_data_problem, GuideWindow.exposure_data_problem, WFICommon.exposure_data_problem]
+  frame_time:
+    title: Detector Readout Time (s)
+    description: |
+      The readout time in seconds of the Wide Field
+      Instrument (WFI) detectors. This represents the time between the
+      start and end of the readout.
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -351,13 +114,28 @@ properties:
         origin: TBD
     archive_catalog:
       datatype: float
-      destination: [WFIExposure.elapsed_exposure_time, GuideWindow.elapsed_exposure_time,
-                    SourceCatalog.elapsed_exposure_time]
+      destination: [WFIExposure.exposure_frame_time, GuideWindow.exposure_frame_time, WFICommon.exposure_frame_time]
+  exposure_time:
+    title: Exposure Time (s)
+    description: |
+      The difference in time (in units of seconds) between
+      the start of the first reset/read and end of the last read in
+      the readout pattern.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_time, GuideWindow.exposure_time, WFICommon.exposure_time]
   effective_exposure_time:
     title: Effective Exposure Time (s)
     description: |
-      The amount of time during which the detector actually collected photons
-      during an exposure.
+      The difference in time (in units of seconds) between
+      the midpoints of the first and last science resultants. If
+      either resultant contains only a single read, then the time at
+      the end of the read is used rather than the midpoint time.
     type: number
     sdf:
       special_processing: VALUE_REQUIRED
@@ -367,34 +145,57 @@ properties:
       datatype: float
       destination: [WFIExposure.effective_exposure_time, GuideWindow.effective_exposure_time,
                     SourceCatalog.effective_exposure_time]
-  duration:
-    title: Exposure Duration (s)
+  ma_table_name:
+    title: Name of the Multi-Accumulation Table
     description: |
-      The amount of time dedicated to a exposure, including any overhead, time
-      spent on dropped frames, and so on.
-    type: number
+      The name of the multi-accumulation (MA) table used for
+      the exposure. The MA table is also referred to as the readout
+      pattern.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 50
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination: [WFIExposure.ma_table_name, GuideWindow.ma_table_name, WFICommon.ma_table_name]
+  ma_table_number:
+    title: Multi-Accumulation Table Identification Number
+    description: |
+      A unique identification number for the
+      multi-accumulation (MA) table used for this exposure. The number
+      comes from the Science Operations Center (SOC) Project Reference
+      Database (PRD).
+    type: integer
     sdf:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
     archive_catalog:
-      datatype: float
-      destination: [WFIExposure.exposure_duration, GuideWindow.exposure_duration,
-                    SourceCatalog.exposure_duration]
-  level0_compressed:
-    title: Level 0 Compression
+      datatype: smallint
+      destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]
+  read_pattern:
+    title: Read Pattern
     description: |
-      A flag indicating that the exposure has data that was decompressed by the
-      ground system.
-    type: boolean
+      The enumeration of detector reads to resultants making
+      up the Level 1 ramp data cube. The read pattern is nested such
+      that each grouping of read numbers represents a resultant. For
+      example, a readout pattern of [[1], [2, 3], [4]] consists of
+      four reads that were downlinked as three resultants with both
+      the first and last resultant each containing a single read.
+    type: array
+    items:
+      type: array
+      items:
+        type: integer
     sdf:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
     archive_catalog:
-      datatype: nchar(1)
-      destination: [WFIExposure.exposure_level0_compressed, GuideWindow.exposure_level0_compressed,
-                    SourceCatalog.exposure_level0_compressed]
+      datatype: nvarchar(3500)
+      destination: [WFIExposure.read_pattern, GuideWindow.read_pattern, WFICommon.read_pattern]
   truncated:
     title: Truncated MA Table
     description: |
@@ -408,27 +209,11 @@ properties:
       datatype: nchar(1)
       destination: [WFIExposure.exposure_truncated,
                     SourceCatalog.exposure_truncated]
-required: [type, start_time,
-           ngroups, nframes, data_problem,
-           frame_divisor, groupgap, frame_time, group_time, exposure_time,
-           ma_table_name, ma_table_number, read_pattern, id,
-          mid_time, end_time,
-          start_time_mjd, mid_time_mjd, end_time_mjd,
-          start_time_tdb, mid_time_tdb, end_time_tdb,
-          sca_number,
-          gain_factor, integration_time, elapsed_exposure_time,
-          effective_exposure_time, duration,
-          level0_compressed]
-propertyOrder: [type, start_time,
-           ngroups, nframes, data_problem,
-           frame_divisor, groupgap, frame_time, group_time, exposure_time,
-           ma_table_name, ma_table_number, read_pattern, id,
-          mid_time, end_time,
-          start_time_mjd, mid_time_mjd, end_time_mjd,
-          start_time_tdb, mid_time_tdb, end_time_tdb,
-          sca_number,
-          gain_factor, integration_time, elapsed_exposure_time,
-          effective_exposure_time, duration,
-          level0_compressed, truncated]
+required: [type, start_time, mid_time, end_time, nresultants, data_problem,
+  frame_time, exposure_time, effective_exposure_time, ma_table_name,
+  ma_table_number, read_pattern, truncated]
+propertyOrder: [type, start_time, mid_time, end_time, nresultants, data_problem,
+  frame_time, exposure_time, effective_exposure_time, ma_table_name,
+  ma_table_number, read_pattern, truncated]
 flowStyle: block
 ...

--- a/src/rad/resources/schemas/exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure_type-1.0.0.yaml
@@ -6,10 +6,12 @@ id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
 # Helper file to enumerate viewing modes for exposure and ref_exposure
 title: Exposure Type
 description: |
-  The type of the WFI exposure. Imaging mode science observations have type
-  "WFI_IMAGE," while spectroscopic mode science observations may be either
-  "WFI_GRISM" or "WFI_PRISM" depending on the chosen optical element. Other
-  values are related to internal calibrations and engineering observations.
+  The type of the exposure. Wide Field Instrument (WFI)
+  imaging mode observations have type WFI_IMAGE, while the
+  spectroscopic mode may be either WFI_GRISM or WFI_PRISM
+  depending on the selected optical element. Other values are
+  related to either internal calibration or engineering
+  observations.
 
 type: string
 enum:

--- a/src/rad/resources/schemas/program-1.0.0.yaml
+++ b/src/rad/resources/schemas/program-1.0.0.yaml
@@ -20,10 +20,11 @@ properties:
       datatype: nvarchar(200)
       destination: [WFIExposure.program_title, WFIMosaic.program_title, GuideWindow.program_title,
                     SourceCatalog.program_title, SegmentationMap.program_title]
-  pi_name:
+  investigator_name:
     title: Principal Investigator Name
     description: |
-      The name of the Principal Investigator (PI) of the program.
+      The name of the principle investigator (PI) of the
+      program.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -34,12 +35,18 @@ properties:
     maxLength: 100
     archive_catalog:
       datatype: nvarchar(100)
-      destination: [WFIExposure.pi_name, WFIMosaic.pi_name, GuideWindow.pi_name,
-                    SourceCatalog.pi_name, SegmentationMap.pi_name]
+      destination: [WFIExposure.investigator_name, WFIMosaic.investigator_name, GuideWindow.investigator_name,
+                    SourceCatalog.investigator_name, SegmentationMap.investigator_name]
   category:
     title: Program Category
     description: |
-      The category of the program.
+      The submitted proposal category of the program. The
+      categories include calibraiton (CAL), core community survey
+      (CCS), coronagraph technology demonstration (CGI), observatory
+      commissioning (COM), engineering (ENG), general astrophysics
+      survey (GAS), general investigator (GI), and observing conducted
+      at the direction of the National Aeronautics and Space
+      Administation (NASA).
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -53,8 +60,18 @@ properties:
   subcategory:
     title: Program Subcategory
     description: |
-      The subcategory of the program.
+      The submitted proposal subcategory of the program. The
+      subcategories include calibration (CAL), coronagraph technology
+      demonstration (CGI), community research programs (CR),
+      discretionary research programs (DR), Galactic Bulge Time Domain
+      Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
+      High-Latitude Wide-Area Survey (HLWA), observational research
+      program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
+      and Control (WFSC). All subcategories belong to only a subset of
+      the meta.program.category values.
     type: string
+    enum: ['CAL', 'CGI', 'CR', 'DR', 'GBTD', 'HLTD', 'HLWA', 'OR',
+           'WFI', 'WFSC', 'None']
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -67,8 +84,8 @@ properties:
   science_category:
     title: Science Category
     description: |
-      The science category assigned during the Telescope Allocation Committee
-      (TAC) process.
+      The science category assigned during the Time
+      Allocation Committee (TAC) review process.
     type: string
     sdf:
       special_processing: VALUE_REQUIRED
@@ -80,10 +97,10 @@ properties:
       destination: [WFIExposure.science_category, WFIMosaic.science_category, GuideWindow.science_category,
                     SourceCatalog.science_category, SegmentationMap.science_category]
   continuation_id:
-    title: Continuation ID
+    title: Program Continuation Identifier
     description: |
-      The identifier that marks the program as a continuation of a previous
-      program.
+      An identifier that indicates if the program is a
+      continuation of a previous program.
     type: integer
     sdf:
       special_processing: VALUE_REQUIRED
@@ -93,7 +110,9 @@ properties:
       datatype: int
       destination: [WFIExposure.continuation_id, WFIMosaic.continuation_id, GuideWindow.continuation_id,
                     SourceCatalog.continuation_id, SegmentationMap.continuation_id]
-propertyOrder: [title, pi_name, category, subcategory, science_category, continuation_id]
+propertyOrder: [title, investigator_name, category, subcategory,
+  science_category, continuation_id]
 flowStyle: block
-required: [title, pi_name, category, subcategory, science_category, continuation_id]
+required: [title, investigator_name, category, subcategory,
+  science_category, continuation_id]
 ...


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-86](https://jira.stsci.edu/browse/RAD-86)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #176

<!-- describe the changes comprising this PR here -->
This PR updates exposure and program attributes information

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [x] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
