### PR TITLE
RCAL-968: add var_sky to mosaic schema.

### DIFF
--- a/changes/573.feature.rst
+++ b/changes/573.feature.rst
@@ -1,0 +1,1 @@
+Add var_sky to WFI mosaic schema.

--- a/latest/wfi_mosaic.yaml
+++ b/latest/wfi_mosaic.yaml
@@ -94,6 +94,13 @@ properties:
     exact_datatype: true
     ndim: 2
     unit: "MJy**2.sr**-2"
+  var_sky:
+    title: Sky Variance (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
   cal_logs:
     tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
 propertyOrder:
@@ -106,6 +113,7 @@ propertyOrder:
     var_poisson,
     var_rnoise,
     var_flat,
+    var_sky,
     cal_logs,
   ]
 flowStyle: block


### PR DESCRIPTION
Resolves [RAD-968](https://jira.stsci.edu/browse/RAD-968)

This PR adds a new attribute, `var_sky`, to the mosaic schema.

## Note
This PR supports changes in romancal's [PR#1691](https://github.com/spacetelescope/romancal/pull/1691).

## Regression test
All the regression tests are passing:
- https://github.com/spacetelescope/RegressionTests/actions/runs/14365098776

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
