### PR TITLE
RAD-177: Update aperture names

### DIFF
--- a/changes/498.misc.rst
+++ b/changes/498.misc.rst
@@ -1,0 +1,1 @@
+Added alternate WFI aperture names to match both the SIAF and legacy names.

--- a/src/rad/resources/schemas/wcsinfo-1.0.0.yaml
+++ b/src/rad/resources/schemas/wcsinfo-1.0.0.yaml
@@ -20,7 +20,13 @@ properties:
            'WFI05_FULL', 'WFI06_FULL', 'WFI07_FULL', 'WFI08_FULL',
            'WFI09_FULL', 'WFI10_FULL', 'WFI11_FULL', 'WFI12_FULL',
            'WFI13_FULL', 'WFI14_FULL', 'WFI15_FULL', 'WFI16_FULL',
-           'WFI17_FULL', 'WFI18_FULL', 'WFI_CEN', 'BORESIGHT', 'CGI_CEN']
+           'WFI17_FULL', 'WFI18_FULL',
+           'WFI_01_FULL', 'WFI_02_FULL', 'WFI_03_FULL', 'WFI_04_FULL',
+           'WFI_05_FULL', 'WFI_06_FULL', 'WFI_07_FULL', 'WFI_08_FULL',
+           'WFI_09_FULL', 'WFI_10_FULL', 'WFI_11_FULL', 'WFI_12_FULL',
+           'WFI_13_FULL', 'WFI_14_FULL', 'WFI_15_FULL', 'WFI_16_FULL',
+           'WFI_17_FULL', 'WFI_18_FULL',
+           'WFI_CEN', 'BORESIGHT', 'CGI_CEN']
     sdf:
       special_processing: VALUE_REQUIRED
       source:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-177](https://jira.stsci.edu/browse/RAD-177)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #426 

<!-- describe the changes comprising this PR here -->
This PR adds alternate WFI aperture names to match both the SIAF and legacy names.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [x] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
