### PR TITLE
Fix issues with `archive_catalog` marked keywords not being required

### DIFF
--- a/changes/505.feature.rst
+++ b/changes/505.feature.rst
@@ -1,0 +1,2 @@
+Require that ``archive_catalog`` and ``sdf`` marked keywords are in the ``required``
+list for the object containing those keywords.

--- a/src/rad/resources/schemas/ref_file-1.0.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.0.0.yaml
@@ -171,5 +171,6 @@ properties:
     archive_catalog:
       datatype: nvarchar(120)
       destination: [ScienceRefData.r_refpix, GuideWindow.r_refpix, WFICommon.r_refpix]
+required: [crds, dark, distortion, mask, flat, gain, readnoise, linearity, inverse_linearity, photom, area, saturation, refpix]
 flowStyle: block
 ...


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #502
Closes #503

<!-- describe the changes comprising this PR here -->
In order to walk the schemas to find `archive_catalog` information, a valid `AsdfFile` object must exist satisfying those schemas. Thus in order to discover this metadata, all those properties must be present meaning that they must be required by the schemas.

This PR adds a test to check that `archive_catalog` (and `sdf`) force the keyword to be required. Moreover, this PR fixes all the failures detected by this process.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
