### PR TITLE
add romancal downstream testing to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,9 @@ jobs:
     with:
       envs: |
         - linux: roman_datamodels-xdist
+
+  romancal:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
+    with:
+      envs: |
+        - linux: romancal-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ requires =
 
 [main]
 roman_datamodels_repo = https://github.com/spacetelescope/roman_datamodels.git
+romancal_repo = https://github.com/spacetelescope/romancal.git
 
 [testenv:check-style]
 description = Run all style and file checks with pre-commit
@@ -27,9 +28,14 @@ description =
     oldestdeps: Run with oldest direct dependencies
 allowlist_externals =
     roman_datamodels: git
+    romancal: git
 set_env =
     devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     devdeps: UV_INDEX_STRATEGY = unsafe-any-match
+    romancal: CRDS_SERVER_URL = https://roman-crds.stsci.edu
+    romancal: CRDS_PATH = /tmp/crds_cache
+    romancal: CRDS_CLIENT_RETRY_COUNT = 3
+    romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS = 20
 extras =
     test
 uv_resolution =
@@ -41,9 +47,11 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     roman_datamodels: roman_datamodels[test] @ git+{[main]roman_datamodels_repo}
+    romancal: romancal[test] @ git+{[main]romancal_repo}
     oldestdeps: minimum_dependencies
 change_dir =
     roman_datamodels: {env_tmp_dir}
+    romancal: {env_tmp_dir}
 commands_pre =
     oldestdeps: minimum_dependencies rad --filename {env_tmp_dir}/requirements-min.txt
     oldestdeps: uv pip install -r {env_tmp_dir}/requirements-min.txt
@@ -51,9 +59,11 @@ commands_pre =
     roman_datamodels: git clone -n --depth=1 --filter=blob:none {[main]roman_datamodels_repo}
     roman_datamodels: git --git-dir={env_tmp_dir}/roman_datamodels/.git checkout HEAD pyproject.toml
     roman_datamodels: git --git-dir={env_tmp_dir}/roman_datamodels/.git checkout HEAD tests/*
+    romancal: git clone --depth=1 {[main]romancal_repo}
 commands =
     pytest \
     roman_datamodels: --config-file={env_tmp_dir}/pyproject.toml tests \
+    romancal: --config-file=romancal/pyproject.toml romancal \
     xdist: -n auto \
     cov: --cov --cov-report=term-missing --cov-report=xml \
     {posargs}


### PR DESCRIPTION
Add romancal unit tests to the CI (similar to the roman_datamodels tests).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
