### PR TITLE
RCAL-911 & 932: remove units from MOS and ELP pipelines.

### DIFF
--- a/changes/485.removal.rst
+++ b/changes/485.removal.rst
@@ -1,0 +1,1 @@
+Remove units from rad schema.

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -13,17 +13,19 @@ properties:
     anyOf:
       - type: number
       - type: "null"
+    unit: "MJy.sr**-1"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.conversion_megajanskys, WFIMosaic.conversion_megajanskys,
                     SourceCatalog.conversion_megajanskys]
   conversion_microjanskys:
-    title: Flux Density Producing 1 count per second (uJy / arcsec2)
+    title: Flux Density Producing 1 count per second (uJy / arcsec^2)
     description: |
-      The conversion from DN / s to uJy / steradian.
+      The conversion from DN / s to uJy / arcsec^2.
     anyOf:
       - type: number
       - type: "null"
+    unit: "uJy.arcsec**-2"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.conversion_microjanskys, WFIMosaic.conversion_microjanskys,
@@ -35,6 +37,7 @@ properties:
     anyOf:
       - type: number
       - type: "null"
+    unit: "sr"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.pixelarea_steradians, WFIMosaic.pixelarea_steradians,
@@ -46,6 +49,7 @@ properties:
     anyOf:
       - type: number
       - type: "null"
+    unit: "arcsec**2"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.pixelarea_arcsecsq, WFIMosaic.pixelarea_arcsecsq,
@@ -58,6 +62,7 @@ properties:
     anyOf:
       - type: number
       - type: "null"
+    unit: "MJy.sr**-1"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.conversion_megajanskys_uncertainty, WFIMosaic.conversion_megajanskys_uncertainty,
@@ -66,10 +71,11 @@ properties:
     title: Uncertainty in Flux Density Conversion (from DN / s to uJy / arcsec^2)
     description: |
       The uncertainty in the flux density conversion from DN / s to
-      uJy /arcsec^2.
+      uJy / arcsec^2.
     anyOf:
       - type: number
       - type: "null"
+    unit: "uJy.arcsec**-2"
     archive_catalog:
       datatype: float
       destination: [WFIExposure.conversion_microjanskys_uncertainty, WFIMosaic.conversion_microjanskys_uncertainty,

--- a/src/rad/resources/schemas/photometry-1.0.0.yaml
+++ b/src/rad/resources/schemas/photometry-1.0.0.yaml
@@ -11,13 +11,7 @@ properties:
     description: |
       The conversion from DN / s to MJy / steradian.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["MJy.sr**-1"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float
@@ -28,13 +22,7 @@ properties:
     description: |
       The conversion from DN / s to uJy / steradian.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["uJy.arcsec**-2"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float
@@ -45,13 +33,7 @@ properties:
     description: |
       The average pixel area in units of steradians.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["sr"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float
@@ -62,13 +44,7 @@ properties:
     description: |
       The average pixel area in units of square arcseconds.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["arcsec**2"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float
@@ -80,13 +56,7 @@ properties:
       The uncertainty in the flux density conversion from DN to MJy /steradians
       in units of MJy / steradians.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["MJy.sr**-1"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float
@@ -98,13 +68,7 @@ properties:
       The uncertainty in the flux density conversion from DN / s to
       uJy /arcsec^2.
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            tag: tag:stsci.edu:asdf/unit/unit-1.*
-            enum: ["uJy.arcsec**-2"]
+      - type: number
       - type: "null"
     archive_catalog:
       datatype: float

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -53,8 +53,8 @@ properties:
       Amplifier 33 Reference Pixel Data in units of DN.
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
-    datatype: float32
-    unit: ["DN", "electron"]
+    datatype: uint16
+    unit: "DN"
     exact_datatype: true
   border_ref_pix_left:
     title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
@@ -64,7 +64,7 @@ properties:
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
-    unit: ["DN", "electron"]
+    unit: "DN"
     exact_datatype: true
   border_ref_pix_right:
     title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
@@ -74,7 +74,7 @@ properties:
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
-    unit: ["DN", "electron"]
+    unit: "DN"
     exact_datatype: true
   border_ref_pix_top:
     title: Border Reference Pixels on the Top of the Detector (DN)
@@ -83,7 +83,7 @@ properties:
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
-    unit: ["DN", "electron"]
+    unit: "DN"
     exact_datatype: true
   border_ref_pix_bottom:
     title: Border Reference Pixels on the Bottom of the Detector (DN)
@@ -92,7 +92,7 @@ properties:
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
-    unit: ["DN", "electron"]
+    unit: "DN"
     exact_datatype: true
   dq_border_ref_pix_left:
     title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -16,16 +16,12 @@ properties:
     description: |
       Science Data Including Border Reference Pixels in units of DN or
       electrons.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN", "electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
   pixeldq:
     title: Two Dimensional Data Quality Flags Array for Each Pixel
     description: |
@@ -46,87 +42,58 @@ properties:
     exact_datatype: true
   err:
     title: Error Array Containing the Square Root of the Exposure-level Combined Variance (DN, electrons)
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN", "electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   amp33:
     title: Amp 33 Reference Pixel Data (DN)
     description: |
       Amplifier 33 Reference Pixel Data in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: uint16
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   border_ref_pix_left:
     title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
     description: |
       Border Reference Pixels on the Left of the Detector, from the instrument's
       perspective in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    value:
-      tag: tag:stsci.edu:asdf/core/ndarray-1.*
-      datatype: float32
-      exact_datatype: true
-      ndim: 3
-    unit:
-      tag: tag:astropy.org:astropy/units/unit-1.*
-      enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   border_ref_pix_right:
     title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
     description: |
       Border Reference Pixels on the Right of the Detector, from the
       instrument's perspective in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   border_ref_pix_top:
     title: Border Reference Pixels on the Top of the Detector (DN)
     description: |
       Border Reference Pixels on the Top of the Detector in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   border_ref_pix_bottom:
     title: Border Reference Pixels on the Bottom of the Detector (DN)
     description: |
       Border Reference Pixels on the Bottom of the Detector in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
   dq_border_ref_pix_left:
     title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
     description: |

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -17,16 +17,11 @@ properties:
       Slope of a specific segment for a ramp with uneven resultants, in units of
       electrons per second. A segment is a set of contiguous resultants where
       none of the resultants are saturated or cosmic ray-affected.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron / s"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
   sigslope:
     title: Uncertainty on Slope for Specific Segment (electrons / s)
     description: |
@@ -34,112 +29,78 @@ properties:
       resultants in units of electrons per second. A segment is a set of
       contiguous resultants where none of the resultants are saturated or cosmic
       ray-affected.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron / s"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
   yint:
     title: Y-Intercept Derived for a Specific Segment (electrons)
     description: |
       Y-intercept derived for a specific segment (electrons). A segment is a set
       of contiguous resultants where none of the resultants are saturated or
       cosmic ray-affected.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
   sigyint:
     title: Uncertainty on Y-Intercept Derived for a Specific Segment (electrons)
     description: |
       Uncertainty on Y-intercept derived for a specific segment (electrons). A
       segment is a set of contiguous resultants where none of the resultants are
       saturated or cosmic ray-affected.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
   pedestal:
     title: Pedestal Array (electrons)
     description: |
       Signal at zero exposure time for each pixel in electrons.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
   weights:
     title: Weights for Segment Specific Fit
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
     ndim: 3
     datatype: float32
     exact_datatype: true
+    unit: "electron"
   crmag:
     title: Approximate Cosmic Ray Magnitudes (AB magnitude)
     description: |
       The magnitude of each segment that was flagged as having a cosmic ray hit.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
   var_poisson:
     title: Poisson Variance Associated with a Segment Specific Slope (electrons^2 / sec^2)
     description: |
       Poisson variance associated with a segment-specific slope, in units of
       electrons^2 / sec^2.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron2 / s2"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
   var_rnoise:
     title: Read Noise Variance Associated for a Segment Specific Slope (electrons^2 / sec^2)
     description: |
       Read noise-associated variance for a segment-specific slope, in units of
       electrons^2 / sec^2.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["electron2 / s2"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
 required: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,
            var_rnoise]
 propertyOrder: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -10,7 +10,10 @@ properties:
     title: Sky Background Level
     description: |
       The sky background level in DN / s or MJy.sr**-1.
-    type: number
+    value:
+        anyOf:
+          - type: number
+          - type: null
     unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -10,8 +10,8 @@ properties:
     title: Sky Background Level
     description: |
       The sky background level in DN / s.
-    properties:
-      datatype: float64
+    type: number
+    unit: "DN / s"
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -12,7 +12,7 @@ properties:
       The sky background level in DN / s or MJy.sr**-1.
     properties:
       datatype: float64
-    unit: ["DN / s", "MJy.sr**-1"]
+      unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -10,17 +10,8 @@ properties:
     title: Sky Background Level
     description: |
       The sky background level in DN / s.
-    anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
-        properties:
-          datatype:
-            enum: ["float64"]
-          unit:
-            oneOf:
-            - tag: tag:stsci.edu:asdf/unit/unit-1.*
-            - tag: tag:astropy.org:astropy/units/unit-1.*
-            enum: ["DN / s", "MJy.sr**-1"]
-      - type: "null"
+    properties:
+      datatype: float64
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -10,9 +10,8 @@ properties:
     title: Sky Background Level
     description: |
       The sky background level in DN / s or MJy.sr**-1.
-    properties:
-      type: number
-      unit: ["DN / s", "MJy.sr**-1"]
+    type: number
+    unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -11,8 +11,8 @@ properties:
     description: |
       The sky background level in DN / s or MJy.sr**-1.
     properties:
-      datatype: float32
-    unit: "DN / s"
+      datatype: float64
+    unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -9,9 +9,9 @@ properties:
   level:
     title: Sky Background Level
     description: |
-      The sky background level in DN / s.
+      The sky background level in DN / s or MJy.sr**-1.
     type: number
-    unit: "DN / s"
+    unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -11,7 +11,7 @@ properties:
     description: |
       The sky background level in DN / s or MJy.sr**-1.
     properties:
-      datatype: float64
+      type: number
       unit: ["DN / s", "MJy.sr**-1"]
   method:
     title: Sky Background Method

--- a/src/rad/resources/schemas/sky_background-1.0.0.yaml
+++ b/src/rad/resources/schemas/sky_background-1.0.0.yaml
@@ -10,8 +10,9 @@ properties:
     title: Sky Background Level
     description: |
       The sky background level in DN / s or MJy.sr**-1.
-    type: number
-    unit: ["DN / s", "MJy.sr**-1"]
+    properties:
+      datatype: float32
+    unit: "DN / s"
   method:
     title: Sky Background Method
     description: |

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -38,10 +38,7 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit:
-      oneOf:
-        - type: string
-          enum: ["DN / s", "MJy.sr**-1"]
+    unit: ["DN / s", "MJy.sr**-1"]
   dq:
     title: Data Quality Flags
     description: |
@@ -58,10 +55,7 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit:
-      oneOf:
-        - type: string
-          enum: ["DN / s", "MJy.sr**-1"]
+    unit: ["DN / s", "MJy.sr**-1"]
   var_poisson:
     title: Poisson Variance (DN^2 / s^2)
     description: |
@@ -70,10 +64,7 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit:
-      oneOf:
-        - type: string
-          enum: ["DN2 / s2", "MJy**2.sr**-2"]
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
   var_rnoise:
     title: Read Noise (DN^2 / s^2)
     description: |
@@ -82,10 +73,7 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit:
-      oneOf:
-        - type: string
-          enum: ["DN2 / s2", "MJy**2.sr**-2"]
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
   var_flat:
     title: Variance for Estimate of Flat Pixel Flux (DN^2 / s^2).
     description: |
@@ -95,10 +83,7 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit:
-      oneOf:
-        - type: string
-          enum: ["DN2 / s2", "MJy**2.sr**-2"]
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
   amp33:
     title: Amp 33 Reference Pixel Data (DN)
     description: |

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -34,18 +34,14 @@ properties:
     description: |
       Science data, excluding border reference pixels, in DNs per second
       or MJ per steradian.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        oneOf:
-          - tag: tag:stsci.edu:asdf/unit/unit-1.*
-          - tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN / s", "MJy.sr**-1"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit:
+      oneOf:
+        - type: string
+          enum: ["DN / s", "MJy.sr**-1"]
   dq:
     title: Data Quality Flags
     description: |
@@ -55,143 +51,101 @@ properties:
     exact_datatype: true
     ndim: 2
   err:
-    title: Error (DN / s) or (MJy / sr)
+    title: Error (DN / s)
     description: |
       Error in units of DNs per second or MJ per steradian.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        oneOf:
-          - tag: tag:stsci.edu:asdf/unit/unit-1.*
-          - tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN / s", "MJy.sr**-1"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit:
+      oneOf:
+        - type: string
+          enum: ["DN / s", "MJy.sr**-1"]
   var_poisson:
-    title: Poisson Variance (DN^2 / s^2) or (MJy^2 / sr^2)
+    title: Poisson Variance (DN^2 / s^2)
     description: |
-      Poisson variance in units of DN^2 / second^2
-      or MJ per steradian.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        oneOf:
-          - tag: tag:stsci.edu:asdf/unit/unit-1.*
-          - tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN2 / s2", "MJy**2.sr**-2"]
+      Poisson variance in units of DN^2 / second^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit:
+      oneOf:
+        - type: string
+          enum: ["DN2 / s2", "MJy**2.sr**-2"]
   var_rnoise:
-    title: Read Noise (DN^2 / s^2) or (MJy^2 / sr^2)
+    title: Read Noise (DN^2 / s^2)
     description: |
-      Read noise in units of DN^2 / second^2 or MJ^2 per steradian^2.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        oneOf:
-          - tag: tag:stsci.edu:asdf/unit/unit-1.*
-          - tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN2 / s2", "MJy**2.sr**-2"]
+      Read noise in units of DN^2 / second^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit:
+      oneOf:
+        - type: string
+          enum: ["DN2 / s2", "MJy**2.sr**-2"]
   var_flat:
-    title: Variance for Estimate of Flat Pixel Flux (DN^2 / s^2) or (MJy^2 / sr^2)
+    title: Variance for Estimate of Flat Pixel Flux (DN^2 / s^2).
     description: |
       Variance for estimate of flat pixel flux in units of
-      DN^2 / second^2 or MJ^2 per steradian^2.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        oneOf:
-          - tag: tag:stsci.edu:asdf/unit/unit-1.*
-          - tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN2 / s2", "MJy**2.sr**-2"]
+      DN^2 / second^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit:
+      oneOf:
+        - type: string
+          enum: ["DN2 / s2", "MJy**2.sr**-2"]
   amp33:
     title: Amp 33 Reference Pixel Data (DN)
     description: |
       Amplifier 33 reference pixel data in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: uint16
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
   border_ref_pix_left:
     title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
     description: |
       Border reference pixels on the left of the detector, from the instrument's
       perspective in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
   border_ref_pix_right:
     title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
     description: |
       Border reference pixels on the right of the detector, from the
       instrument's perspective in units of DN
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
   border_ref_pix_top:
     title: Border Reference Pixels on the Top of the Detector (DN)
     description: |
       Border reference pixels on the top of the detector in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
   border_ref_pix_bottom:
     title: Border Reference Pixels on the Bottom of the Detector (DN)
     description: |
       Border reference pixels on the bottom of the detector in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
   dq_border_ref_pix_left:
     title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
     description: |

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -52,15 +52,14 @@ properties:
     datatype: float32
     exact_datatype: true
     ndim: 2
-    unit: "MJy / sr"
+    unit: "MJy.sr**-1"
   err:
     title: Error Data (MJy / steradian)
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy.sr**-1"
   context:
     title: Context Data
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
@@ -75,28 +74,25 @@ properties:
     ndim: 2
   var_poisson:
     title: Poisson Variability (MJy^2 / steradian^2)
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
   var_rnoise:
     title: Read Noise Variance (MJy^2 / steradian^2
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
   var_flat:
     title: Flat Field Variance (MJy^2 / steradian^2)
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
   cal_logs:
     tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
 propertyOrder: [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat,

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -48,28 +48,19 @@ properties:
     description: |
       The science data array, excluding the border reference pixels in units of
       MJy / steradian.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: float32
-        exact_datatype: true
-        ndim: 2
-      unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.*
-        enum: ["MJy.sr**-1"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy / sr"
   err:
     title: Error Data (MJy / steradian)
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
         tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         exact_datatype: true
         ndim: 2
-      unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.*
-        enum: ["MJy.sr**-1"]
   context:
     title: Context Data
     tag: tag:stsci.edu:asdf/core/ndarray-1.*
@@ -84,40 +75,28 @@ properties:
     ndim: 2
   var_poisson:
     title: Poisson Variability (MJy^2 / steradian^2)
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
         tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         exact_datatype: true
         ndim: 2
-      unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.*
-        enum: ["MJy**2.sr**-2"]
   var_rnoise:
     title: Read Noise Variance (MJy^2 / steradian^2
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
         tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         exact_datatype: true
         ndim: 2
-      unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.*
-        enum: ["MJy**2.sr**-2"]
   var_flat:
     title: Flat Field Variance (MJy^2 / steradian^2)
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
     properties:
       value:
         tag: tag:stsci.edu:asdf/core/ndarray-1.*
         datatype: float32
         exact_datatype: true
         ndim: 2
-      unit:
-        tag: tag:stsci.edu:asdf/unit/unit-1.*
-        enum: ["MJy**2.sr**-2"]
   cal_logs:
     tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
 propertyOrder: [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat,

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -17,30 +17,21 @@ properties:
     title: Science Data (DN)
     description: |
       Science data, including reference pixels in units of DN
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: uint16
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+
   amp33:
     title: Amplifier 33 Reference Pixel Data (DN)
     description: |
       Reference pixel data from amplifier 33 in units of DN.
-    tag: tag:stsci.edu:asdf/unit/quantity-1.*
-    properties:
-      value:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.*
-        datatype: uint16
-        exact_datatype: true
-        ndim: 3
-      unit:
-        tag: tag:astropy.org:astropy/units/unit-1.*
-        enum: ["DN"]
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
 
   resultantdq:
     title: Resultant Data Quality Array


### PR DESCRIPTION
Resolves [RCAL-911](https://jira.stsci.edu/browse/RCAL-911)
Resolves [RCAL-932](https://jira.stsci.edu/browse/RCAL-932)

This PR modifies several files so that units are not used anymore.
The information about units is still retained in the RAD schema.

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/485.removal.rst``: Remove units from rad schema.

</details>
