### PR TITLE
Remove SegmentationMap.engineering_quality/ma_table_id

### DIFF
--- a/changes/600.feature.rst
+++ b/changes/600.feature.rst
@@ -1,0 +1,2 @@
+Remove the ``SegmentationMap.engineering_quality`` and ``SegmentationMap.ma_table_id`` values
+from the ``archive_catalog.destination`` keyword.

--- a/latest/exposure.yaml
+++ b/latest/exposure.yaml
@@ -76,7 +76,7 @@ properties:
     archive_catalog:
       datatype: nvarchar(10)
       destination: [WFIExposure.engineering_quality, GuideWindow.engineering_quality,
-                    SourceCatalog.engineering_quality, SegmentationMap.engineering_quality]
+                    SourceCatalog.engineering_quality]
   ma_table_id:
     title: Multi-Accumulation Table Identifier
     description: |
@@ -92,7 +92,7 @@ properties:
     archive_catalog:
       datatype: nvarchar(10)
       destination: [WFIExposure.ma_table_id, GuideWindow.ma_table_id,
-                    SourceCatalog.ma_table_id, SegmentationMap.ma_table_id]
+                    SourceCatalog.ma_table_id]
   nresultants:
     title: Number of Resultants
     description: |


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #595

<!-- describe the changes comprising this PR here -->
This PR removes the `SegmentationMap.engineering_quality` and `SegmentationMap.ma_table_id` keywords from the `archive_catalog.destination` item.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
