### PR TITLE
RAD-189: APCORR and ABVEGAOFFSET optional nulls

### DIFF
--- a/changes/516.misc.rst
+++ b/changes/516.misc.rst
@@ -1,0 +1,1 @@
+Added null values to allowed APCORR and ABVEGAOFFSET keyword values.

--- a/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
@@ -28,7 +28,9 @@ properties:
             description: Magnitude difference between the AB and Vega magnitude
                 systems. Found by calculating the AB magnitude of Vega within
                 the optical element bandpass.
-            type: number
+            anyOf:
+              - type: number
+              - type: "null"
         required: [abvega_offset]
 required: [meta, data]
 flowStyle: block

--- a/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
@@ -27,39 +27,49 @@ properties:
             title: Aperture Corrections
             description: The aperture correction for each enclosed energy
                 fraction, corresponding to 1 / ee_fractions.
-            tag: tag:stsci.edu:asdf/core/ndarray-1.*
-            datatype: float64
-            exact_datatype: true
-            ndim: 1
+            anyOf:
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+              - type: "null"
           ee_fractions:
             title: Enclosed Energy Fractions
             description: Fractions of the enclosed energy of the PSF at which
                 to estimate the aperture correction and enclosed energy radii.
-            tag: tag:stsci.edu:asdf/core/ndarray-1.*
-            datatype: float64
-            exact_datatype: true
-            ndim: 1
+            anyOf:
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+              - type: "null"
           ee_radii:
             title: Enclosed Energy Radii
             description: Radius, in pixels, within which the enclosed energy
                 fractions are met. The indexing matches that of
                   "ee_fractions".
-            tag: tag:stsci.edu:asdf/core/ndarray-1.*
-            datatype: float64
-            exact_datatype: true
-            ndim: 1
+            anyOf:
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+              - type: "null"
           sky_background_rin:
             title: Inner Radius for the Sky Background
             description: Inner radius, in pixels, to use when estimating the
                 local sky background within an annulus between this
                 radius and "sky_background_rout".
-            type: number
+            anyOf:
+              - type: number
+              - type: "null"
           sky_background_rout:
             title: Outer Radius for the Sky Background
             description: Outer radius, in pixels, to use when estimating the
                 local sky background within an annulus between this
                 radius and "sky_background_rin".
-            type: number
+            anyOf:
+              - type: number
+              - type: "null"
         required: [ap_corrections, ee_fractions, ee_radii, sky_background_rin, sky_background_rout]
 required: [meta, data]
 flowStyle: block


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-189](https://jira.stsci.edu/browse/RAD-189)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #488 

<!-- describe the changes comprising this PR here -->
This PR adds null values to allowed APCORR and ABVEGAOFFSET keyword values.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
