### PR TITLE
Add roman_datamodels testing job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,9 @@ jobs:
           coverage: codecov
         - linux: py312-xdist
         - linux: py313-xdist
+
+  roman_datamodels:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
+    with:
+      envs: |
+        - linux: roman_datamodels-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist =
 requires =
     tox-uv
 
+[main]
+roman_datamodels_repo = https://github.com/spacetelescope/roman_datamodels.git
+
 [testenv:check-style]
 description = Run all style and file checks with pre-commit
 skip_install = true
@@ -22,6 +25,8 @@ description =
     xdist: using parallel processing
     devdeps: Run with select dev dependencies
     oldestdeps: Run with oldest direct dependencies
+allowlist_externals =
+    roman_datamodels: git
 set_env =
     devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     devdeps: UV_INDEX_STRATEGY = unsafe-any-match
@@ -35,10 +40,19 @@ deps =
     devdeps: pyerfa>=0.0.dev0
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+    roman_datamodels: roman_datamodels[test] @ git+{[main]roman_datamodels_repo}
+change_dir =
+    roman_datamodels: {env_tmp_dir}
 commands_pre =
+    oldestdeps: minimum_dependencies
+    oldestdeps: uv pip install -r {env_tmp_dir}/requirements-min.txt
     {list_dependencies_command}
+    roman_datamodels: git clone -n --depth=1 --filter=blob:none {[main]roman_datamodels_repo}
+    roman_datamodels: git --git-dir={env_tmp_dir}/roman_datamodels/.git checkout HEAD pyproject.toml
+    roman_datamodels: git --git-dir={env_tmp_dir}/roman_datamodels/.git checkout HEAD tests/*
 commands =
     pytest \
+    roman_datamodels: --config-file={env_tmp_dir}/pyproject.toml tests \
     xdist: -n auto \
     cov: --cov --cov-report=term-missing --cov-report=xml \
     {posargs}


### PR DESCRIPTION
closes #263

This PR adds downstream testing of `roman_datamodels`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
