### PR TITLE
Add new exposure_types

### DIFF
--- a/changes/605.feature.rst
+++ b/changes/605.feature.rst
@@ -1,0 +1,1 @@
+Add new ``exposure_types`` to the ``exposure_type`` schema.

--- a/latest/common.yaml
+++ b/latest/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
 
 title: Common metadata properties
 
@@ -19,7 +19,7 @@ allOf:
       tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
     exposure:
       title: Exposure Information
-      tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+      tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
     guide_star:
       title: Guide Star Window Information
       tag: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0

--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -19,28 +19,28 @@ tags:
   title: Level 1 Detector Guide Star Window Information schema
   description: |-
     Level 1 Detector Guide Star Window Information schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
   title: Guide window schema
   description: |-
     Guide window schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.2.0
   title: Ramp schema
   description: |-
     Ramp schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
   title: Ramp fit output schema
   description: |-
     Ramp fit output schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
   title: Roman WFI Raw Science Data datamodel
   description: |-
     Basic Roman Raw Science
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.2.0
   title: Wfi level 2 image information
   description: |-
     Wfi level 2 image information
@@ -54,15 +54,15 @@ tags:
   title: Roman WFI Instrument Mode
   description: |-
     Roman WFI Instrument
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.1.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
   title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
   description: |-
     Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
     modified WCS applicable for Science Raw (L1).
 # Metadata Modules
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
   title: Exposure information
   description: |-
     Exposure information
@@ -187,8 +187,8 @@ tags:
   title: Aperture correction reference schema
   description: |-
     Aperture correction reference schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.1.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
   title: Dark reference schema
   description: |-
     Dark reference schema
@@ -237,8 +237,8 @@ tags:
   title: Pixel area reference schema
   description: |-
     Pixel area reference schema
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.0.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.1.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
   title: Read noise reference schema
   description: |-
     Read noise reference schema
@@ -288,8 +288,8 @@ tags:
   title: Calibration reference file names.
   description: |-
     Calibration reference file names.
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.2.0
   title: Image source catalog
   description: |-
     Photometry and astrometry computed by the Source Catalog Step
@@ -534,8 +534,8 @@ tags:
   description: |-
     TVAC Telescope used to acquire the data
 # SSC data models
-- tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.1.0
-  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.1.0
+- tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.2.0
+  schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
   title: MSOS Stack Level 3 Schema
   description: |-
     Level 3 schema for SSC's MSOS stack products

--- a/latest/exposure.yaml
+++ b/latest/exposure.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
 
 
 title: |
@@ -11,7 +11,7 @@ type: object
 properties:
   type:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/exposure_type.yaml
+++ b/latest/exposure_type.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
 
 # Helper file to enumerate viewing modes for exposure and ref_exposure
 title: Exposure Type

--- a/latest/exposure_type.yaml
+++ b/latest/exposure_type.yaml
@@ -16,9 +16,14 @@ description: |
 type: string
 enum:
   - WFI_IMAGE
+  - WFI_SPECTROSCOPY
+  - WFI_IM_DARK
+  - WFI_SP_DARK
+  - WFI_FLAT
+  - WFI_LOLO
+  - WFI_WFSC
+  # These are slated for removal in the future
+  - WFI_DARK
   - WFI_GRISM
   - WFI_PRISM
-  - WFI_DARK
-  - WFI_FLAT
-  - WFI_WFSC
 ...

--- a/latest/guidewindow.yaml
+++ b/latest/guidewindow.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
 
 title: Guide Star Window Information
 
@@ -13,7 +13,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
       - type: object
         properties:
           gw_start_time:

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.2.0
 
 title: Source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -19,7 +19,7 @@ properties:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
           exposure:
             title: Exposure Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
       - type: object
         properties:
           image_list:

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.2.0
 
 title: Ramp Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
       - type: object
         properties:
           cal_step:

--- a/latest/ramp_fit_output.yaml
+++ b/latest/ramp_fit_output.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
 
 title: Ramp Fit Output Schema
 
@@ -10,7 +10,7 @@ datamodel_name: RampFitOutputModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
   slope:
     title: Slope for Specific Segment (electrons / s)
     description: |

--- a/latest/reference_files/dark.yaml
+++ b/latest/reference_files/dark.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
 
 title: Dark Reference File Schema
 
@@ -35,7 +35,7 @@ properties:
                 type: integer
             required: [ma_table_name, ma_table_number]
         required: [exposure]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
   data:
     title: Dark Current Array

--- a/latest/reference_files/readnoise.yaml
+++ b/latest/reference_files/readnoise.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
 
 title: Read Noise Reference File Schema
 
@@ -16,7 +16,7 @@ properties:
         properties:
           reftype:
             enum: [READNOISE]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
   data:
     title: Read Noise Data Array
     description: |

--- a/latest/reference_files/ref_exposure_type.yaml
+++ b/latest/reference_files/ref_exposure_type.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
 
 title: Exposure Type Reference Schema
 
@@ -12,7 +12,7 @@ properties:
     properties:
       type:
         allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
         title: WFI Mode
         description: |
           The type of data taken with the WFI. Allowed values are WFI_IMAGE for

--- a/latest/reference_files/ref_exposure_type.yaml
+++ b/latest/reference_files/ref_exposure_type.yaml
@@ -24,7 +24,7 @@ properties:
           The potentially multiple mode strings applied to data for reference
           file matching in CRDS. Modes are separated by "|".
         type: string
-        pattern: "^((WFI_IMAGE|WFI_GRISM|WFI_PRISM|WFI_DARK|WFI_FLAT|WFI_WFSC)\\s*\\|\\s*)+$"
+        pattern: "^((WFI_IMAGE|WFI_SPECTROSCOPY|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC|WFI_DARK|WFI_GRISM|WFI_PRISM)\\s*\\|\\s*)+$"
     required: [type,p_exptype]
 required: [exposure]
 ...

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.2.0
 
 title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
       - type: object
         properties:
           background:

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: None
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
   data:
     title: Science Data (DN)
     description: |

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
 
 title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -23,7 +23,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
           exposure:
             title: Exposure Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
           instrument:
             title: WFI Observing Configuration
             tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0

--- a/src/rad/resources/schemas/common-1.1.0.yaml
+++ b/src/rad/resources/schemas/common-1.1.0.yaml
@@ -1,1 +1,56 @@
-../../../../latest/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+
+title: Common metadata properties
+
+allOf:
+# Meta Variables
+- $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+- type: object
+  properties:
+    # Meta Objects
+    coordinates:
+      title: Name Of The Coordinate Reference Frame
+      tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+    ephemeris:
+      title: Ephemeris Data Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+    exposure:
+      title: Exposure Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+    guide_star:
+      title: Guide Star Window Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0
+    instrument:
+      title: WFI Observing Configuration
+      tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
+    observation:
+      title: Observation Identifiers
+      tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+    pointing:
+      title: Spacecraft Pointing Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+    program:
+      title: Program Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+    ref_file:
+      title: Reference File Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+    rcs:
+      title: Relative Calibration System Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/rcs-1.0.0
+    velocity_aberration:
+      title: Velocity Aberration Correction Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+    visit:
+      title: Visit Information
+      tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+    wcsinfo:
+      title: World Coordinate System (WCS) Parameters
+      tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+  required: [coordinates, ephemeris, exposure, guide_star,
+             instrument, observation, pointing, program, ref_file,
+             rcs, velocity_aberration, visit, wcsinfo]
+...

--- a/src/rad/resources/schemas/common-1.2.0.yaml
+++ b/src/rad/resources/schemas/common-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/common.yaml

--- a/src/rad/resources/schemas/exposure-1.1.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.1.0.yaml
@@ -1,1 +1,246 @@
-../../../../latest/exposure.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.1.0
+
+
+title: |
+  Exposure Information
+
+type: object
+properties:
+  type:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.template
+    maxLength: 25
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination: [WFIExposure.exposure_type, GuideWindow.exposure_type, WFICommon.exposure_type]
+  start_time:
+    title: Exposure Start Time (UTC)
+    description: |
+      The UTC time at the beginning of the exposure. The
+      time is serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_start_time, GuideWindow.exposure_start_time, WFICommon.exposure_start_time]
+  end_time:
+    title: Exposure End Time (UTC)
+    description: |
+      The UTC time at the end of the exposure. The time is
+      serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination: [WFIExposure.exposure_end_time, GuideWindow.exposure_end_time,
+                    SourceCatalog.exposure_end_time]
+  engineering_quality:
+    title: Engineering Data Quality
+    description: |
+      Indicator of data quality problems with the
+      engineering data used to populated select metadata fields. A
+      value of "OK" indicates no suspected problems, while a value of
+      "SUSPECT" indicates one or more metadata values populated from
+      the engineering database may be missing information during the
+      exposure or are otherwise of lower quality.
+    type: string
+    enum: [OK, SUSPECT]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.engineering_quality, GuideWindow.engineering_quality,
+                    SourceCatalog.engineering_quality, SegmentationMap.engineering_quality]
+  ma_table_id:
+    title: Multi-Accumulation Table Identifier
+    description: |
+      A unique identifier for the multi-accumulation (MA) table used for this exposure.
+      The identifier comes from the Science Operations Center (SOC) Project Reference
+      Database (PRD).
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.ma_table_id, GuideWindow.ma_table_id,
+                    SourceCatalog.ma_table_id, SegmentationMap.ma_table_id]
+  nresultants:
+    title: Number of Resultants
+    description: |
+      The number of resultant frames in this exposure that
+      were transmitted to the ground.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_resultant
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.exposure_nresultants, GuideWindow.exposure_nresultants, WFICommon.exposure_nresultants]
+  data_problem:
+    title: Data Problem
+    description: |
+      String error codes indicating that a problem occurred with the exposure.
+      A value of None indicates there were no problems with the exposure.
+      See the Roman Documentation System (RDox) for more information on the meaning of the error codes.
+    anyOf:
+      - type: string
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(max)
+      destination: [WFIExposure.exposure_data_problem, GuideWindow.exposure_data_problem, WFICommon.exposure_data_problem]
+  frame_time:
+    title: Detector Readout Time (s)
+    description: |
+      The readout time in seconds of the Wide Field
+      Instrument (WFI) detectors. This represents the time between the
+      start and end of the readout.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_frame_time, GuideWindow.exposure_frame_time, WFICommon.exposure_frame_time]
+  exposure_time:
+    title: Exposure Time (s)
+    description: |
+      The difference in time (in units of seconds) between
+      the start of the first reset/read and end of the last read in
+      the readout pattern.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.exposure_time, GuideWindow.exposure_time, WFICommon.exposure_time]
+  effective_exposure_time:
+    title: Effective Exposure Time (s)
+    description: |
+      The difference in time (in units of seconds) between
+      the midpoints of the first and last science resultants. If
+      either resultant contains only a single read, then the time at
+      the end of the read is used rather than the midpoint time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.effective_exposure_time, GuideWindow.effective_exposure_time,
+                    SourceCatalog.effective_exposure_time]
+  ma_table_name:
+    title: Name of the Multi-Accumulation Table
+    description: |
+      The name of the multi-accumulation (MA) table used for
+      the exposure. The MA table is also referred to as the readout
+      pattern.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_table_name
+    maxLength: 50
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination: [WFIExposure.ma_table_name, GuideWindow.ma_table_name, WFICommon.ma_table_name]
+  ma_table_number:
+    title: Multi-Accumulation Table Identification Number
+    description: |
+      A unique identification number for the
+      multi-accumulation (MA) table used for this exposure. The number
+      comes from the Science Operations Center (SOC) Project Reference
+      Database (PRD).
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_table_number
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.ma_table_number, GuideWindow.ma_table_number, WFICommon.ma_table_number]
+  read_pattern:
+    title: Read Pattern
+    description: |
+      The enumeration of detector reads to resultants making
+      up the Level 1 ramp data cube. The read pattern is nested such
+      that each grouping of read numbers represents a resultant. For
+      example, a readout pattern of [[1], [2, 3], [4]] consists of
+      four reads that were downlinked as three resultants with both
+      the first and last resultant each containing a single read.
+    type: array
+    items:
+      type: array
+      items:
+        type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(3500)
+      destination: [WFIExposure.read_pattern, GuideWindow.read_pattern, WFICommon.read_pattern]
+  truncated:
+    title: Truncated MA Table
+    description: |
+      A flag indicating whether the MA table was truncated.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.exposure_truncated,
+                    SourceCatalog.exposure_truncated]
+  sdf_log_file:
+    title: SDF Log File Name
+    description: |
+      File name of the Science Data Formatting (SDF) log for this exposure.
+    type: string
+    maxLength: 120
+required: [type, start_time, end_time, engineering_quality, nresultants, data_problem,
+  frame_time, exposure_time, effective_exposure_time, ma_table_name, ma_table_number, ma_table_id,
+  read_pattern, truncated]
+propertyOrder: [type, start_time, end_time, engineering_quality, nresultants, data_problem,
+  frame_time, exposure_time, effective_exposure_time, ma_table_name, ma_table_number, ma_table_id,
+  read_pattern, truncated, sdf_log_file]
+flowStyle: block
+...

--- a/src/rad/resources/schemas/exposure-1.2.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/exposure.yaml

--- a/src/rad/resources/schemas/exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/exposure_type-1.0.0.yaml
@@ -1,1 +1,24 @@
-../../../../latest/exposure_type.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+
+# Helper file to enumerate viewing modes for exposure and ref_exposure
+title: Exposure Type
+description: |
+  The type of the exposure. Wide Field Instrument (WFI)
+  imaging mode observations have type WFI_IMAGE, while the
+  spectroscopic mode may be either WFI_GRISM or WFI_PRISM
+  depending on the selected optical element. Other values are
+  related to either internal calibration or engineering
+  observations.
+
+type: string
+enum:
+  - WFI_IMAGE
+  - WFI_GRISM
+  - WFI_PRISM
+  - WFI_DARK
+  - WFI_FLAT
+  - WFI_WFSC
+...

--- a/src/rad/resources/schemas/exposure_type-1.1.0.yaml
+++ b/src/rad/resources/schemas/exposure_type-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/exposure_type.yaml

--- a/src/rad/resources/schemas/guidewindow-1.1.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.1.0.yaml
@@ -1,1 +1,278 @@
-../../../../latest/guidewindow.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.1.0
+
+title: Guide Star Window Information
+
+datamodel_name: GuidewindowModel
+
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - type: object
+        properties:
+          gw_start_time:
+            title: Start Time of Guide Window Exposure (UTC)
+            description: |
+              Time in UTC at the start of the guide window exposure.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_start_time]
+          gw_end_time:
+            title: End Time of Guide Window Exposure (UTC)
+            description: |
+              Time in UTC at the end of the guide window exposure.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_end_time]
+          gw_frame_readout_time:
+            title: Guide Window Read Time (Seconds)
+            description: |
+              Time to read out the guide window frame in units of seconds.
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_frame_readout_time]
+          gw_function_start_time:
+            title: Guide Window Function Start Time (UTC)
+            description: |
+              Time in UTC at the start of the guider function.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_function_start_time]
+          gw_function_end_time:
+            title: Guide Window Function End Time (UTC)
+            description: |
+              Time in UTC at the end of the guider function.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_function_end_time]
+          gw_acq_exec_stat:
+            title: Guide Star Acquisition Status
+            description: |
+              Status of the guide star acquisition.
+            type: string
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 15
+            archive_catalog:
+              datatype: nvarchar(15)
+              destination: [GuideWindow.gw_acq_exec_stat]
+          pedestal_resultant_exp_time:
+            title: Guide Window Pedestal Exposure Time (Seconds)
+            description: |
+              Cumulative exposure time for all of the guide window pedestal
+              resultants in units of seconds.
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_pedestal_resultant_exp_time]
+          signal_resultant_exp_time:
+            title: Guide Window Signal Exposure Time (Seconds)
+            description: |
+              Cumulative exposure time for all of the guide window signal
+              resultants in units of seconds
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_signal_resultant_exp_time]
+          gw_acq_number:
+            title: Guide Star Acquisition Identifier
+            description: |
+              Identifier representing the guide star acquisition number within
+              the visit.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_acq_number]
+          gw_science_file_source:
+            title: Science File Name
+            description: |
+                Name of the file containing the WFI science exposure
+                corresponding to the guide window data contained within this
+                file.
+            type: string
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 120
+            archive_catalog:
+              datatype: nvarchar(120)
+              destination: [GuideWindow.gw_science_file_source]
+          gw_mode:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 18
+            archive_catalog:
+              datatype: nvarchar(18)
+              destination: [GuideWindow.gw_mode]
+          gw_window_xstart:
+            title: Guide Window X Start Position (pixels)
+            description: |
+              Minimum X position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xstart]
+          gw_window_ystart:
+            title: Guide Window Y Start Position (pixels)
+            description: |
+              Minimum Y position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ystart]
+          gw_window_xstop:
+            title: Guide Window X Stop Position (pixels)
+            description: |
+              Maximum X position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xstop]
+          gw_window_ystop:
+            title: Guide Window Y Stop Position (pixels)
+            description: |
+              Maximum Y position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ystop]
+          gw_window_xsize:
+            title: Guide window size in the x direction in detector coordinates
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xsize]
+          gw_window_ysize:
+            title: Guide window size in the y direction in detector coordinates
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ysize]
+        required: [gw_start_time, gw_end_time, gw_frame_readout_time,
+                   gw_function_start_time, gw_function_end_time,
+                   gw_acq_exec_stat, pedestal_resultant_exp_time,
+                   signal_resultant_exp_time, gw_acq_number,
+                   gw_mode, gw_window_xstart, gw_window_ystart,
+                   gw_window_xstop, gw_window_ystop,
+                   gw_window_xsize, gw_window_ysize, gw_science_file_source]
+  pedestal_frames:
+    title: Guide Window Pedestal Resultant Array (DN)
+    description: |
+      Array containing the guide window pedestal resultants in units of DN. The
+      array has dimensions of (J, H, K, X, Y) where J is the number of science
+      resultants, H is the number of reads of the detector in a given science
+      resultant, K is the number of guide window reads in a science read, and X
+      and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+  signal_frames:
+    title: Guide Window Signal Resultant Array (DN)
+    description: |
+      Array containing the guide window signal resultants in units of DN. The
+      array has dimensions of (J, H, K, X, Y) where J is the number of science
+      resultants, H is the number of reads of the detector in a given science
+      resultant, K is the number of guide window reads in a science read, and X
+      and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+  amp33:
+    title: Guide Window Amplifier 33 Reference Pixel Resultant Array (DN)
+    description: |
+      Array containing the amplifier 33 reference pixel resultants in units of
+      DN. The array has dimensions of (J, H, K, X, Y) where J is the number of
+      science resultants, H is the number of reads of the detector in a given
+      science resultant, K is the number of guide window reads in a science
+      read, and X and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+propertyOrder: [meta, pedestal_frames, signal_frames, amp33]
+flowStyle: block
+required: [meta, pedestal_frames, signal_frames, amp33]
+...

--- a/src/rad/resources/schemas/guidewindow-1.2.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/guidewindow.yaml

--- a/src/rad/resources/schemas/image_source_catalog-1.1.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.1.0.yaml
@@ -1,1 +1,45 @@
-../../../../latest/image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.1.0
+
+title: Source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ImageSourceCatalogModel
+
+archive_meta: None
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          optical_element:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0
+          exposure:
+            title: Exposure Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+          photometry:
+            title: Photometry Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+          ref_file:
+            title: Reference File Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+          visit:
+            title: Visit Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+        required: [optical_element, exposure, photometry, program, ref_file, visit]
+  source_catalog:
+    title: Source Catalog
+    description: |
+       Photometry and astrometry computed in the Source Catalog Step.
+    tag: tag:astropy.org:astropy/table/table-1.*
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]
+...

--- a/src/rad/resources/schemas/image_source_catalog-1.2.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/image_source_catalog.yaml

--- a/src/rad/resources/schemas/msos_stack-1.1.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.1.0.yaml
@@ -1,1 +1,55 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.1.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - type: object
+        properties:
+          image_list:
+              type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage]
+...

--- a/src/rad/resources/schemas/msos_stack-1.2.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/ramp-1.1.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.1.0.yaml
@@ -1,1 +1,169 @@
-../../../../latest/ramp.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.1.0
+
+title: Ramp Schema
+
+datamodel_name: RampModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - type: object
+        properties:
+          cal_step:
+            tag: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.1.0
+  data:
+    title: Science Data Including Border Reference Pixels (DN, electrons)
+    description: |
+      Science Data Including Border Reference Pixels in units of DN or
+      electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
+  pixeldq:
+    title: Two Dimensional Data Quality Flags Array for Each Pixel
+    description: |
+      Two dimensional data quality flags array applying to all resultants in a
+      given pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+  groupdq:
+    title: Three-dimensional Data Quality Array For Each Resultant in Each Pixel
+    description: |
+      Three-dimensional data quality array indicating quality of each individual
+      resultant for each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+  err:
+    title: Error Array Containing the Square Root of the Exposure-level Combined Variance (DN, electrons)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+  amp33:
+    title: Amp 33 Reference Pixel Data (DN)
+    description: |
+      Amplifier 33 Reference Pixel Data in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_left:
+    title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Left of the Detector, from the instrument's
+      perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_right:
+    title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Right of the Detector, from the
+      instrument's perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Top of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_bottom:
+    title: Border Reference Pixels on the Bottom of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Bottom of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  dq_border_ref_pix_left:
+    title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Left Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Data Quality Flag for Border Reference Pixels, on the Right Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Right Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Data Quality Flag for Border Reference Pixels, on Top.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Data Quality Flag for Border Reference Pixels, on Bottom.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, pixeldq, groupdq, err, amp33, border_ref_pix_left,
+                border_ref_pix_right, border_ref_pix_top,
+                border_ref_pix_bottom, dq_border_ref_pix_left,
+                dq_border_ref_pix_right, dq_border_ref_pix_top,
+                dq_border_ref_pix_bottom, reset_read, reset_amp33]
+flowStyle: block
+required: [meta, data, pixeldq, groupdq, err, amp33, border_ref_pix_left,
+           border_ref_pix_right, border_ref_pix_top, border_ref_pix_bottom,
+           dq_border_ref_pix_left, dq_border_ref_pix_right,
+           dq_border_ref_pix_top, dq_border_ref_pix_bottom]
+...

--- a/src/rad/resources/schemas/ramp-1.2.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp.yaml

--- a/src/rad/resources/schemas/ramp_fit_output-1.1.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.1.0.yaml
@@ -1,1 +1,109 @@
-../../../../latest/ramp_fit_output.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.1.0
+
+title: Ramp Fit Output Schema
+
+datamodel_name: RampFitOutputModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+  slope:
+    title: Slope for Specific Segment (electrons / s)
+    description: |
+      Slope of a specific segment for a ramp with uneven resultants, in units of
+      electrons per second. A segment is a set of contiguous resultants where
+      none of the resultants are saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  sigslope:
+    title: Uncertainty on Slope for Specific Segment (electrons / s)
+    description: |
+      Uncertainty on slope for specific segment for a ramp with uneven
+      resultants in units of electrons per second. A segment is a set of
+      contiguous resultants where none of the resultants are saturated or cosmic
+      ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  yint:
+    title: Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Y-intercept derived for a specific segment (electrons). A segment is a set
+      of contiguous resultants where none of the resultants are saturated or
+      cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  sigyint:
+    title: Uncertainty on Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Uncertainty on Y-intercept derived for a specific segment (electrons). A
+      segment is a set of contiguous resultants where none of the resultants are
+      saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  pedestal:
+    title: Pedestal Array (electrons)
+    description: |
+      Signal at zero exposure time for each pixel in electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  weights:
+    title: Weights for Segment Specific Fit
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  crmag:
+    title: Approximate Cosmic Ray Magnitudes (AB magnitude)
+    description: |
+      The magnitude of each segment that was flagged as having a cosmic ray hit.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  var_poisson:
+    title: Poisson Variance Associated with a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Poisson variance associated with a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+  var_rnoise:
+    title: Read Noise Variance Associated for a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Read noise-associated variance for a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+required: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,
+           var_rnoise]
+propertyOrder: [meta, slope, sigslope, yint, sigyint, pedestal, weights, crmag, var_poisson,
+                var_rnoise]
+flowStyle: block
+...

--- a/src/rad/resources/schemas/ramp_fit_output-1.2.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp_fit_output.yaml

--- a/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.0.0.yaml
@@ -1,1 +1,82 @@
-../../../../../latest/reference_files/dark.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.0.0
+
+title: Dark Reference File Schema
+
+datamodel_name: DarkRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [DARK]
+          exposure:
+            type: object
+            properties:
+              ma_table_name:
+                title: Multi-Accumulation Table Name
+                description: |
+                  The name of the MA Table used. Not a unique identifier; see
+                  ma_table_number.
+                type: string
+              ma_table_number:
+                title: Multi-Accumulation Table Number
+                description: |
+                  The unique number of the MA Table used. A modification to a MA
+                  Table that keeps the same name will have a new
+                  ma_table_number.
+                type: integer
+            required: [ma_table_name, ma_table_number]
+        required: [exposure]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.0.0
+  data:
+    title: Dark Current Array
+    description: |
+      The dark current array represents the integrated number of counts due to
+      the accumulation of dark current electrons in the pixels.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: DN
+  dq:
+    title: 2-D Data Quality Array
+    description: |
+      The 2-D data quality array for the Dark Current Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dark_slope:
+    title: Dark Current Rate Array
+    description: |
+      The dark current rate array represents the slope of the integrated number
+      of counts due to the accumulation of dark current electrons in the pixels
+      calculated from slope fitting the Dark Current Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN / s
+  dark_slope_error:
+    title: Dark Current Rate Uncertainty Array
+    description: |
+      The uncertainty calculated from the slope fitting of the Dark Current
+      Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN / s
+required: [meta, data, dq, dark_slope, dark_slope_error]
+flowStyle: block
+propertyOrder: [meta, data, dq, dark_slope, dark_slope_error]
+...

--- a/src/rad/resources/schemas/reference_files/dark-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/dark.yaml

--- a/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.0.0.yaml
@@ -1,1 +1,33 @@
-../../../../../latest/reference_files/readnoise.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.0.0
+
+title: Read Noise Reference File Schema
+
+datamodel_name: ReadnoiseRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            enum: [READNOISE]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+  data:
+    title: Read Noise Data Array
+    description: |
+      The pixel-by-pixel map read noise data array is used in estimating the
+      expected noise in each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]
+...

--- a/src/rad/resources/schemas/reference_files/readnoise-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/readnoise.yaml

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.0.0.yaml
@@ -1,1 +1,30 @@
-../../../../../latest/reference_files/ref_exposure_type.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0
+
+title: Exposure Type Reference Schema
+
+type: object
+properties:
+  exposure:
+    type: object
+    properties:
+      type:
+        allOf:
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0
+        title: WFI Mode
+        description: |
+          The type of data taken with the WFI. Allowed values are WFI_IMAGE for
+          imaging mode, WFI_GRISM and WFI_PRISM for spectral mode, WFI_DARK for
+          dark exposures, WFI_FLAT for flat fields, and WFI_WFSC.
+      p_exptype:
+        title: WFI Mode for CRDS
+        description: |
+          The potentially multiple mode strings applied to data for reference
+          file matching in CRDS. Modes are separated by "|".
+        type: string
+        pattern: "^((WFI_IMAGE|WFI_GRISM|WFI_PRISM|WFI_DARK|WFI_FLAT|WFI_WFSC)\\s*\\|\\s*)+$"
+    required: [type,p_exptype]
+required: [exposure]
+...

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/ref_exposure_type.yaml

--- a/src/rad/resources/schemas/wfi_image-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.1.0.yaml
@@ -1,1 +1,241 @@
-../../../../latest/wfi_image.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.1.0
+
+title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: ImageModel
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+      - type: object
+        properties:
+          background:
+            tag: asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0
+          cal_logs:
+            tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+          cal_step:
+            tag: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.1.0
+          outlier_detection:
+            tag: asdf://stsci.edu/datamodels/roman/tags/outlier_detection-1.0.0
+          photometry:
+            tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+          source_catalog:
+            tag: asdf://stsci.edu/datamodels/roman/tags/source_catalog-1.0.0
+          statistics:
+            tag: asdf://stsci.edu/datamodels/roman/tags/statistics-1.0.0
+          wcs:
+            title: WCS object
+            anyOf:
+              - tag: tag:stsci.edu:gwcs/wcs-*
+              - type: "null"
+
+        required: [photometry, wcs]
+  data:
+    title: Science Data (DN/s) or (MJy/sr)
+    description: |
+      Calibrated science rate image in units of data numbers
+      per second (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  dq:
+    title: Data Quality
+    description: |
+      Bitwise sum of data quality flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Error (DN / s) or (MJy / sr)
+    description: |
+      Total error array in units of data numbers per second
+      (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  var_poisson:
+    title: Poisson Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to Poisson
+      noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_rnoise:
+    title: Read Noise Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to detector
+      read noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_flat:
+    title: Flat Field Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to the flat
+      field in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DN).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_left:
+    title: Left-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the left-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, :4] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_right:
+    title: Right-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the right-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, 4092:] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border reference pixels on the top of the detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the bottom-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :4, :] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  dq_border_ref_pix_left:
+    title: Left-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the left-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, :4] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Right-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the right-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, 4092:] in a
+      zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Border Reference Pixel Data Quality on the Top of the Detector (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the top-edge of the detector in
+      the science frame orientation. In the L1 uncal file data array,
+      these are pixels (z, y, x) = [:, 4092:, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the bottom-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :4, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, dq, err, var_poisson, var_rnoise, var_flat,
+                amp33, border_ref_pix_left, border_ref_pix_right,
+                border_ref_pix_top, border_ref_pix_bottom,
+                dq_border_ref_pix_left, dq_border_ref_pix_right,
+                dq_border_ref_pix_top, dq_border_ref_pix_bottom,
+                reset_read, reset_amp33]
+flowStyle: block
+required: [meta, data, dq, err, var_poisson, var_rnoise, amp33,
+           border_ref_pix_left, border_ref_pix_right, border_ref_pix_top,
+           border_ref_pix_bottom, dq_border_ref_pix_left,
+           dq_border_ref_pix_right, dq_border_ref_pix_top,
+           dq_border_ref_pix_bottom]
+...

--- a/src/rad/resources/schemas/wfi_image-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_image.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.1.0.yaml
@@ -1,1 +1,74 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.1.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.1.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reset_read, reset_amp33]
+flowStyle: block
+required: [meta, data, amp33]
+...

--- a/src/rad/resources/schemas/wfi_science_raw-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.0.0.yaml
@@ -1,1 +1,74 @@
-../../../../latest/wfi_wcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.0.0
+
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          coordinates:
+            title: Name Of The Coordinate Reference Frame
+            tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+          ephemeris:
+            title: Ephemeris Data Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+          exposure:
+            title: Exposure Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.1.0
+          instrument:
+            title: WFI Observing Configuration
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0
+          observation:
+            title: Observation Identifiers
+            tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+          pointing:
+            title: Spacecraft Pointing Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+          velocity_aberration:
+            title: Velocity Aberration Correction Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+          visit:
+            title: Visit Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+          wcsinfo:
+            title: World Coordinate System (WCS) Parameters
+            tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
+        required: [coordinates, ephemeris, exposure,
+                   instrument, observation, pointing, program,
+                   velocity_aberration, visit, wcsinfo]
+  wcs_l2:
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta]
+...

--- a/src/rad/resources/schemas/wfi_wcs-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_wcs.yaml

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -16,7 +16,6 @@ from .conftest import MANIFESTS, METASCHEMA_URI, SCHEMA_URIS, TAG_DEFS
 WFI_OPTICAL_ELEMENTS = tuple(
     asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0")["enum"]
 )
-EXPOSURE_TYPE_ELEMENTS = tuple(asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.0.0")["enum"])
 EXPECTED_COMMON_REFERENCE = {"$ref": "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0"}
 METADATA_FORCING_REQUIRED = ("archive_catalog", "sdf")
 
@@ -169,26 +168,28 @@ def test_datamodel_name(schema):
         assert _model_name_from_schema_uri(schema["id"]) == schema["datamodel_name"]
 
 
-# Confirm that the optical_element filter in wfi_img_photom.yml matches WFI_OPTICAL_ELEMENTS
-def test_matched_optical_element_entries():
-    phot_table_keys = list(
-        asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.0.0")["properties"][
-            "phot_table"
-        ]["patternProperties"]
-    )
-    r = re.compile(phot_table_keys[0])
-    for element_str in WFI_OPTICAL_ELEMENTS:
-        assert r.search(element_str)
+def test_phot_table_keys_have_optical_element_entry(phot_table_key_pattern, optical_element):
+    """
+    Confirm that the optical_element filter in wfi_img_photom.yaml matches WFI_OPTICAL_ELEMENTS
+    """
+    assert phot_table_key_pattern.search(optical_element), f"phot_table_key pattern is missing {optical_element}."
 
 
-def test_matched_p_exptype_entries():
+def test_optical_elements_have_phot_table_key(phot_table_key, optical_elements):
+    """
+    Confirm that the optical_element filter in wfi_img_photom.yaml matches WFI_OPTICAL_ELEMENTS
+    """
+    assert phot_table_key in optical_elements, f"phot_table_key {phot_table_key} not found in optical_elements."
+
+
+def test_p_exptype_entries_have_exposure_type(p_exptype_pattern, exposure_type):
     """Confirm that the p_keyword version of exposure type match the enum version."""
-    p_exptype = asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.0.0")[
-        "properties"
-    ]["exposure"]["properties"]["p_exptype"]["pattern"]
-    r = re.compile(p_exptype)
-    for element_str in EXPOSURE_TYPE_ELEMENTS:
-        assert r.search(element_str + "|")
+    assert p_exptype_pattern.search(f"{exposure_type}|"), f"p_exptype pattern is missing {exposure_type}."
+
+
+def test_exposure_types_have_p_exptype_entry(p_exptype, exposure_types):
+    """Confirm that the p_exptype entry is in the exposure_types enum."""
+    assert p_exptype in exposure_types, f"p_exptype {p_exptype} not found in exposure_types."
 
 
 def _find_ndarrays(key, schema):


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #604

<!-- describe the changes comprising this PR here -->
This PR adds the new exposure_types requested in #604.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
