### PR TITLE
Clean up linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     - id: check-yaml
       args: ["--unsafe"]
     - id: check-toml
+    - id: check-json
     - id: check-merge-conflict
     - id: check-symlinks
     - id: debug-statements
@@ -19,8 +20,6 @@ repos:
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0
   hooks:
-    - id: python-check-blanket-noqa
-    - id: python-check-mock-methods
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
@@ -33,30 +32,13 @@ repos:
       additional_dependencies:
         - tomli
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.19.0'
-  hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: 'v0.8.0'
   hooks:
     - id: ruff
       args: ["--fix"]
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-
 - repo: https://github.com/psf/black
   rev: 24.10.0
   hooks:
     - id: black
-
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.10
-  hooks:
-    - id: bandit
-      args: ["-r", "-ll"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,9 +36,5 @@ repos:
   rev: 'v0.8.0'
   hooks:
     - id: ruff
-      args: ["--fix"]
-
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-    - id: black
+      args: ["--fix", "--show-fixes"]
+    - id: ruff-format

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,12 +59,12 @@ configuration = conf["project"]
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.2'
 
-intersphinx_mapping["pypa-packaging"] = ("https://packaging.python.org/en/latest/", None)  # noqa: E501, F405
-intersphinx_mapping["asdf"] = ("https://asdf.readthedocs.io/en/latest/", None)  # noqa: E501, F405
-intersphinx_mapping["asdf-standard"] = ("https://asdf-standard.readthedocs.io/en/latest/", None)  # noqa: E501, F405
-intersphinx_mapping["asdf-astropy"] = ("https://asdf-astropy.readthedocs.io/en/latest/", None)  # noqa: E501, F405
-intersphinx_mapping["pytest"] = ("https://docs.pytest.org/en/latest/", None)  # noqa: E501, F405
-intersphinx_mapping["roman_datamodels"] = ("https://roman-datamodels.readthedocs.io/en/latest/", None)  # noqa: E501, F405
+intersphinx_mapping["pypa-packaging"] = ("https://packaging.python.org/en/latest/", None)  # noqa: F405
+intersphinx_mapping["asdf"] = ("https://asdf.readthedocs.io/en/latest/", None)  # noqa: F405
+intersphinx_mapping["asdf-standard"] = ("https://asdf-standard.readthedocs.io/en/latest/", None)  # noqa: F405
+intersphinx_mapping["asdf-astropy"] = ("https://asdf-astropy.readthedocs.io/en/latest/", None)  # noqa: F405
+intersphinx_mapping["pytest"] = ("https://docs.pytest.org/en/latest/", None)  # noqa: F405
+intersphinx_mapping["roman_datamodels"] = ("https://roman-datamodels.readthedocs.io/en/latest/", None)  # noqa: F405
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ else:
 from importlib_metadata import distribution
 
 try:
-    numpy.random.seed(int(os.environ["SOURCE_DATE_EPOCH"]))
+    numpy.random.seed(int(os.environ["SOURCE_DATE_EPOCH"]))  # noqa: NPY002
 except KeyError:
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ rad = "rad.integration:get_resource_mappings"
 requires = [
     "setuptools >=61",
     "setuptools_scm[toml] >=3.4",
-    "wheel",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -81,13 +80,21 @@ minversion = 7.0
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"
-addopts = "--show-capture=no"
+log_cli_level = "INFO"
+xfail_strict = true
+addopts = [
+    "--color=yes",      # color test output
+    "--doctest-rst",    # enable doctests
+    "--strict-config",  # fail on unknown config options
+    "--strict-markers", # fail on unknown markers
+    "-ra",              # Show summary of all failures/errors
+]
 testpaths = [
     "tests",
     "src/rad/resources/schemas",
 ]
 filterwarnings = [
-    "error::ResourceWarning",
+    "error",
 ]
 asdf_schema_tests_enabled = "true"
 asdf_schema_skip_tests = "src/rad/resources/schemas/rad_schema-1.0.0.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ extend-select = [
     "B",    # BugBear
     "S",    # Bandit
     "RUF",  # ruff specific
+    "NPY",  # numpy specific
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,6 @@ asdf_schema_tests_enabled = "true"
 asdf_schema_skip_tests = "src/rad/resources/schemas/rad_schema-1.0.0.yaml"
 asdf_schema_root = "src/rad/resources/schemas"
 
-[tool.black]
-line-length = 130
-force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n    | \\.tox\n  )/\n)\n"
-
 [tool.ruff]
 line-length = 130
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,17 +93,26 @@ asdf_schema_tests_enabled = "true"
 asdf_schema_skip_tests = "src/rad/resources/schemas/rad_schema-1.0.0.yaml"
 asdf_schema_root = "src/rad/resources/schemas"
 
-[tool.isort]
-profile = "black"
-filter_files = true
-line_length = 130
-
 [tool.black]
 line-length = 130
 force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n    | \\.tox\n  )/\n)\n"
 
 [tool.ruff]
 line-length = 130
+
+[tool.ruff.lint]
+extend-select = [
+    "UP",   # PyUpgrade
+    "I",    # isort
+    "B",    # BugBear
+    "S",    # Bandit
+    "RUF",  # ruff specific
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = [
+    "S101" # Bandit: Use of assert detected (fine in test files)
+]
 
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"

--- a/scripts/insert_next_release.py
+++ b/scripts/insert_next_release.py
@@ -3,6 +3,7 @@
 Insert the next release's changelog header.  Prints the version, which
 our GitHub Actions workflow uses to generate a commit message.
 """
+
 import re
 from pathlib import Path
 

--- a/scripts/set_release_date.py
+++ b/scripts/set_release_date.py
@@ -4,6 +4,7 @@ Set the (latest and unreleased) changelog header release date to today.
 Prints the version, which our GitHub Actions workflow uses to
 generate a commit message and release tag.
 """
+
 import re
 from datetime import date
 from pathlib import Path

--- a/src/rad/integration.py
+++ b/src/rad/integration.py
@@ -1,11 +1,6 @@
-import sys
+import importlib.resources as importlib_resources
 
 from asdf.resource import DirectoryResourceMapping
-
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
 
 
 def get_resource_mappings():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,12 +2,7 @@
 Test that the asdf library integration is working properly.
 """
 
-import sys
-
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
+import importlib.resources as importlib_resources
 
 import asdf
 import pytest

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -90,7 +90,7 @@ def test_property_order(schema, manifest):
                         "missing properties: " + missing_list + "\n"
                         "extra properties: " + extra_list
                     )
-                    assert False, message
+                    raise ValueError(message)
 
         asdf.treeutil.walk(schema, callback)
     else:
@@ -111,7 +111,7 @@ def test_required(schema):
             if not required_names.issubset(property_names):
                 missing_list = ", ".join(required_names - property_names)
                 message = "required references names that do not exist: " + missing_list
-                assert False, message
+                raise ValueError(message)
 
     asdf.treeutil.walk(schema, callback)
 
@@ -279,7 +279,8 @@ def test_varchar_length(uri):
     """
     schema = asdf.schema.load_schema(uri)
 
-    def callback(node, nvarchars={}):
+    def callback(node, nvarchars=None):
+        nvarchars = nvarchars or {}
         if not isinstance(node, dict):
             return
         if node.get("type", "") != "string":


### PR DESCRIPTION
This PR cleans up the linting in RAD, so that ruff is used over other tools performing the same function.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
