### PR TITLE
TST: sphinx_asdf pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
 ]
 docs = [
     "sphinx",
-    "sphinx-asdf>=0.1.3",
+    "sphinx-asdf @ git+https://github.com/braingram/sphinx-asdf@sphinx9",
     "sphinx-astropy",
     "sphinx-rtd-theme",
     "astropy>=5.0.4",


### PR DESCRIPTION
This is to test https://github.com/asdf-format/sphinx-asdf/pull/101 which addresses a few warnings that are seen in the docs builds due to upstream issues.

It is a test PR that will be closed when the upstream PR is resolved.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
