### PR TITLE
Use the list_dependencies_command instead of pip freeze

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -22,3 +22,4 @@ jobs:
       envs: |
         - macos: py310-xdist
         - linux: py312-devdeps-xdist
+        - linux: py310-oldestdeps-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf >=2.14.2",
+    "asdf >=2.15.2",
     "asdf-astropy >=0.5.0",
 ]
 dynamic = [
@@ -28,8 +28,8 @@ file = "LICENSE"
 
 [project.optional-dependencies]
 test = [
-    "pytest>=4.6.0",
-    "pytest-doctestplus>=0.11.1",
+    "pytest>=7.0.0",
+    "pytest-doctestplus>=1.2.1",
     "crds>=11.16.16",
 ]
 docs = [
@@ -77,7 +77,7 @@ where = [
 ]
 
 [tool.pytest.ini_options]
-minversion = 4.6
+minversion = 7.0
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ envlist =
     check-{style,build}
     test-xdist{,-cov,-devdeps}
     build-{docs,dist}
-
-[main]
-extra_url = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+requires =
+    tox-uv
 
 [testenv:check-style]
 description = Run all style and file checks with pre-commit
@@ -21,14 +20,17 @@ description =
     run tests
     cov: with coverage
     xdist: using parallel processing
+    devdeps: Run with select dev dependencies
+    oldestdeps: Run with oldest direct dependencies
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = {[main]extra_url}
-    devdeps: UV_INDEX = {[main]extra_url}
+    devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     devdeps: UV_INDEX_STRATEGY = unsafe-any-match
 extras =
     test
+uv_resolution =
+    oldestdeps: lowest-direct
 deps =
-    xdist: pytest-xdist
+    xdist: pytest-xdist>=3
     cov: pytest-cov
     devdeps: pyerfa>=0.0.dev0
     devdeps: numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ envlist =
     test-xdist{,-cov,-devdeps}
     build-{docs,dist}
 
+[main]
+extra_url = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
 [testenv:check-style]
 description = Run all style and file checks with pre-commit
 skip_install = true
@@ -19,15 +22,17 @@ description =
     cov: with coverage
     xdist: using parallel processing
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = {[main]extra_url}
+    devdeps: UV_INDEX = {[main]extra_url}
+    devdeps: UV_INDEX_STRATEGY = unsafe-any-match
 extras =
     test
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
+    devdeps: pyerfa>=0.0.dev0
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
-    devdeps: pyerfa>=0.0.dev0
 commands_pre =
     {list_dependencies_command}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,9 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
+commands_pre =
+    {list_dependencies_command}
 commands =
-    pip freeze
     pytest \
     xdist: -n auto \
     cov: --cov --cov-report=term-missing --cov-report=xml \


### PR DESCRIPTION
This is what `tox` recommends. It also allows this `tox` to be compatible with using `tox-uv`.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
