### PR TITLE
Per SPEC 0, bump min python to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d68193b68216da64eafaa618f53c59f5d271c56e  # v1.14.0
     with:
       envs: |
-        - linux: py310-xdist
-        - linux: py311-xdist-cov
+        - linux: py311-xdist
+        - linux: py312-xdist-cov
           coverage: codecov
-        - linux: py312-xdist
         - linux: py313-xdist
 
   roman_datamodels:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -20,6 +20,6 @@ jobs:
     if: (github.repository == 'spacetelescope/rad' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     with:
       envs: |
-        - macos: py310-xdist
-        - linux: py312-devdeps-xdist
-        - linux: py310-oldestdeps-xdist
+        - macos: py311-xdist
+        - linux: py313-devdeps-xdist
+        - linux: py311-oldestdeps-xdist

--- a/changes/520.misc.rst
+++ b/changes/520.misc.rst
@@ -1,0 +1,1 @@
+Bump min Python to 3.11 per SPEC 0.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,16 +25,11 @@
 import datetime
 import os
 import sys
+import tomllib
 from pathlib import Path
 
 # Ensure documentation examples are deterministically random.
 import numpy
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
-
 from importlib_metadata import distribution
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ docs = [
     "graphviz",
     "matplotlib",
     "docutils",
-    "tomli; python_version <\"3.11\"",
     "importlib-metadata",
     "towncrier",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rad"
 description = "Roman Attribute Dictionary"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]


### PR DESCRIPTION
This PR bumps min python to 3.11 per [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window). `astropy` 7 has already made this bump.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
