### PR TITLE
update versioning docs

### DIFF
--- a/changes/572.doc.rst
+++ b/changes/572.doc.rst
@@ -1,0 +1,1 @@
+Update versioning docs to describe non-ASDF schema changes will not result in new schema versions.

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -14,6 +14,21 @@ mostly follow that of other ASDF extensions where:
 This allows files created with the old tag to be validated (against
 the old schema) and opened.
 
+Non-versioned changes
+=====================
+
+The RAD schemas contain archive database destination and other
+non-ASDF information including schema keywords:
+
+- archive_catalog
+- origin
+- sdf
+
+Changes to content stored under these keys will not be trigger a new
+schema version. Please consult the newest schema version for the most
+accurate values for these keywords.
+
+
 Manifest Versioning
 ===================
 


### PR DESCRIPTION
Update versioning docs to reflect the 16 Jan 2025 RAD meeting where it was discussed that:
> Versioning only required for changes that affect the datamodel based on the schema. Accordingly, database, RSDP, other archive_catalog field changes, etc. will not require new versions.

Link to updated docs: https://rad--572.org.readthedocs.build/en/572/versioning.html#non-versioned-changes

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
