### PR TITLE
move refs under allOfs where required

### DIFF
--- a/changes/525.bugfix.rst
+++ b/changes/525.bugfix.rst
@@ -1,0 +1,1 @@
+Move schema references under allOf combiners if the schema contains other items.

--- a/src/rad/resources/schemas/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.0.0.yaml
@@ -10,7 +10,8 @@ title: |
 type: object
 properties:
   type:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/exposure-1.0.0.yaml
@@ -10,7 +10,8 @@ title: |
 type: object
 properties:
   type:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure_type-1.0.0
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure_type-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
@@ -19,7 +19,8 @@ properties:
       datatype: nvarchar(20)
       destination: [WFICommon.gw_id]
   gw_fgs_mode:
-    $ref: guidewindow_modes-1.0.0
+    allOf:
+      - $ref: guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
@@ -21,10 +21,11 @@ properties:
       datatype: nvarchar(5)
       destination: [WFICommon.instrument_name]
   detector:
+    allOf:
+      - $ref: wfi_detector-1.0.0
     title: WFI Detector
     description: |
       WFI detector used to take the data.
-    $ref: wfi_detector-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -33,10 +34,11 @@ properties:
       datatype: nvarchar(10)
       destination: [WFICommon.detector]
   optical_element:
+    allOf:
+      - $ref: wfi_optical_element-1.0.0
     title: WFI Optical Element
     description: |
       WFI optical element used to take the data.
-    $ref: wfi_optical_element-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -26,7 +26,8 @@ properties:
       datatype: nvarchar(20)
       destination: [WFIExposure.guide_window_id, GuideWindow.guide_window_id, WFICommon.guide_window_id]
   guide_mode:
-    $ref: guidewindow_modes-1.0.0
+    allOf:
+      - $ref: guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -144,7 +144,8 @@ properties:
               datatype: nvarchar(120)
               destination: [GuideWindow.gw_science_file_source]
           gw_mode:
-            $ref: guidewindow_modes-1.0.0
+            allOf:
+              - $ref: guidewindow_modes-1.0.0
             sdf:
               special_processing: VALUE_REQUIRED
               source:

--- a/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
@@ -109,7 +109,8 @@ properties:
       datatype: nvarchar(15)
       destination: [WFIMosaic.survey, SourceCatalog.survey, SegmentationMap.survey]
   optical_element:
-    $ref: wfi_optical_element-1.0.0
+    allOf:
+      - $ref: wfi_optical_element-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -59,10 +59,11 @@ properties:
         type: string
         enum: [WFI]
       detector:
+        allOf:
+          - $ref: ../wfi_detector-1.0.0
         title: Detector
         description: |
           The numbered WFI detector in the focal plane (e.g., WFI01 for SCA 01).
-        $ref: ../wfi_detector-1.0.0
     required: [name, detector]
 required: [reftype, author, description, pedigree, useafter, telescope, origin, instrument]
 ...

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
@@ -11,12 +11,13 @@ properties:
     type: object
     properties:
       type:
+        allOf:
+          - $ref: ../exposure_type-1.0.0
         title: WFI Mode
         description: |
           The type of data taken with the WFI. Allowed values are WFI_IMAGE for
           imaging mode, WFI_GRISM and WFI_PRISM for spectral mode, WFI_DARK for
           dark exposures, WFI_FLAT for flat fields, and WFI_WFSC.
-        $ref: ../exposure_type-1.0.0
       p_exptype:
         title: WFI Mode for CRDS
         description: |

--- a/src/rad/resources/schemas/reference_files/ref_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_optical_element-1.0.0.yaml
@@ -11,9 +11,6 @@ properties:
     type: object
     properties:
       optical_element:
-        title: Optical Element
-        description: |
-          The optical element filter name.
         $ref: ../wfi_optical_element-1.0.0
     required: [optical_element]
 required: [instrument]

--- a/src/rad/resources/schemas/segmentation_map-1.0.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.0.0.yaml
@@ -16,9 +16,6 @@ properties:
       - type: object
         properties:
           optical_element:
-            title: WFI Optical Element
-            description: |
-              WFI optical element used to take the data.
             $ref: wfi_optical_element-1.0.0
           program:
             title: Program Information

--- a/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/exposure-1.0.0.yaml
@@ -10,7 +10,8 @@ title: |
 type: object
 properties:
   type:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure_type-1.0.0
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure_type-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
@@ -19,7 +19,8 @@ properties:
       datatype: nvarchar(20)
       destination: [WFICommon.gw_id]
   gw_fgs_mode:
-    $ref: guidewindow_modes-1.0.0
+    allOf:
+      - $ref: guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
@@ -21,10 +21,11 @@ properties:
       datatype: nvarchar(5)
       destination: [WFICommon.instrument_name]
   detector:
+    allOf:
+       - $ref: wfi_detector-1.0.0
     title: WFI Detector
     description: |
       WFI detector used to take the data.
-    $ref: wfi_detector-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -33,10 +34,11 @@ properties:
       datatype: nvarchar(10)
       destination: [WFICommon.detector]
   optical_element:
+    allOf:
+      - $ref: wfi_optical_element-1.0.0
     title: WFI Optical Element
     description: |
       WFI optical element used to take the data.
-    $ref: wfi_optical_element-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
@@ -23,11 +23,12 @@ properties:
       datatype: nvarchar(5)
       destination: [WFIExposure.instrument_name, GuideWindow.instrument_name, WFICommon.instrument_name]
   detector:
+    allOf:
+      - $ref: wfi_detector-1.0.0
     title: Wide Field Instrument (WFI) Detector Identifier
     description: |
       Name of the Wide Field Instrument (WFI) detector used
       to take the science data in this file.
-    $ref: wfi_detector-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:
@@ -37,11 +38,12 @@ properties:
       datatype: nvarchar(10)
       destination: [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
   optical_element:
+    allOf:
+      - $ref: wfi_optical_element-1.0.0
     title: Wide Field Instrument (WFI) Optical Element
     description: |
       Name of the optical element used to take the science
       data.
-    $ref: wfi_optical_element-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -297,16 +297,7 @@ def test_varchar_length(uri):
     asdf.treeutil.walk(schema, callback)
 
 
-# don't test tvac or fps schemas as they are static
-@pytest.mark.parametrize(
-    "uri",
-    [
-        uri
-        for uri in SCHEMA_URIS
-        if not uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/fps/")
-        and not uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/tvac/")
-    ],
-)
+@pytest.mark.parametrize("uri", SCHEMA_URIS)
 def test_ref_loneliness(uri):
     """
     An object with a $ref should contain no other items

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -295,3 +295,29 @@ def test_varchar_length(uri):
         assert node["maxLength"] == v, f"archive_catalog nvarchar does not match maxLength in schema {uri}"
 
     asdf.treeutil.walk(schema, callback)
+
+
+# don't test tvac or fps schemas as they are static
+@pytest.mark.parametrize(
+    "uri",
+    [
+        uri
+        for uri in SCHEMA_URIS
+        if not uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/fps/")
+        and not uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/tvac/")
+    ],
+)
+def test_ref_loneliness(uri):
+    """
+    An object with a $ref should contain no other items
+    """
+    schema = asdf.schema.load_schema(uri)
+
+    def callback(node):
+        if not isinstance(node, dict):
+            return
+        if "$ref" not in node:
+            return
+        assert len(node) == 1
+
+    asdf.treeutil.walk(schema, callback)


### PR DESCRIPTION
Including a `$ref` key in a schema mapping/object/dict comes with the requirement that other members of that mapping are ignored. See https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03#section-3

This PR updates the RAD schemas nesting `$ref`s in `allOf` combiners when the mapping contains other items and adds a test to verify the changes.

Romancal regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/12260132209

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
