### PR TITLE
remove upper pin for asdf

### DIFF
--- a/changes/510.misc.rst
+++ b/changes/510.misc.rst
@@ -1,0 +1,1 @@
+Remove upper pin for asdf.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf >=2.14.2,<4.0",
+    "asdf >=2.14.2",
     "asdf-astropy >=0.5.0",
 ]
 dynamic = [


### PR DESCRIPTION
Now that the release is made we can remove the upper pin for asdf. This should help to fix the "test_with_nightly" run (although other pins might need to be removed in romancal):
https://github.com/spacetelescope/RegressionTests/actions/runs/11865364654/job/33070520465#step:14:190

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
