### PR TITLE
Bump the asdf version to 4.1.0 to fix schema_info issue

### DIFF
--- a/changes/603.feature.rst
+++ b/changes/603.feature.rst
@@ -1,0 +1,1 @@
+Bump ASDF to ``>=4.1.0`` to ensure that the ``schema_info`` issue is fixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf >=2.15.2",
+    "asdf >=4.1.0",
     "asdf-astropy >=0.5.0",
 ]
 license-files = ["LICENSE"]


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #405

<!-- describe the changes comprising this PR here -->
The fixes for #405 have been in place with an ASDF release (4.1.0) for awhile. This PR bumps the min ASDF to that version to ensure that the `schema_info` issue is fixed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
