### PR TITLE
Bugfix the oldestdeps job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ file = "LICENSE"
 test = [
     "pytest>=7.0.0",
     "pytest-doctestplus>=1.2.1",
-    "crds>=11.16.16",
+    "crds>=12.0.4",
 ]
 docs = [
     "sphinx",

--- a/tox.ini
+++ b/tox.ini
@@ -41,10 +41,11 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     roman_datamodels: roman_datamodels[test] @ git+{[main]roman_datamodels_repo}
+    oldestdeps: minimum_dependencies
 change_dir =
     roman_datamodels: {env_tmp_dir}
 commands_pre =
-    oldestdeps: minimum_dependencies
+    oldestdeps: minimum_dependencies rad --filename {env_tmp_dir}/requirements-min.txt
     oldestdeps: uv pip install -r {env_tmp_dir}/requirements-min.txt
     {list_dependencies_command}
     roman_datamodels: git clone -n --depth=1 --filter=blob:none {[main]roman_datamodels_repo}


### PR DESCRIPTION
The tox for `oldestdeps` test was broken. This PR fixes that.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
