### PR TITLE
reorder anyOf in apcorr schema to work around asdf bug

### DIFF
--- a/changes/542.bugfix.rst
+++ b/changes/542.bugfix.rst
@@ -1,0 +1,1 @@
+Reorder anyOf items in apcorr schema to work around asdf bug.

--- a/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
@@ -28,32 +28,32 @@ properties:
             description: The aperture correction for each enclosed energy
                 fraction, corresponding to 1 / ee_fractions.
             anyOf:
+              - type: "null"
               - tag: tag:stsci.edu:asdf/core/ndarray-1.*
                 datatype: float64
                 exact_datatype: true
                 ndim: 1
-              - type: "null"
           ee_fractions:
             title: Enclosed Energy Fractions
             description: Fractions of the enclosed energy of the PSF at which
                 to estimate the aperture correction and enclosed energy radii.
             anyOf:
+              - type: "null"
               - tag: tag:stsci.edu:asdf/core/ndarray-1.*
                 datatype: float64
                 exact_datatype: true
                 ndim: 1
-              - type: "null"
           ee_radii:
             title: Enclosed Energy Radii
             description: Radius, in pixels, within which the enclosed energy
                 fractions are met. The indexing matches that of
                   "ee_fractions".
             anyOf:
+              - type: "null"
               - tag: tag:stsci.edu:asdf/core/ndarray-1.*
                 datatype: float64
                 exact_datatype: true
                 ndim: 1
-              - type: "null"
           sky_background_rin:
             title: Inner Radius for the Sky Background
             description: Inner radius, in pixels, to use when estimating the


### PR DESCRIPTION
The asdf datatype validator raises an exception instead of yielding leading to incorrect validation failure for the `anyOf` schema combiner in the apcorr ref file schema (xref: https://github.com/asdf-format/asdf/issues/1903).

This PR works around the issue (until an asdf fix can be made and released) by reordering the `anyOf` to check for `None` first (when this succeeds the remainder of the `anyOf` will not be evaluated avoiding the asdf bug).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
