### PR TITLE
Make all $ref absolute URI refs

### DIFF
--- a/changes/527.feature.rst
+++ b/changes/527.feature.rst
@@ -1,0 +1,1 @@
+Update all ``$ref`` so that they use absolute URIs rather than relative URIs.

--- a/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/guidestar-1.0.0.yaml
@@ -20,7 +20,7 @@ properties:
       destination: [WFICommon.gw_id]
   gw_fgs_mode:
     allOf:
-      - $ref: guidewindow_modes-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps/wfi_mode-1.0.0.yaml
@@ -22,7 +22,7 @@ properties:
       destination: [WFICommon.instrument_name]
   detector:
     allOf:
-      - $ref: wfi_detector-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_detector-1.0.0
     title: WFI Detector
     description: |
       WFI detector used to take the data.
@@ -35,7 +35,7 @@ properties:
       destination: [WFICommon.detector]
   optical_element:
     allOf:
-      - $ref: wfi_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_optical_element-1.0.0
     title: WFI Optical Element
     description: |
       WFI optical element used to take the data.

--- a/src/rad/resources/schemas/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.0.0.yaml
@@ -27,7 +27,7 @@ properties:
       destination: [WFIExposure.guide_window_id, GuideWindow.guide_window_id, WFICommon.guide_window_id]
   guide_mode:
     allOf:
-      - $ref: guidewindow_modes-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/guidewindow-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.0.0.yaml
@@ -13,7 +13,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
       - type: object
         properties:
           gw_start_time:
@@ -145,7 +145,7 @@ properties:
               destination: [GuideWindow.gw_science_file_source]
           gw_mode:
             allOf:
-              - $ref: guidewindow_modes-1.0.0
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
             sdf:
               special_processing: VALUE_REQUIRED
               source:

--- a/src/rad/resources/schemas/image_source_catalog-1.0.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.0.0.yaml
@@ -12,11 +12,11 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: basic-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
       - type: object
         properties:
           optical_element:
-            $ref: wfi_optical_element-1.0.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
           exposure:
             title: Exposure Information
             tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0

--- a/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
@@ -110,7 +110,7 @@ properties:
       destination: [WFIMosaic.survey, SourceCatalog.survey, SegmentationMap.survey]
   optical_element:
     allOf:
-      - $ref: wfi_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/mosaic_segmentation_map-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_segmentation_map-1.0.0.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: basic-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
       - type: object
         properties:
           basic:

--- a/src/rad/resources/schemas/mosaic_source_catalog-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-1.0.0.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: basic-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
       - type: object
         properties:
           basic:

--- a/src/rad/resources/schemas/msos_stack-1.0.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.0.0.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
       - image_list:
           type: string
   data:

--- a/src/rad/resources/schemas/ramp-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
       - type: object
         properties:
           cal_step:

--- a/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.0.0.yaml
@@ -10,7 +10,7 @@ datamodel_name: RampFitOutputModel
 type: object
 properties:
   meta:
-    $ref: common-1.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
   slope:
     title: Slope for Specific Segment (electrons / s)
     description: |

--- a/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:
@@ -50,8 +50,8 @@ properties:
                 type: integer
             required: [ngroups, nframes, groupgap, ma_table_name, ma_table_number]
         required: [exposure]
-      - $ref: ref_exposure_type-1.0.0
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
   data:
     title: Dark Current Array
     description: |

--- a/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:
@@ -30,7 +30,7 @@ properties:
             tag: tag:stsci.edu:asdf/unit/unit-1.*
             enum: ["arcsec"]
         required: [output_units, input_units]
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
   coordinate_distortion_transform:
     title: Distortion Transform Model
     description: |

--- a/src/rad/resources/schemas/reference_files/epsf-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/epsf-1.0.0.yaml
@@ -11,8 +11,8 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.0.0.yaml
@@ -11,13 +11,13 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:
             type: string
             enum: [FLAT]
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
   data:
     title: Flat Data Array
     description: |

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ipc-1.0.0.yaml
@@ -11,8 +11,8 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:
@@ -48,7 +48,7 @@ properties:
                   - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
         required: [photometry]
-      - $ref: ref_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
   data:
     title: Pixel Area Array
     description: |

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -11,12 +11,12 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:
             enum: [READNOISE]
-      - $ref: ref_exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
   data:
     title: Read Noise Data Array
     description: |

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -60,7 +60,7 @@ properties:
         enum: [WFI]
       detector:
         allOf:
-          - $ref: ../wfi_detector-1.0.0
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
         title: Detector
         description: |
           The numbered WFI detector in the focal plane (e.g., WFI01 for SCA 01).

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
@@ -12,7 +12,7 @@ properties:
     properties:
       type:
         allOf:
-          - $ref: ../exposure_type-1.0.0
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
         title: WFI Mode
         description: |
           The type of data taken with the WFI. Allowed values are WFI_IMAGE for

--- a/src/rad/resources/schemas/reference_files/ref_optical_element-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_optical_element-1.0.0.yaml
@@ -11,7 +11,7 @@ properties:
     type: object
     properties:
       optical_element:
-        $ref: ../wfi_optical_element-1.0.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
     required: [optical_element]
 required: [instrument]
 ...

--- a/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
@@ -13,7 +13,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.0.0.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
       - type: object
         properties:
           reftype:

--- a/src/rad/resources/schemas/segmentation_map-1.0.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.0.0.yaml
@@ -12,11 +12,11 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: basic-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
       - type: object
         properties:
           optical_element:
-            $ref: wfi_optical_element-1.0.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
           program:
             title: Program Information
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.0.0

--- a/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/guidestar-1.0.0.yaml
@@ -20,7 +20,7 @@ properties:
       destination: [WFICommon.gw_id]
   gw_fgs_mode:
     allOf:
-      - $ref: guidewindow_modes-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidewindow_modes-1.0.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/tvac/wfi_mode-1.0.0.yaml
@@ -22,7 +22,7 @@ properties:
       destination: [WFICommon.instrument_name]
   detector:
     allOf:
-       - $ref: wfi_detector-1.0.0
+       - $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_detector-1.0.0
     title: WFI Detector
     description: |
       WFI detector used to take the data.
@@ -35,7 +35,7 @@ properties:
       destination: [WFICommon.detector]
   optical_element:
     allOf:
-      - $ref: wfi_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_optical_element-1.0.0
     title: WFI Optical Element
     description: |
       WFI optical element used to take the data.

--- a/src/rad/resources/schemas/wfi_image-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.0.0.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
       - type: object
         properties:
           background:

--- a/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mode-1.0.0.yaml
@@ -24,7 +24,7 @@ properties:
       destination: [WFIExposure.instrument_name, GuideWindow.instrument_name, WFICommon.instrument_name]
   detector:
     allOf:
-      - $ref: wfi_detector-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
     title: Wide Field Instrument (WFI) Detector Identifier
     description: |
       Name of the Wide Field Instrument (WFI) detector used
@@ -39,7 +39,7 @@ properties:
       destination: [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
   optical_element:
     allOf:
-      - $ref: wfi_optical_element-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
     title: Wide Field Instrument (WFI) Optical Element
     description: |
       Name of the optical element used to take the science

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -13,7 +13,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: basic-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
       - type: object
         properties:
           # Placeholder for 'dither' schema tag

--- a/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.0.0.yaml
@@ -14,7 +14,7 @@ archive_meta: None
 type: object
 properties:
   meta:
-    $ref: common-1.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.0.0
   data:
     title: Science Data (DN)
     description: |

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Mapping
 
 import asdf
+import asdf.treeutil
 import pytest
 import yaml
 from crds.config import is_crds_name
@@ -310,5 +311,25 @@ def test_ref_loneliness(uri):
         if "$ref" not in node:
             return
         assert len(node) == 1
+
+    asdf.treeutil.walk(schema, callback)
+
+
+@pytest.mark.parametrize("uri", SCHEMA_URIS)
+def test_absolute_ref(uri):
+    """
+    Test that all $ref are absolute URIs matching those registered with ASDF
+    """
+    schema = asdf.schema.load_schema(uri)
+    resources = asdf.config.get_config().resource_manager
+
+    def callback(node):
+        if not isinstance(node, dict):
+            return
+        if "$ref" not in node:
+            return
+
+        # Check that the $ref is a full URI registered with ASDF
+        assert node["$ref"] in resources
 
     asdf.treeutil.walk(schema, callback)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR makes all `$ref` uris absolute URIs (the `id` registered for a given schema in ASDF) rather than relative URIs. Additionally it adds tests which enforce this convention.

This is useful for two reasons:

1. It makes all the URI usage (both `tag` and `$ref`) follow a consistent pattern.
2. Makes processing of `$ref` values outside of the directory structure of `rad` or ASDF easier as it is much easier to look up based on the `id` URI rather than figuring out a `$ref` based on context.

Note this breaks one test in `roman_datamodels`, which for some reason is testing RAD schema contents rather than datamodels (it checks `ref_common` is included in all reference file schemas).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
