### PR TITLE
RAD-206: Define new schema WfiWcs

### DIFF
--- a/changes/564.feature.rst
+++ b/changes/564.feature.rst
@@ -1,0 +1,1 @@
+Define new schema WfiWcs.

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -20,6 +20,7 @@ Level 2 (calibrated exposure) schema
 .. asdf-autoschemas::
 
    wfi_image-1.0.0
+   wfi_wcs-1.0.0
 
 Level 3 (resampled mosaic) schema
 ---------------------------------

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -44,6 +44,12 @@ tags:
   title: Roman WFI Instrument Mode
   description: |-
     Roman WFI Instrument
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+  title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+  description: |-
+    Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and |-
+    modified WCS applicable for Science Raw (L1).
 # Metadata Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0

--- a/src/rad/resources/manifests/datamodels-1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.0.yaml
@@ -44,12 +44,6 @@ tags:
   title: Roman WFI Instrument Mode
   description: |-
     Roman WFI Instrument
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
-  title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
-  description: |-
-    Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and |-
-    modified WCS applicable for Science Raw (L1).
 # Metadata Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0

--- a/src/rad/resources/manifests/datamodels-1.1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.1.0.yaml
@@ -44,6 +44,12 @@ tags:
   title: Roman WFI Instrument Mode
   description: |-
     Roman WFI Instrument
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.0.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+  title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+  description: |-
+    Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and |-
+    modified WCS applicable for Science Raw (L1).
 # Metadata Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.0.0

--- a/src/rad/resources/manifests/datamodels-1.1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.1.0.yaml
@@ -48,7 +48,7 @@ tags:
   schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
   title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
   description: |-
-    Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and |-
+    Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
     modified WCS applicable for Science Raw (L1).
 # Metadata Modules
 - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -3,7 +3,7 @@
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
 id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
 
-title: Level 2 (L2) WCS information for  Roman Wide Field Instrument (WFI) Rate Image.
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
 datamodel_name: WfiWcsModel
 archive_meta: None

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -55,10 +55,18 @@ properties:
             If missing or None, GAIA alignment was not done or failed.
           type: object
   wcs_l2:
-    title: L2 WCS Object
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
     tag: tag:stsci.edu:gwcs/wcs-*
   wcs_l1:
-    title: L1 WCS Object
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
     tag: tag:stsci.edu:gwcs/wcs-*
 propertyOrder: [meta, wcs_l2, wcs_l1]
 flowStyle: block

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -45,16 +45,15 @@ properties:
           wcsinfo:
             title: World Coordinate System (WCS) Parameters
             tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.0.0
-        required: [coordinates, ephemeris, exposure,
-                   instrument, observation, pointing, program,
-                   velocity_aberration, visit, wcsinfo]
-      - properties:
           wcs_fit_results:
             title: tweakreg/GAIA fit results
             description: |
               Results from the tweakreg result when aligning to GAIA.
               If missing or None, GAIA alignment was not done or failed.
             type: object
+        required: [coordinates, ephemeris, exposure,
+                   instrument, observation, pointing, program,
+                   velocity_aberration, visit, wcsinfo]
   wcs_l2:
     title: L2 GWCS
     description: |

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+
+title: Level 2 (L2) WCS information for  Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          coordinates:
+            title: Name Of The Coordinate Reference Frame
+            tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+          ephemeris:
+            title: Ephemeris Data Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.0.0
+          exposure:
+            title: Exposure Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.0.0
+          instrument:
+            title: WFI Observing Configuration
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
+          observation:
+            title: Observation Identifiers
+            tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+          pointing:
+            title: Spacecraft Pointing Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.0.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.0.0
+          velocity_aberration:
+            title: Velocity Aberration Correction Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+          visit:
+            title: Visit Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.0.0
+          wcsinfo:
+            title: World Coordinate System (WCS) Parameters
+            tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.0.0
+        required: [coordinates, ephemeris, exposure,
+                   instrument, observation, pointing, program,
+                   velocity_aberration, visit, wcsinfo]
+  wcs_l2:
+    title: L2 WCS Object
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 WCS Object
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta, wcs_l2, wcs_l1]
+...

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -48,6 +48,12 @@ properties:
         required: [coordinates, ephemeris, exposure,
                    instrument, observation, pointing, program,
                    velocity_aberration, visit, wcsinfo]
+      - wcs_fit_results:
+          title: tweakreg/GAIA fit results
+          description: |
+            Results from the tweakreg result when aligning to GAIA.
+            If missing or None, GAIA alignment was not done or failed.
+          type: object
   wcs_l2:
     title: L2 WCS Object
     tag: tag:stsci.edu:gwcs/wcs-*

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -48,12 +48,13 @@ properties:
         required: [coordinates, ephemeris, exposure,
                    instrument, observation, pointing, program,
                    velocity_aberration, visit, wcsinfo]
-      - wcs_fit_results:
-          title: tweakreg/GAIA fit results
-          description: |
-            Results from the tweakreg result when aligning to GAIA.
-            If missing or None, GAIA alignment was not done or failed.
-          type: object
+      - properties:
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
   wcs_l2:
     title: L2 GWCS
     description: |

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -71,5 +71,5 @@ properties:
     tag: tag:stsci.edu:gwcs/wcs-*
 propertyOrder: [meta, wcs_l2, wcs_l1]
 flowStyle: block
-required: [meta, wcs_l2, wcs_l1]
+required: [meta]
 ...

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -196,7 +196,7 @@ def _model_name_from_schema_uri(schema_uri):
     if schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/reference_files/"):
         class_name += "Ref"
 
-    if class_name not in ['WfiWcs']:  # Names to be unmodified
+    if class_name not in ["WfiWcs"]:  # Names to be unmodified
         if class_name.startswith("Wfi") and "Ref" not in class_name:
             class_name = class_name.split("Wfi")[-1]
         elif class_name.startswith("MatableRef"):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -196,10 +196,11 @@ def _model_name_from_schema_uri(schema_uri):
     if schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/reference_files/"):
         class_name += "Ref"
 
-    if class_name.startswith("Wfi") and "Ref" not in class_name:
-        class_name = class_name.split("Wfi")[-1]
-    elif class_name.startswith("MatableRef"):
-        class_name = "MATableRef" + class_name.split("MatableRef")[-1]
+    if class_name not in ['WfiWcs']:  # Names to be unmodified
+        if class_name.startswith("Wfi") and "Ref" not in class_name:
+            class_name = class_name.split("Wfi")[-1]
+        elif class_name.startswith("MatableRef"):
+            class_name = "MATableRef" + class_name.split("MatableRef")[-1]
 
     return f"{class_name}Model"
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->
Resolves [RAD-206](https://jira.stsci.edu/browse/RAD-206)
WIP [RCAL-1025](https://jira.stsci.edu/browse/RCAL-1025)

<!-- describe the changes comprising this PR here -->
This PR creates the new schema `WfiWcs`. This schema defines the new ELP product output as defined in RCAL-1025. This schema represents the WCS determined for each L2 output from ELP. If the `tweakreg` step is executed successfully, this WCS represents the GAIA-aligned solution. The intent of this file is to document this calculated WCS and, if desired, be applied back to the L1 product.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] Update or add relevant `rad` tests.
- [x] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [x] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [x] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
