### PR TITLE
Consistency fixes for `maxLength` and `nvarchar`

### DIFF
--- a/changes/611.bugfix.rst
+++ b/changes/611.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfixes for ``maxLength`` and ``nvarchar`` issues throughout the schemas. Note
+that this includes the introduction of unit tests to check that the ``maxLength``
+is included and matches the ``nvarchar`` when applicable.

--- a/latest/cal_step_flag.yaml
+++ b/latest/cal_step_flag.yaml
@@ -13,3 +13,4 @@ enum:
   - FAILED
   - SKIPPED
   - INCOMPLETE
+maxLength: 15

--- a/latest/common.yaml
+++ b/latest/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
 
 title: Common metadata properties
 
@@ -19,16 +19,16 @@ allOf:
         tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
       exposure:
         title: Exposure Information
-        tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
       guide_star:
         title: Guide Star Window Information
-        tag: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.2.0
       instrument:
         title: WFI Observing Configuration
-        tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.2.0
       observation:
         title: Observation Identifiers
-        tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0
       pointing:
         title: Spacecraft Pointing Information
         tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
@@ -40,13 +40,13 @@ allOf:
         tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
       rcs:
         title: Relative Calibration System Information
-        tag: asdf://stsci.edu/datamodels/roman/tags/rcs-1.0.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/rcs-1.1.0
       velocity_aberration:
         title: Velocity Aberration Correction Information
         tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
       visit:
         title: Visit Information
-        tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
       wcsinfo:
         title: World Coordinate System (WCS) Parameters
         tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0

--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -177,88 +177,88 @@ tags:
     description: |-
       Mosaic WCS parameters
   # Reference Modules
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.1.0
     title: AB Vega Offset reference schema
     description: |-
       AB Vega Offset reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.1.0
     title: Aperture correction reference schema
     description: |-
       Aperture correction reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.2.0
     title: Dark reference schema
     description: |-
       Dark reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.2.0
     title: Distortion reference schema
     description: |-
       Distortion reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.2.0
     title: ePSF reference schema
     description: |-
       ePSF reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.2.0
     title: Flat reference schema
     description: |-
       Flat field information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.1.0
     title: Gain reference schema
     description: |-
       Gain reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.1.0
     title: Inverse linearity correction reference schema
     description: |-
       Inverse linearity correction reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.2.0
     title: IPC kernel reference schema
     description: |-
       IPC kernel reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.1.0
     title: Linearity correction reference schema
     description: |-
       Linearity correction reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.1.0
     title: DQ Mask reference schema
     description: |-
       DQ Mask reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.2.0
     title: Pixel area reference schema
     description: |-
       Pixel area reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.2.0
     title: Read noise reference schema
     description: |-
       Read noise reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.1.0
     title: Reference pixel correction reference schema
     description: |-
       Reference pixel correction reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.1.0
     title: Saturation reference schema
     description: |-
       Saturation reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.1.0
     title: Super-bias reference schema
     description: |-
       Super-bias reference schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.2.0
     title: WFI imaging photometric flux conversion data model
     description: |-
       WFI imaging photometric flux conversion data model
@@ -267,8 +267,8 @@ tags:
     title: Skycells Reference File Schema
     description: |-
       This file contains definitions for all the skycells that cover the entire celestial sphere
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.1.0
     title: Multiple Accumulation Table Reference File Schema
     description: |-
       Multiple Accumulation Table Reference File Schema

--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -9,8 +9,8 @@ asdf_standard_requirement:
   gte: 1.1.0
 tags:
   # Object Modules
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.2.0
     title: Level 1 FACE Guide Star Window Information schema
     description: |-
       Level 1 FACE Guide Star Window Information schema
@@ -19,8 +19,8 @@ tags:
     title: Level 1 Detector Guide Star Window Information schema
     description: |-
       Level 1 Detector Guide Star Window Information schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.3.0
     title: Guide window schema
     description: |-
       Guide window schema
@@ -29,13 +29,13 @@ tags:
     title: Ramp schema
     description: |-
       Ramp schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.3.0
     title: Ramp fit output schema
     description: |-
       Ramp fit output schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.3.0
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
@@ -49,20 +49,20 @@ tags:
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.2.0
     title: Roman WFI Instrument Mode
     description: |-
       Roman WFI Instrument
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.2.0
     title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
     description: |-
       Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
       modified WCS applicable for Science Raw (L1).
   # Metadata Modules
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.3.0
     title: Exposure information
     description: |-
       Exposure information
@@ -71,8 +71,8 @@ tags:
     title: Program information
     description: |-
       Program information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.1.0
     title: Observation information
     description: |-
       Observation information
@@ -81,8 +81,8 @@ tags:
     title: Ephemeris information
     description: |-
       Ephemeris information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.2.0
     title: Visit information
     description: |-
       Visit information
@@ -106,8 +106,8 @@ tags:
     title: Spacecraft Pointing information
     description: |-
       Spacecraft Pointing information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/rcs-1.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/rcs-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.1.0
     title: Relative Calibration System Information
     description: |-
       Relative Calibration System Information
@@ -126,8 +126,8 @@ tags:
     title: Wcsinfo information
     description: |-
       Wcsinfo information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.2.0
     title: Guidestar information
     description: |-
       Guidestar information
@@ -161,8 +161,8 @@ tags:
     title: Combined level 2 metadata
     description: |-
       Combined level 2 metadata
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.2.0
     title: Basic mosaic metadata keywords
     description: |-
       Basic mosaic metadata keywords
@@ -293,8 +293,8 @@ tags:
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.3.0
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
@@ -308,8 +308,8 @@ tags:
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.3.0
     title: Mosaic segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
@@ -385,8 +385,8 @@ tags:
     description: |-
       The name of the telescope used to acquire the data.
   # SSC data models
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.3.0
     title: MSOS Stack Level 3 Schema
     description: |-
       Level 3 schema for SSC's MSOS stack products

--- a/latest/exposure.yaml
+++ b/latest/exposure.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.3.0
 
 title: |
   Exposure Information
@@ -15,7 +15,6 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: PSS:dms_visit.template
-    maxLength: 25
     archive_catalog:
       datatype: nvarchar(25)
       destination:

--- a/latest/exposure.yaml
+++ b/latest/exposure.yaml
@@ -10,7 +10,7 @@ type: object
 properties:
   type:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.2.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/exposure_type.yaml
+++ b/latest/exposure_type.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.2.0
 
 # Helper file to enumerate viewing modes for exposure and ref_exposure
 title: Exposure Type
@@ -26,3 +26,4 @@ enum:
   - WFI_DARK
   - WFI_GRISM
   - WFI_PRISM
+maxLength: 25

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -19,7 +19,7 @@ properties:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
           exposure:
             title: Exposure Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
@@ -31,7 +31,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
           visit:
             title: Visit Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
         required:
           [optical_element, exposure, photometry, program, ref_file, visit]
   source_catalog:

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           optical_element:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
           exposure:
             title: Exposure Information
             tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0

--- a/latest/forced_mosaic_source_catalog.yaml
+++ b/latest/forced_mosaic_source_catalog.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           basic:
-            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0

--- a/latest/guidestar.yaml
+++ b/latest/guidestar.yaml
@@ -27,7 +27,7 @@ properties:
       destination: [WFIExposure.guide_window_id, GuideWindow.guide_window_id]
   guide_mode:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.1.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/guidestar.yaml
+++ b/latest/guidestar.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.2.0
 
 title: Guide Star and Guide Window Information
 
@@ -32,7 +32,6 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-    maxLength: 18
     archive_catalog:
       datatype: nvarchar(18)
       destination: [WFIExposure.guide_mode, GuideWindow.guide_mode]

--- a/latest/guidewindow.yaml
+++ b/latest/guidewindow.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.3.0
 
 title: Guide Star Window Information
 
@@ -14,7 +14,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
       - type: object
         properties:
           gw_start_time:
@@ -151,7 +151,6 @@ properties:
               special_processing: VALUE_REQUIRED
               source:
                 origin: Science Data Formatting
-            maxLength: 18
             archive_catalog:
               datatype: nvarchar(18)
               destination: [GuideWindow.gw_mode]

--- a/latest/guidewindow.yaml
+++ b/latest/guidewindow.yaml
@@ -146,7 +146,7 @@ properties:
               destination: [GuideWindow.gw_science_file_source]
           gw_mode:
             allOf:
-              - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.1.0
             sdf:
               special_processing: VALUE_REQUIRED
               source:

--- a/latest/guidewindow_modes.yaml
+++ b/latest/guidewindow_modes.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.1.0
 
 # Helper file to enumerate guide window modes for guidestar and guidewindow
 
@@ -18,3 +18,4 @@ enum:
   - WSM-TRACK
   - DEFOCUSED-MODERATE
   - DEFOCUSED-LARGE
+maxLength: 18

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -19,7 +19,7 @@ properties:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
           exposure:
             title: Exposure Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
@@ -31,7 +31,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
           visit:
             title: Visit Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
         required:
           [optical_element, exposure, photometry, program, ref_file, visit]
   source_catalog:

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           optical_element:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
           exposure:
             title: Exposure Information
             tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0

--- a/latest/l1_detector_guidewindow.yaml
+++ b/latest/l1_detector_guidewindow.yaml
@@ -18,7 +18,7 @@ properties:
         properties:
           instrument:
             title: WFI Observing Configuration
-            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.2.0
           fgs_modes_used:
             title: FGS Guiding Modes
             description: |

--- a/latest/l1_face_guidewindow.yaml
+++ b/latest/l1_face_guidewindow.yaml
@@ -18,7 +18,7 @@ properties:
         properties:
           optical_element:
             allOf:
-              - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
             title: Wide Field Instrument (WFI) Optical Element
             description: |
               Optical element used during the exposure.

--- a/latest/l1_face_guidewindow.yaml
+++ b/latest/l1_face_guidewindow.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.2.0
 
 title: Level 1 FACE Guide Star Window Information schema
 
@@ -26,7 +26,6 @@ properties:
               special_processing: VALUE_REQUIRED
               source:
                 origin: TBD
-            maxLength: 20
             archive_catalog:
               datatype: nvarchar(20)
               destination: [GuideWindow.optical_element]

--- a/latest/l2_cal_step.yaml
+++ b/latest/l2_cal_step.yaml
@@ -13,7 +13,6 @@ properties:
       System (WCS) object to a science image.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_assign_wcs]
@@ -26,7 +25,6 @@ properties:
       response.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_flat_field]
@@ -38,7 +36,6 @@ properties:
       science data.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_dark]
@@ -49,7 +46,6 @@ properties:
       array and masks known bad pixels.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_dq_init]
@@ -60,7 +56,6 @@ properties:
       The data are converted from DN/s to MJy/sr.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_flux]
@@ -71,7 +66,6 @@ properties:
       correct for deviations from a linear response.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_linearity]
@@ -82,7 +76,6 @@ properties:
       calibration information in the metadata of the science file.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_photom]
@@ -93,7 +86,6 @@ properties:
       image for use in astrometric alignment.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_source_catalog]
@@ -104,7 +96,6 @@ properties:
       compute the count rate.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_ramp_fit]
@@ -116,7 +107,6 @@ properties:
       using the reference pixels.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_refpix]
@@ -127,7 +117,6 @@ properties:
       pixels at or above the saturation threshold.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_saturation]
@@ -137,7 +126,6 @@ properties:
       Step in ROMANCAL which detects and flags outliers in a science image.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_outlier_detection]
@@ -150,7 +138,6 @@ properties:
       (WCS) alignment.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_tweakreg]
@@ -161,7 +148,6 @@ properties:
       and derives scalings to equalize overlapping regions.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_skymatch]

--- a/latest/l3_cal_step.yaml
+++ b/latest/l3_cal_step.yaml
@@ -13,7 +13,6 @@ properties:
       The data are converted from DN/s to MJy/sr.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_flux]
@@ -23,7 +22,6 @@ properties:
       Step in ROMANCAL which detects and flags outliers in a science image.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_outlier_detection]
@@ -34,7 +32,6 @@ properties:
       and derives scalings to equalize overlapping regions.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_skymatch]
@@ -46,7 +43,6 @@ properties:
       multiple resampled images into a single, undistorted product.
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
-    maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_resample]

--- a/latest/mosaic_basic.yaml
+++ b/latest/mosaic_basic.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.2.0
 
 title: Basic mosaic metadata keywords
 type: object
@@ -143,7 +143,6 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-    maxLength: 20
     archive_catalog:
       datatype: nvarchar(20)
       destination:

--- a/latest/mosaic_basic.yaml
+++ b/latest/mosaic_basic.yaml
@@ -138,7 +138,7 @@ properties:
         [WFIMosaic.survey, SourceCatalog.survey, SegmentationMap.survey]
   optical_element:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/mosaic_segmentation_map.yaml
+++ b/latest/mosaic_segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.3.0
 
 title: Segmentation map generated from a Level 3 file by the Source Catalog Step.
 
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           basic:
-            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
           program:
             title: Program Information
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0

--- a/latest/mosaic_source_catalog.yaml
+++ b/latest/mosaic_source_catalog.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           basic:
-            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.3.0
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
       - type: object
         properties:
           image_list:

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           basic:
-            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
           photometry:
             title: Photometry Information
             tag: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0

--- a/latest/observation.yaml
+++ b/latest/observation.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.1.0
 
 title: Observation Identifiers
 type: object
@@ -150,7 +150,6 @@ properties:
       within the visit file. The allowed range of visit file group
       numbers is 01 to 99 inclusive.
     type: integer
-    maxLength: 3
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
       - type: object
         properties:
           cal_step:

--- a/latest/ramp_fit_output.yaml
+++ b/latest/ramp_fit_output.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.3.0
 
 title: Ramp Fit Output Schema
 
@@ -10,7 +10,7 @@ datamodel_name: RampFitOutputModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
   slope:
     title: Slope for Specific Segment (electrons / s)
     description: |

--- a/latest/rcs.yaml
+++ b/latest/rcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.1.0
 
 title: Relative Calibration System Information
 type: object
@@ -28,8 +28,8 @@ properties:
     anyOf:
       - type: string
         enum: ["A", "B", None]
+        maxLength: 5
       - type: "null"
-    maxLength: 5
     archive_catalog:
       datatype: nvarchar(5)
       destination: [WFIExposure.electronics]
@@ -43,8 +43,8 @@ properties:
     anyOf:
       - type: string
         enum: ["1", "2", None]
+        maxLength: 5
       - type: "null"
-    maxLength: 5
     archive_catalog:
       datatype: nvarchar(5)
       destination: [WFIExposure.bank]
@@ -58,8 +58,8 @@ properties:
     anyOf:
       - type: string
         enum: ["1", "2", "3", "4", "5", "6", None]
+        maxLength: 5
       - type: "null"
-    maxLength: 5
     archive_catalog:
       datatype: nvarchar(5)
       destination: [WFIExposure.led]

--- a/latest/reference_files/abvegaoffset.yaml
+++ b/latest/reference_files/abvegaoffset.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.1.0
 
 title: AB Vega Offset Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/apcorr.yaml
+++ b/latest/reference_files/apcorr.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.1.0
 
 title: Aperture Correction Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/dark.yaml
+++ b/latest/reference_files/dark.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.2.0
 
 title: Dark Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:
@@ -35,8 +35,8 @@ properties:
                 type: integer
             required: [ma_table_name, ma_table_number]
         required: [exposure]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
   data:
     title: Dark Current Array
     description: |

--- a/latest/reference_files/distortion.yaml
+++ b/latest/reference_files/distortion.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.2.0
 
 title: Distortion Reference Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
 
         input_units: "pixel"
@@ -21,7 +21,7 @@ properties:
           reftype:
             type: string
             enum: [DISTORTION]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
   coordinate_distortion_transform:
     title: Distortion Transform Model with inputs in "pixel" and outputs in "arcsec"
     description: |

--- a/latest/reference_files/epsf.yaml
+++ b/latest/reference_files/epsf.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.2.0
 
 title: ePSF Reference File Schema
 
@@ -11,8 +11,8 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/flat.yaml
+++ b/latest/reference_files/flat.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.2.0
 
 title: Flat Reference File Schema
 
@@ -11,13 +11,13 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:
             type: string
             enum: [FLAT]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
   data:
     title: Flat Data Array
     description: |

--- a/latest/reference_files/gain.yaml
+++ b/latest/reference_files/gain.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.1.0
 
 title: Gain Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/inverselinearity.yaml
+++ b/latest/reference_files/inverselinearity.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.1.0
 
 title: Inverse Linearity Correction Reference Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
 
         input_units: "DN"

--- a/latest/reference_files/ipc.yaml
+++ b/latest/reference_files/ipc.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.2.0
 
 title: Interpixel Capacitance Reference File Schema
 
@@ -11,8 +11,8 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/linearity.yaml
+++ b/latest/reference_files/linearity.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.1.0
 
 title: Linearity Correction Reference Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
 
         input_units: "DN"

--- a/latest/reference_files/mask.yaml
+++ b/latest/reference_files/mask.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.1.0
 
 title: Mask Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/matable.yaml
+++ b/latest/reference_files/matable.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.1.0
 
 title: Multiple Accumulation Table Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/pixelarea.yaml
+++ b/latest/reference_files/pixelarea.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.2.0
 
 title: Pixel Area Reference Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:
@@ -37,7 +37,7 @@ properties:
                   - type: "null"
             required: [pixelarea_steradians, pixelarea_arcsecsq]
         required: [photometry]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
   data:
     title: Pixel Area Array
     description: |

--- a/latest/reference_files/readnoise.yaml
+++ b/latest/reference_files/readnoise.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.2.0
 
 title: Read Noise Reference File Schema
 
@@ -11,12 +11,12 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:
             enum: [READNOISE]
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.2.0
   data:
     title: Read Noise Data Array
     description: |

--- a/latest/reference_files/ref_common.yaml
+++ b/latest/reference_files/ref_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
 
 title: Common Reference File Metadata Properties
 
@@ -60,7 +60,7 @@ properties:
         enum: [WFI]
       detector:
         allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.1.0
         title: Detector
         description: |
           The numbered WFI detector in the focal plane (e.g., WFI01 for SCA 01).

--- a/latest/reference_files/ref_exposure_type.yaml
+++ b/latest/reference_files/ref_exposure_type.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.2.0
 
 title: Exposure Type Reference Schema
 
@@ -12,7 +12,7 @@ properties:
     properties:
       type:
         allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.2.0
         title: WFI Mode
         description: |
           The type of data taken with the WFI. Allowed values are WFI_IMAGE for

--- a/latest/reference_files/ref_optical_element.yaml
+++ b/latest/reference_files/ref_optical_element.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.2.0
 
 title: Optical Element Reference Schema
 
@@ -11,6 +11,6 @@ properties:
     type: object
     properties:
       optical_element:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
     required: [optical_element]
 required: [instrument]

--- a/latest/reference_files/refpix.yaml
+++ b/latest/reference_files/refpix.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.1.0
 
 title: Reference Pixel Correction Reference Schema
 
@@ -13,7 +13,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
 
         input_units: "DN"

--- a/latest/reference_files/saturation.yaml
+++ b/latest/reference_files/saturation.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.1.0
 
 title: Saturation Reference File Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/superbias.yaml
+++ b/latest/reference_files/superbias.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.1.0
 
 title: Super-Bias Reference Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/wfi_img_photom.yaml
+++ b/latest/reference_files/wfi_img_photom.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.2.0
 
 title: WFI Imaging Photometric Flux Conversion Data Model
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.1.0
       - type: object
         properties:
           reftype:

--- a/latest/segmentation_map.yaml
+++ b/latest/segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.3.0
 
 title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
 
@@ -22,7 +22,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
           visit:
             title: Visit Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
         required: [optical_element, program, visit]
   data:
     title: Segmentation map

--- a/latest/segmentation_map.yaml
+++ b/latest/segmentation_map.yaml
@@ -16,7 +16,7 @@ properties:
       - type: object
         properties:
           optical_element:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
           program:
             title: Program Information
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0

--- a/latest/visit.yaml
+++ b/latest/visit.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/visit-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/visit-1.2.0
 
 title: Visit Information
 type: object
@@ -17,12 +17,12 @@ properties:
           the visit.
         anyOf:
           - type: string
+            maxLength: 100
           - type: "null"
         sdf:
           special_processing: VALUE_REQUIRED
           source:
             origin: PSS:dms_visit.dither_type
-        maxLength: 100
         archive_catalog:
           datatype: nvarchar(100)
           destination:
@@ -38,12 +38,12 @@ properties:
           the visit.
         anyOf:
           - type: string
+            maxLength: 100
           - type: "null"
         sdf:
           special_processing: VALUE_REQUIRED
           source:
             origin: PSS:dms_visit.subpixel_dither_type
-        maxLength: 100
         archive_catalog:
           datatype: nvarchar(100)
           destination:

--- a/latest/wfi_detector.yaml
+++ b/latest/wfi_detector.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.1.0
 
 # Helper file to enumerate detectors for wfi_mode and ref_detector
 
@@ -26,3 +26,4 @@ enum:
   - WFI16
   - WFI17
   - WFI18
+maxLength: 10

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
       - type: object
         properties:
           background:

--- a/latest/wfi_mode.yaml
+++ b/latest/wfi_mode.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.2.0
 
 title: Wide Field Instrument (WFI) Configuration Information
 type: object
@@ -37,7 +37,6 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-    maxLength: 10
     archive_catalog:
       datatype: nvarchar(10)
       destination:
@@ -53,7 +52,6 @@ properties:
       special_processing: VALUE_REQUIRED
       source:
         origin: TBD
-    maxLength: 20
     archive_catalog:
       datatype: nvarchar(20)
       destination:

--- a/latest/wfi_mode.yaml
+++ b/latest/wfi_mode.yaml
@@ -28,7 +28,7 @@ properties:
         ]
   detector:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.1.0
     title: Wide Field Instrument (WFI) Detector Identifier
     description: |
       Name of the Wide Field Instrument (WFI) detector used
@@ -43,7 +43,7 @@ properties:
         [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
   optical_element:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
     title: Wide Field Instrument (WFI) Optical Element
     description: |
       Name of the optical element used to take the science

--- a/latest/wfi_mosaic.yaml
+++ b/latest/wfi_mosaic.yaml
@@ -20,7 +20,7 @@ properties:
           asn:
             tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_associations-1.0.0
           basic:
-            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
           cal_logs:
             tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
           cal_step:

--- a/latest/wfi_optical_element.yaml
+++ b/latest/wfi_optical_element.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
 
 # Helper file to enumerate filters for wfi_mode and ref_optical_element
 
@@ -23,3 +23,4 @@ enum:
   - PRISM
   - DARK
   - NOT_CONFIGURED
+maxLength: 20

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.3.0
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: None
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.3.0
   data:
     title: Science Data (DN)
     description: |

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.2.0
 
 title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -23,13 +23,13 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
           exposure:
             title: Exposure Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
           instrument:
             title: WFI Observing Configuration
-            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.2.0
           observation:
             title: Observation Identifiers
-            tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0
           pointing:
             title: Spacecraft Pointing Information
             tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
@@ -41,7 +41,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
           visit:
             title: Visit Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
           wcsinfo:
             title: World Coordinate System (WCS) Parameters
             tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0

--- a/src/rad/resources/schemas/common-1.2.0.yaml
+++ b/src/rad/resources/schemas/common-1.2.0.yaml
@@ -1,1 +1,68 @@
-../../../../latest/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+
+title: Common metadata properties
+
+allOf:
+  # Meta Variables
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+  - type: object
+    properties:
+      # Meta Objects
+      coordinates:
+        title: Name Of The Coordinate Reference Frame
+        tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+      ephemeris:
+        title: Ephemeris Data Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+      exposure:
+        title: Exposure Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+      guide_star:
+        title: Guide Star Window Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0
+      instrument:
+        title: WFI Observing Configuration
+        tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+      observation:
+        title: Observation Identifiers
+        tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+      pointing:
+        title: Spacecraft Pointing Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+      program:
+        title: Program Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+      ref_file:
+        title: Reference File Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+      rcs:
+        title: Relative Calibration System Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/rcs-1.0.0
+      velocity_aberration:
+        title: Velocity Aberration Correction Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+      visit:
+        title: Visit Information
+        tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+      wcsinfo:
+        title: World Coordinate System (WCS) Parameters
+        tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+    required:
+      [
+        coordinates,
+        ephemeris,
+        exposure,
+        guide_star,
+        instrument,
+        observation,
+        pointing,
+        program,
+        ref_file,
+        rcs,
+        velocity_aberration,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/common-1.3.0.yaml
+++ b/src/rad/resources/schemas/common-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/common.yaml

--- a/src/rad/resources/schemas/exposure-1.2.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.2.0.yaml
@@ -1,1 +1,334 @@
-../../../../latest/exposure.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
+
+title: |
+  Exposure Information
+
+type: object
+properties:
+  type:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.template
+    maxLength: 25
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination:
+        [
+          WFIExposure.exposure_type,
+          GuideWindow.exposure_type,
+          WFICommon.exposure_type,
+        ]
+  start_time:
+    title: Exposure Start Time (UTC)
+    description: |
+      The UTC time at the beginning of the exposure. The
+      time is serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination:
+        [
+          WFIExposure.exposure_start_time,
+          GuideWindow.exposure_start_time,
+          WFICommon.exposure_start_time,
+        ]
+  end_time:
+    title: Exposure End Time (UTC)
+    description: |
+      The UTC time at the end of the exposure. The time is
+      serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination:
+        [
+          WFIExposure.exposure_end_time,
+          GuideWindow.exposure_end_time,
+          SourceCatalog.exposure_end_time,
+        ]
+  engineering_quality:
+    title: Engineering Data Quality
+    description: |
+      Indicator of data quality problems with the
+      engineering data used to populated select metadata fields. A
+      value of "OK" indicates no suspected problems, while a value of
+      "SUSPECT" indicates one or more metadata values populated from
+      the engineering database may be missing information during the
+      exposure or are otherwise of lower quality.
+    type: string
+    enum: [OK, SUSPECT]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination:
+        [
+          WFIExposure.engineering_quality,
+          GuideWindow.engineering_quality,
+          SourceCatalog.engineering_quality,
+        ]
+  ma_table_id:
+    title: Multi-Accumulation Table Identifier
+    description: |
+      A unique identifier for the multi-accumulation (MA) table used for this exposure.
+      The identifier comes from the Science Operations Center (SOC) Project Reference
+      Database (PRD).
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination:
+        [
+          WFIExposure.ma_table_id,
+          GuideWindow.ma_table_id,
+          SourceCatalog.ma_table_id,
+        ]
+  nresultants:
+    title: Number of Resultants
+    description: |
+      The number of resultant frames in this exposure that
+      were transmitted to the ground.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_resultant
+    archive_catalog:
+      datatype: int
+      destination:
+        [
+          WFIExposure.exposure_nresultants,
+          GuideWindow.exposure_nresultants,
+          WFICommon.exposure_nresultants,
+        ]
+  data_problem:
+    title: Data Problem
+    description: |
+      String error codes indicating that a problem occurred with the exposure.
+      A value of None indicates there were no problems with the exposure.
+      See the Roman Documentation System (RDox) for more information on the meaning of the error codes.
+    anyOf:
+      - type: string
+      - type: "null"
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(max)
+      destination:
+        [
+          WFIExposure.exposure_data_problem,
+          GuideWindow.exposure_data_problem,
+          WFICommon.exposure_data_problem,
+        ]
+  frame_time:
+    title: Detector Readout Time (s)
+    description: |
+      The readout time in seconds of the Wide Field
+      Instrument (WFI) detectors. This represents the time between the
+      start and end of the readout.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIExposure.exposure_frame_time,
+          GuideWindow.exposure_frame_time,
+          WFICommon.exposure_frame_time,
+        ]
+  exposure_time:
+    title: Exposure Time (s)
+    description: |
+      The difference in time (in units of seconds) between
+      the start of the first reset/read and end of the last read in
+      the readout pattern.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIExposure.exposure_time,
+          GuideWindow.exposure_time,
+          WFICommon.exposure_time,
+        ]
+  effective_exposure_time:
+    title: Effective Exposure Time (s)
+    description: |
+      The difference in time (in units of seconds) between
+      the midpoints of the first and last science resultants. If
+      either resultant contains only a single read, then the time at
+      the end of the read is used rather than the midpoint time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIExposure.effective_exposure_time,
+          GuideWindow.effective_exposure_time,
+          SourceCatalog.effective_exposure_time,
+        ]
+  ma_table_name:
+    title: Name of the Multi-Accumulation Table
+    description: |
+      The name of the multi-accumulation (MA) table used for
+      the exposure. The MA table is also referred to as the readout
+      pattern.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_table_name
+    maxLength: 50
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination:
+        [
+          WFIExposure.ma_table_name,
+          GuideWindow.ma_table_name,
+          WFICommon.ma_table_name,
+        ]
+  ma_table_number:
+    title: Multi-Accumulation Table Identification Number
+    description: |
+      A unique identification number for the
+      multi-accumulation (MA) table used for this exposure. The number
+      comes from the Science Operations Center (SOC) Project Reference
+      Database (PRD).
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.multi_accum_table_number
+    archive_catalog:
+      datatype: smallint
+      destination:
+        [
+          WFIExposure.ma_table_number,
+          GuideWindow.ma_table_number,
+          WFICommon.ma_table_number,
+        ]
+  read_pattern:
+    title: Read Pattern
+    description: |
+      The enumeration of detector reads to resultants making
+      up the Level 1 ramp data cube. The read pattern is nested such
+      that each grouping of read numbers represents a resultant. For
+      example, a readout pattern of [[1], [2, 3], [4]] consists of
+      four reads that were downlinked as three resultants with both
+      the first and last resultant each containing a single read.
+    type: array
+    items:
+      type: array
+      items:
+        type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(3500)
+      destination:
+        [
+          WFIExposure.read_pattern,
+          GuideWindow.read_pattern,
+          WFICommon.read_pattern,
+        ]
+  truncated:
+    title: Truncated MA Table
+    description: |
+      A flag indicating whether the MA table was truncated.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination:
+        [WFIExposure.exposure_truncated, SourceCatalog.exposure_truncated]
+  sdf_log_file:
+    title: SDF Log File Name
+    description: |
+      File name of the Science Data Formatting (SDF) log for this exposure.
+    type: string
+    maxLength: 120
+required:
+  [
+    type,
+    start_time,
+    end_time,
+    engineering_quality,
+    nresultants,
+    data_problem,
+    frame_time,
+    exposure_time,
+    effective_exposure_time,
+    ma_table_name,
+    ma_table_number,
+    ma_table_id,
+    read_pattern,
+    truncated,
+  ]
+propertyOrder:
+  [
+    type,
+    start_time,
+    end_time,
+    engineering_quality,
+    nresultants,
+    data_problem,
+    frame_time,
+    exposure_time,
+    effective_exposure_time,
+    ma_table_name,
+    ma_table_number,
+    ma_table_id,
+    read_pattern,
+    truncated,
+    sdf_log_file,
+  ]
+flowStyle: block

--- a/src/rad/resources/schemas/exposure-1.3.0.yaml
+++ b/src/rad/resources/schemas/exposure-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/exposure.yaml

--- a/src/rad/resources/schemas/exposure_type-1.1.0.yaml
+++ b/src/rad/resources/schemas/exposure_type-1.1.0.yaml
@@ -1,1 +1,28 @@
-../../../../latest/exposure_type.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+
+# Helper file to enumerate viewing modes for exposure and ref_exposure
+title: Exposure Type
+description: |
+  The type of the exposure. Wide Field Instrument (WFI)
+  imaging mode observations have type WFI_IMAGE, while the
+  spectroscopic mode may be either WFI_GRISM or WFI_PRISM
+  depending on the selected optical element. Other values are
+  related to either internal calibration or engineering
+  observations.
+
+type: string
+enum:
+  - WFI_IMAGE
+  - WFI_SPECTRAL
+  - WFI_IM_DARK
+  - WFI_SP_DARK
+  - WFI_FLAT
+  - WFI_LOLO
+  - WFI_WFSC
+  # These are slated for removal in the future
+  - WFI_DARK
+  - WFI_GRISM
+  - WFI_PRISM

--- a/src/rad/resources/schemas/exposure_type-1.2.0.yaml
+++ b/src/rad/resources/schemas/exposure_type-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/exposure_type.yaml

--- a/src/rad/resources/schemas/guidestar-1.1.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.1.0.yaml
@@ -1,1 +1,142 @@
-../../../../latest/guidestar.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.1.0
+
+title: Guide Star and Guide Window Information
+
+type: object
+properties:
+  guide_window_id:
+    title: Guide Window Identifier
+    description: |
+      A unique identification number of the guide window.
+      This identifier combines the visit identifier and guide star
+      acquisition number, and is set in the visit information uplinked
+      to the observatory. As the number may be zero-padded, this value
+      is saved as a string. See technical report Roman-STScI-000193
+      "Roman Programmatic Data Identification" for more information.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 20
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.guide_window_id, GuideWindow.guide_window_id]
+  guide_mode:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 18
+    archive_catalog:
+      datatype: nvarchar(18)
+      destination: [WFIExposure.guide_mode, GuideWindow.guide_mode]
+  window_xstart:
+    title: Guide Window X Start Position (pixels)
+    description: |
+      Minimum X position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_xstart]
+  window_ystart:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Minimum Y position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_ystart]
+  window_xstop:
+    title: Guide Window X Stop Position (pixels)
+    description: |
+      Maximum X position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_xstop]
+  window_ystop:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Maximum Y position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_ystop]
+  guide_star_id:
+    title: Guide Star Identifier
+    description: |
+      Identification of the guide star from the Guide Star Catalog (GSC).
+      This is based on planned information from the Roman Planning and
+      Scheduling Subsystem.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_guide_star.star_id
+    maxLength: 20
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.guide_star_id, GuideWindow.guide_star_id]
+  epoch:
+    title: Guide Star Coordinates Epoch
+    description: |
+      Epoch of the celestial coordinates of the guide star
+      from the Guide Star Catalog (GSC).
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.epoch, GuideWindow.epoch]
+propertyOrder:
+  [
+    guide_window_id,
+    guide_mode,
+    window_xstart,
+    window_ystart,
+    window_xstop,
+    window_ystop,
+    guide_star_id,
+    epoch,
+  ]
+required:
+  [
+    guide_window_id,
+    guide_mode,
+    window_xstart,
+    window_ystart,
+    window_xstop,
+    window_ystop,
+    guide_star_id,
+    epoch,
+  ]
+flowStyle: block

--- a/src/rad/resources/schemas/guidestar-1.2.0.yaml
+++ b/src/rad/resources/schemas/guidestar-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/guidestar.yaml

--- a/src/rad/resources/schemas/guidewindow-1.2.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.2.0.yaml
@@ -1,1 +1,291 @@
-../../../../latest/guidewindow.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
+
+title: Guide Star Window Information
+
+datamodel_name: GuidewindowModel
+
+# Deprecated
+# archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - type: object
+        properties:
+          gw_start_time:
+            title: Start Time of Guide Window Exposure (UTC)
+            description: |
+              Time in UTC at the start of the guide window exposure.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_start_time]
+          gw_end_time:
+            title: End Time of Guide Window Exposure (UTC)
+            description: |
+              Time in UTC at the end of the guide window exposure.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_end_time]
+          gw_frame_readout_time:
+            title: Guide Window Read Time (Seconds)
+            description: |
+              Time to read out the guide window frame in units of seconds.
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_frame_readout_time]
+          gw_function_start_time:
+            title: Guide Window Function Start Time (UTC)
+            description: |
+              Time in UTC at the start of the guider function.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_function_start_time]
+          gw_function_end_time:
+            title: Guide Window Function End Time (UTC)
+            description: |
+              Time in UTC at the end of the guider function.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: datetime2
+              destination: [GuideWindow.gw_function_end_time]
+          gw_acq_exec_stat:
+            title: Guide Star Acquisition Status
+            description: |
+              Status of the guide star acquisition.
+            type: string
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 15
+            archive_catalog:
+              datatype: nvarchar(15)
+              destination: [GuideWindow.gw_acq_exec_stat]
+          pedestal_resultant_exp_time:
+            title: Guide Window Pedestal Exposure Time (Seconds)
+            description: |
+              Cumulative exposure time for all of the guide window pedestal
+              resultants in units of seconds.
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_pedestal_resultant_exp_time]
+          signal_resultant_exp_time:
+            title: Guide Window Signal Exposure Time (Seconds)
+            description: |
+              Cumulative exposure time for all of the guide window signal
+              resultants in units of seconds
+            type: number
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: float
+              destination: [GuideWindow.gw_signal_resultant_exp_time]
+          gw_acq_number:
+            title: Guide Star Acquisition Identifier
+            description: |
+              Identifier representing the guide star acquisition number within
+              the visit.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_acq_number]
+          gw_science_file_source:
+            title: Science File Name
+            description: |
+              Name of the file containing the WFI science exposure
+              corresponding to the guide window data contained within this
+              file.
+            type: string
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 120
+            archive_catalog:
+              datatype: nvarchar(120)
+              destination: [GuideWindow.gw_science_file_source]
+          gw_mode:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            maxLength: 18
+            archive_catalog:
+              datatype: nvarchar(18)
+              destination: [GuideWindow.gw_mode]
+          gw_window_xstart:
+            title: Guide Window X Start Position (pixels)
+            description: |
+              Minimum X position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xstart]
+          gw_window_ystart:
+            title: Guide Window Y Start Position (pixels)
+            description: |
+              Minimum Y position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ystart]
+          gw_window_xstop:
+            title: Guide Window X Stop Position (pixels)
+            description: |
+              Maximum X position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xstop]
+          gw_window_ystop:
+            title: Guide Window Y Stop Position (pixels)
+            description: |
+              Maximum Y position in the science coordinate frame of all tracking
+              guide windows in this exposure measured in pixels.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ystop]
+          gw_window_xsize:
+            title: Guide window size in the x direction in detector coordinates
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_xsize]
+          gw_window_ysize:
+            title: Guide window size in the y direction in detector coordinates
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: Science Data Formatting
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_window_ysize]
+        required:
+          [
+            gw_start_time,
+            gw_end_time,
+            gw_frame_readout_time,
+            gw_function_start_time,
+            gw_function_end_time,
+            gw_acq_exec_stat,
+            pedestal_resultant_exp_time,
+            signal_resultant_exp_time,
+            gw_acq_number,
+            gw_mode,
+            gw_window_xstart,
+            gw_window_ystart,
+            gw_window_xstop,
+            gw_window_ystop,
+            gw_window_xsize,
+            gw_window_ysize,
+            gw_science_file_source,
+          ]
+  pedestal_frames:
+    title: Guide Window Pedestal Resultant Array (DN)
+    description: |
+      Array containing the guide window pedestal resultants in units of DN. The
+      array has dimensions of (J, H, K, X, Y) where J is the number of science
+      resultants, H is the number of reads of the detector in a given science
+      resultant, K is the number of guide window reads in a science read, and X
+      and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+  signal_frames:
+    title: Guide Window Signal Resultant Array (DN)
+    description: |
+      Array containing the guide window signal resultants in units of DN. The
+      array has dimensions of (J, H, K, X, Y) where J is the number of science
+      resultants, H is the number of reads of the detector in a given science
+      resultant, K is the number of guide window reads in a science read, and X
+      and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+  amp33:
+    title: Guide Window Amplifier 33 Reference Pixel Resultant Array (DN)
+    description: |
+      Array containing the amplifier 33 reference pixel resultants in units of
+      DN. The array has dimensions of (J, H, K, X, Y) where J is the number of
+      science resultants, H is the number of reads of the detector in a given
+      science resultant, K is the number of guide window reads in a science
+      read, and X and Y are the pixel locations.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 5
+    unit: DN
+propertyOrder: [meta, pedestal_frames, signal_frames, amp33]
+flowStyle: block
+required: [meta, pedestal_frames, signal_frames, amp33]

--- a/src/rad/resources/schemas/guidewindow-1.3.0.yaml
+++ b/src/rad/resources/schemas/guidewindow-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/guidewindow.yaml

--- a/src/rad/resources/schemas/guidewindow_modes-1.0.0.yaml
+++ b/src/rad/resources/schemas/guidewindow_modes-1.0.0.yaml
@@ -1,1 +1,20 @@
-../../../../latest/guidewindow_modes.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/guidewindow_modes-1.0.0
+
+# Helper file to enumerate guide window modes for guidestar and guidewindow
+
+title: Guide Window Mode
+description: |
+  Type of guide window mode used during the exposure. This is based on
+  planned information from the Roman Planning and Scheduling Subsystem.
+type: string
+enum:
+  - WIM-ACQ
+  - WIM-TRACK
+  - WSM-ACQ-1
+  - WSM-ACQ-2
+  - WSM-TRACK
+  - DEFOCUSED-MODERATE
+  - DEFOCUSED-LARGE

--- a/src/rad/resources/schemas/guidewindow_modes-1.1.0.yaml
+++ b/src/rad/resources/schemas/guidewindow_modes-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/guidewindow_modes.yaml

--- a/src/rad/resources/schemas/l1_face_guidewindow-1.1.0.yaml
+++ b/src/rad/resources/schemas/l1_face_guidewindow-1.1.0.yaml
@@ -1,1 +1,340 @@
-../../../../latest/l1_face_guidewindow.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.1.0
+
+title: Level 1 FACE Guide Star Window Information schema
+
+datamodel_name: L1FaceGuidewindowModel
+
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          optical_element:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+            title: Wide Field Instrument (WFI) Optical Element
+            description: |
+              Optical element used during the exposure.
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: TBD
+            maxLength: 20
+            archive_catalog:
+              datatype: nvarchar(20)
+              destination: [GuideWindow.optical_element]
+          fgs_modes_used:
+            title: FGS Guiding Modes
+            description: |
+              List of unique FGS guiding modes used during the guide window exposure.
+            type: array
+            items:
+              type: string
+              enum:
+                [
+                  "NOT_CONFIGURED",
+                  "STANDBY",
+                  "WIM_ACQ_VW",
+                  "WIM_ACQ_NA",
+                  "WIM_TRK",
+                  "WIM_TRK_S",
+                  "WSM_ACQ_HC",
+                  "WSM_ACQ_VC",
+                  "WSM_TRK",
+                  "WIM_DFC",
+                ]
+              maxLength: 20
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: TBD
+            archive_catalog:
+              datatype: nvarchar(20)
+              destination: [GuideWindow.gw_fgs_modes_used]
+          ma_table_ids_used:
+            title: Used MA Table IDs
+            description: |
+              List of unique IDs for the guide window MA table used for this guide star.
+              IDs combine a "GW" prefix with a 4-digit zero-padded identifying integer.
+              The order matches that of 'fgs_modes_used'.
+            type: array
+            items:
+              type: string
+              maxLength: 10
+          gw_cycles_per_sci_read_used:
+            title: Guide Window Cycles per Science Read Used
+            description: |
+              List of the number of guide window pedestal and signal pairs per full frame read.
+              The order matches that of 'fgs_modes_used'.
+            type: array
+            items:
+              type: integer
+          guide_star_acq_num:
+            title: Guide Star Acquisition Number
+            description: |
+              Guide star acquisition number (1-9) for the guide window exposure.
+            type: integer
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: TBD
+            archive_catalog:
+              datatype: int
+              destination: [GuideWindow.gw_guide_star_acq_num]
+          guide_window_id:
+            title: Guide Window ID
+            description: |
+              A unique identification number of the guide window. This identifier combines the
+              visit identifier and guide star acquisition number, and is set in the visit information
+              uplinked to the observatory. As the number may be zero-padded, this value is saved as
+              a string. See technical report Roman-STScI-000193 "Roman Programmatic Data
+              Identification" for more information.
+            type: string
+            maxLength: 120
+            sdf:
+              special_processing: VALUE_REQUIRED
+              source:
+                origin: TBD
+            archive_catalog:
+              datatype: nvarchar(120)
+              destination: [GuideWindow.gw_guide_window_id]
+          detector_gw_files:
+            title: Detector Guide Window Files
+            description: |
+              Dictionary of the detector specific guide window files that were used in the
+              attitude corrections listed within this file. All 18 detector names are the keys
+              (e.g. WFI03, WFI11) and the values are either the string filename or None if no
+              guide window data is available for that detector.
+            anyOf:
+              - type: "null"
+              - type: object
+          expected_gw_acquisitions:
+            title: Detector Acquisition Guide Window Operation Mode
+            description: |
+              Dictionary of strings denoting how each detector guide window was expected to
+              be used for during the acquisition phase:
+                DET_FIXED - The guide window does not move from the defined location,
+                  e.g., for calibrations.
+                GUIDE - the guide star is in the guide window.
+                NOT_USED - then the guide window location is not used for guiding, i.e.,
+                  the detector is offline or not available.
+                SKY_FIXED the guide window follows the pattern relative to the other
+                  guide windows.
+            type: object
+          expected_gw_tracking:
+            title: Detector Tacking Guide Window Operation Mode
+            description: |
+              Dictionary of strings denoting how each detector guide window was expected to
+              be used for during the tracking phase:
+                DET_FIXED - The guide window does not move from the defined location,
+                  e.g., for calibrations.
+                GUIDE - the guide star is in the guide window.
+                NOT_USED - then the guide window location is not used for guiding, i.e.,
+                  the detector is offline or not available.
+                SKY_FIXED the guide window follows the pattern relative to the other
+                  guide windows.
+            type: object
+          # Optional
+          wsm_edge_used:
+            title: Guiding Spectral Edge
+            description: |
+              Spectral edge used for guiding with the prism or grism. Either "red" or "blue".
+            type: string
+            enum: ["blue", "red"]
+            maxLength: 5
+        required:
+          [
+            fgs_modes_used,
+            ma_table_ids_used,
+            gw_cycles_per_sci_read_used,
+            optical_element,
+            guide_star_acq_num,
+            guide_window_id,
+            detector_gw_files,
+            expected_gw_acquisitions,
+            expected_gw_tracking,
+          ]
+
+  face_data:
+    type: object
+    properties:
+      delta:
+        title: Best Fit F1 Axis Rotation
+        description: |
+          1D array of the best fit rotation about the F1 axis in radians.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+        unit: "rad"
+      delta2:
+        title: Best 2 DOF Fit F1 Axis Rotation
+        description: |
+          1D array of the best fit rotation about the F1 axis for a 2 degree
+          of freedom solution in radians.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+        unit: "rad"
+      epsilon:
+        title: Best Fit F2 Axis Rotation
+        description: |
+          1D array of the best fit rotation about the F2 axis in radians.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+        unit: "rad"
+      epsilon2:
+        title: Best 2 DOF Fit F2 Axis Rotation
+        description: |
+          1D array of the best fit rotation about the F2 axis for a 2 degree
+          of freedom solution in radians.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+        unit: "rad"
+      zeta:
+        title: Best Fit F3 Axis Rotation
+        description: |
+          1D array of the best fit rotation about the F3 axis in radians.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+        unit: "rad"
+      delta_var:
+        title: Delta Variance
+        description: |
+          1D array of the theoretical estimate of the variance in delta.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+      epsilon_var:
+        title: Epsilon Variance
+        description: |
+          1D array of the theoretical estimate of the variance in epsilon.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+      zeta_var:
+        title: Zeta Variance
+        description: |
+          1D array of the theoretical estimate of the variance in zeta.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+      horizontal_variance:
+        title: FGS Horizontal Variance
+        description: |
+          1D array of the horizontal residuals variance during the FGS attitude
+          error estimate.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+      vertical_variance:
+        title: FGS Vertical Variance
+        description: |
+          1D array of the vertical residuals variance during the FGS attitude
+          error estimate.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: float32
+        exact_datatype: true
+      num_stars_used:
+        title: Number of FGS Stars
+        description: |
+          1D array containing the number of stars used for FGS attitude error estimate.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: uint8
+        exact_datatype: true
+      num_centroid_cycles:
+        title: Number of Centroid Cycles
+        description: |
+          1D array containing the number of cycles of centroid residual sigma editing
+          that were performed.
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: uint8
+        exact_datatype: true
+      attitude_estimate_quality:
+        title: Quality Flag for Attitude Estimate
+        description: |
+          1D array containing the estimate for the quality of the FGS attitude error
+          estimate. Possible values include:
+            "AQ_DOF_3": Good Quality, 3 Degrees of Freedom
+            "AQ_DOF_2": Good Quality, 2 Degrees of Freedom
+            "AQ_DOF_1": Good Quality, 1 Degree of Freedom
+            "AQ_DEFAULT_BAD": Bad Quality
+            "AQ_TOO_FEW_STARS": Too Few Stars
+            "AQ_FAILED_IN_PHASE_TRANSITION": Failed in Phase Transition
+            "AQ_VIRTUAL_WINDOWING_BAD": Bad Virtual Windowing
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
+        ndim: 1
+        datatype: [ucs4, 30]
+        exact_datatype: true
+      centroid_times:
+        title: Centroid Times
+        description: |
+          1D array of times associated with the centroids used in the FACE calculation.
+          The centroid times should lie between the pedestal and signal resultant times.
+        type: array
+        items:
+          tag: tag:stsci.edu:asdf/time/time-1.*
+      fgs_op_phase:
+        title: FGS Guiding Modes
+        description: |
+          1D array of string operational phases used for each FACE calculation.
+          These strings can be used to distinguish the different phases of the guide star cycle.
+        type: array
+        items:
+          type: string
+          enum:
+            [
+              "NOT_CONFIGURED",
+              "STANDBY",
+              "WIM_ACQ_VW",
+              "WIM_ACQ_NA",
+              "WIM_TRK",
+              "WIM_TRK_S",
+              "WSM_ACQ_HC",
+              "WSM_ACQ_VC",
+              "WSM_TRK",
+              "WIM_DFC",
+            ]
+          maxLength: 20
+    required:
+      [
+        delta,
+        delta2,
+        epsilon,
+        epsilon2,
+        zeta,
+        delta_var,
+        epsilon_var,
+        zeta_var,
+        horizontal_variance,
+        vertical_variance,
+        num_stars_used,
+        num_centroid_cycles,
+        attitude_estimate_quality,
+        centroid_times,
+        fgs_op_phase,
+      ]
+propertyOrder: [meta, face_data]
+flowStyle: block
+required: [meta, face_data]

--- a/src/rad/resources/schemas/l1_face_guidewindow-1.2.0.yaml
+++ b/src/rad/resources/schemas/l1_face_guidewindow-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/l1_face_guidewindow.yaml

--- a/src/rad/resources/schemas/mosaic_basic-1.1.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.1.0.yaml
@@ -1,1 +1,238 @@
-../../../../latest/mosaic_basic.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.1.0
+
+title: Basic mosaic metadata keywords
+type: object
+
+properties:
+  time_first_mjd:
+    title: Earliest component image start time in the mosaic in MJD
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIMosaic.time_first_mjd,
+          SourceCatalog.time_first_mjd,
+          SegmentationMap.time_first_mjd,
+        ]
+  time_last_mjd:
+    title: Latest component image end time in the mosaic in MJD
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIMosaic.time_last_mjd,
+          SourceCatalog.time_last_mjd,
+          SegmentationMap.time_last_mjd,
+        ]
+  time_mean_mjd:
+    title: Mean of mid-times of component images in MJD
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIMosaic.time_mean_mjd,
+          SourceCatalog.time_mean_mjd,
+          SegmentationMap.time_mean_mjd,
+        ]
+  max_exposure_time:
+    title: Maximum component image exposure time in MJD
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIMosaic.max_exposure_time,
+          SourceCatalog.max_exposure_time,
+          SegmentationMap.max_exposure_time,
+        ]
+  mean_exposure_time:
+    title: Mean of component image exposure times in MJD
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination:
+        [
+          WFIMosaic.mean_exposure_time,
+          SourceCatalog.mean_exposure_time,
+          SegmentationMap.mean_exposure_time,
+        ]
+  visit:
+    title: Visit number within the observation, defined range of
+      values is 1..999; included in obs_id and visit_id as 'VVV'.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIMosaic.visit, SourceCatalog.visit, SegmentationMap.visit]
+  segment:
+    title: Segment Number within pass, defined range is 1..999;
+      included in obs_id and visit_id as 'SSS'.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination:
+        [WFIMosaic.segment, SourceCatalog.segment, SegmentationMap.segment]
+  pass:
+    title: Pass number within execution plan, defined range is 1..999;
+      included in obs_id and visit_id as 'AA'.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIMosaic.pass, SourceCatalog.pass, SegmentationMap.pass]
+  program:
+    title: Program number, defined range is 1..18445;
+      included in obs_id and visit_id as 'PPPPP'.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination:
+        [WFIMosaic.program, SourceCatalog.program, SegmentationMap.program]
+  survey:
+    title: Observation Survey
+    type: string
+    maxLength: 15
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination:
+        [WFIMosaic.survey, SourceCatalog.survey, SegmentationMap.survey]
+  optical_element:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 20
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination:
+        [
+          WFIMosaic.optical_element,
+          SourceCatalog.optical_element,
+          SegmentationMap.optical_element,
+        ]
+  instrument:
+    title: Instrument used to acquire the data
+    type: string
+    enum: [WFI]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 5
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination:
+        [
+          WFIMosaic.instrument_name,
+          SourceCatalog.instrument_name,
+          SegmentationMap.instrument_name,
+        ]
+  location_name:
+    title: Name of the skycell containing the mosaic
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 25
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination:
+        [
+          WFIMosaic.location_name,
+          SourceCatalog.location_name,
+          SegmentationMap.location_name,
+        ]
+  product_type:
+    title: Association product type
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 25
+    archive_catalog:
+      datatype: nvarchar(25)
+      destination:
+        [
+          WFIMosaic.product_type,
+          SourceCatalog.product_type,
+          SegmentationMap.product_type,
+        ]
+propertyOrder:
+  [
+    time_first_mjd,
+    time_last_mjd,
+    time_mean_mjd,
+    max_exposure_time,
+    mean_exposure_time,
+    visit,
+    segment,
+    pass,
+    program,
+    survey,
+    optical_element,
+    instrument,
+    location_name,
+    product_type,
+  ]
+flowStyle: block
+required:
+  [
+    time_first_mjd,
+    time_last_mjd,
+    time_mean_mjd,
+    max_exposure_time,
+    mean_exposure_time,
+    visit,
+    segment,
+    pass,
+    program,
+    survey,
+    optical_element,
+    instrument,
+    location_name,
+    product_type,
+  ]

--- a/src/rad/resources/schemas/mosaic_basic-1.2.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_basic.yaml

--- a/src/rad/resources/schemas/mosaic_segmentation_map-1.2.0.yaml
+++ b/src/rad/resources/schemas/mosaic_segmentation_map-1.2.0.yaml
@@ -1,1 +1,35 @@
-../../../../latest/mosaic_segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.2.0
+
+title: Segmentation map generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: MosaicSegmentationMapModel
+
+archive_meta: None
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          basic:
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+        required: [basic, program]
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/mosaic_segmentation_map-1.3.0.yaml
+++ b/src/rad/resources/schemas/mosaic_segmentation_map-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_segmentation_map.yaml

--- a/src/rad/resources/schemas/msos_stack-1.2.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.2.0.yaml
@@ -1,1 +1,54 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+      - type: object
+        properties:
+          image_list:
+            type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage]

--- a/src/rad/resources/schemas/msos_stack-1.3.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/observation-1.0.0.yaml
+++ b/src/rad/resources/schemas/observation-1.0.0.yaml
@@ -1,1 +1,240 @@
-../../../../latest/observation.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
+
+title: Observation Identifiers
+type: object
+properties:
+  observation_id:
+    title: Programmatic Observation Identifier
+    description: |
+      The format of the programmatic observation identifier
+      is "PPPPPCCAAASSSOOOVVVggsaaeee" where "PPPPP" is the program
+      number, "CC" is the execution plan number, "AAA" is the pass
+      number, "SSS" is the segment number, "OOO" is the observation
+      number, "VVV" is the visit number, "gg" is the visit file group,
+      "s" is the visit file sequence, "aa" is the visit file activity,
+      and "eeee" is the exposure number. The observation identifier is
+      the complete concatenation of the visit_id +
+      visit_file_statement (visit_file_group + visit_file_sequence +
+      visit_file_activity) + exposure.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 28
+    archive_catalog:
+      datatype: nvarchar(28)
+      destination: [WFIExposure.observation_id, GuideWindow.observation_id]
+  visit_id:
+    title: Visit Identifier
+    description: |
+      A unique identifier for a visit. The format is "PPPPPCCAAASSSOOOVVV" where
+      "PPPPP" is the program number, "CC" is the execution plan number, "AAA" is the pass number,
+      "SSS" is the segment number, "OOO" is the observation number, and "VVV" is the
+      visit number.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 19
+    archive_catalog:
+      datatype: nvarchar(19)
+      destination: [WFIExposure.visit_id, GuideWindow.visit_id]
+  program:
+    title: Program Number
+    description: |
+      Identifier for the observing program. A program is an
+      approved specification for a science, calibration, or
+      engineering investigation to be pursued using Roman Space
+      Telescope mission resources. The allowed range of program
+      numbers is 00001 to 18445 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.program, GuideWindow.program]
+  execution_plan:
+    title: Execution Plan Number
+    description: |
+      Identifier for the execution plan. An execution plan
+      is a version of the complete set of activities for a survey. A
+      survey may include portions of multiple execution plans. A new
+      execution plan is required whenever there is a change in the
+      program. The allowed range of execution plan numbers is 01 to 99
+      inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.execution_plan, GuideWindow.execution_plan]
+  pass:
+    title: Pass Number
+    description: |
+      Identifier for the pass. A pass is the collection of
+      activities generated from each iteration of a pass plan in the
+      Astronomer's Proposal Tool (APT). Multiple Passes may be
+      generated from the same Pass Plan to allow repetition or execute
+      at different orientations (via special requirements). The
+      allowed range of pass numbers is 001 to 999 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.pass, GuideWindow.pass]
+  segment:
+    title: Segment Number
+    description: |
+      Identifier for the segment. A segment is the sequence
+      of activities produced by each iteration of an Astronomer's
+      Proposal Tool (APT) segment plan in a pass. A segment may
+      include multiple traversals of mosaic pattern(s), with element
+      wheel moves occurring between observations. The allowed range of
+      segment numbers is 001 to 999 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.segment, GuideWindow.segment]
+  observation:
+    title: Observation Number
+    description: |
+      Identifier for the observation. An observation is a
+      single traversal of a mosaic pattern, using a single, constant
+      instrument configuration (i.e., with no element wheel moves).
+      The allowed range of observation numbers is 001 to 999
+      inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.observation, GuideWindow.observation]
+  visit:
+    title: Visit Number
+    description: |
+      A visit is the smallest scheduling unit for Roman,
+      which is a sequence of exposures executed without interruption,
+      including dither patterns. A visit corresponds to one tile of
+      the selected mosaic pattern. The allowed range of visit numbers
+      is 001 to 999 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.visit, GuideWindow.visit]
+  visit_file_group:
+    title: Visit File Group
+    description: |
+      The visit file group identifies the sequence group
+      within the visit file. The allowed range of visit file group
+      numbers is 01 to 99 inclusive.
+    type: integer
+    maxLength: 3
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: smallint
+      destination: [WFIExposure.visit_file_group, GuideWindow.visit_file_group]
+  visit_file_sequence:
+    title: Visit File Sequence
+    description: |
+      The visit file sequence identifies the sequence within
+      the visit file group. A value of 1 indicates a prime instrument
+      exposure, and a value greater than 1 indicates a parallel
+      instrument exposure. The allowed range of visit file sequence
+      numbers of 1 to 5 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: tinyint
+      destination:
+        [WFIExposure.visit_file_sequence, GuideWindow.visit_file_sequence]
+  visit_file_activity:
+    title: Visit File Activity
+    description: |
+      The visit file activity number identifies the activity
+      within the visit file sequence. The allowed range of visit file
+      activity numbers is 01 to 99 inclusive.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 2
+    archive_catalog:
+      datatype: nvarchar(2)
+      destination:
+        [WFIExposure.visit_file_activity, GuideWindow.visit_file_activity]
+  exposure:
+    title: Exposure Number
+    description: |
+      An exposure is a single multi-accumulation (MA) table
+      sequence of the detector array at a single dither point in the
+      dither pattern. The allowed range of exposure numbers is 0001 to
+      9999 inclusive.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: int
+      destination:
+        [WFIExposure.observation_exposure, GuideWindow.observation_exposure]
+propertyOrder:
+  [
+    observation_id,
+    visit_id,
+    program,
+    execution_plan,
+    pass,
+    segment,
+    observation,
+    visit,
+    visit_file_group,
+    visit_file_sequence,
+    visit_file_activity,
+    exposure,
+  ]
+flowStyle: block
+required:
+  [
+    observation_id,
+    visit_id,
+    program,
+    execution_plan,
+    pass,
+    segment,
+    observation,
+    visit,
+    visit_file_group,
+    visit_file_sequence,
+    visit_file_activity,
+    exposure,
+  ]

--- a/src/rad/resources/schemas/observation-1.1.0.yaml
+++ b/src/rad/resources/schemas/observation-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/observation.yaml

--- a/src/rad/resources/schemas/ramp_fit_output-1.2.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.2.0.yaml
@@ -1,1 +1,130 @@
-../../../../latest/ramp_fit_output.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
+
+title: Ramp Fit Output Schema
+
+datamodel_name: RampFitOutputModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+  slope:
+    title: Slope for Specific Segment (electrons / s)
+    description: |
+      Slope of a specific segment for a ramp with uneven resultants, in units of
+      electrons per second. A segment is a set of contiguous resultants where
+      none of the resultants are saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  sigslope:
+    title: Uncertainty on Slope for Specific Segment (electrons / s)
+    description: |
+      Uncertainty on slope for specific segment for a ramp with uneven
+      resultants in units of electrons per second. A segment is a set of
+      contiguous resultants where none of the resultants are saturated or cosmic
+      ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  yint:
+    title: Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Y-intercept derived for a specific segment (electrons). A segment is a set
+      of contiguous resultants where none of the resultants are saturated or
+      cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  sigyint:
+    title: Uncertainty on Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Uncertainty on Y-intercept derived for a specific segment (electrons). A
+      segment is a set of contiguous resultants where none of the resultants are
+      saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  pedestal:
+    title: Pedestal Array (electrons)
+    description: |
+      Signal at zero exposure time for each pixel in electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  weights:
+    title: Weights for Segment Specific Fit
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  crmag:
+    title: Approximate Cosmic Ray Magnitudes (AB magnitude)
+    description: |
+      The magnitude of each segment that was flagged as having a cosmic ray hit.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  var_poisson:
+    title: Poisson Variance Associated with a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Poisson variance associated with a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+  var_rnoise:
+    title: Read Noise Variance Associated for a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Read noise-associated variance for a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+required:
+  [
+    meta,
+    slope,
+    sigslope,
+    yint,
+    sigyint,
+    pedestal,
+    weights,
+    crmag,
+    var_poisson,
+    var_rnoise,
+  ]
+propertyOrder:
+  [
+    meta,
+    slope,
+    sigslope,
+    yint,
+    sigyint,
+    pedestal,
+    weights,
+    crmag,
+    var_poisson,
+    var_rnoise,
+  ]
+flowStyle: block

--- a/src/rad/resources/schemas/ramp_fit_output-1.3.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp_fit_output.yaml

--- a/src/rad/resources/schemas/rcs-1.0.0.yaml
+++ b/src/rad/resources/schemas/rcs-1.0.0.yaml
@@ -1,1 +1,79 @@
-../../../../latest/rcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.0.0
+
+title: Relative Calibration System Information
+type: object
+properties:
+  active:
+    title: Status of the Relative Calibration System (RCS)
+    description: |
+      A boolean flag to indicate if the Relative Calibration
+      System (RCS) is on (True) or off (False) during the exposure.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nchar(1)
+      destination: [WFIExposure.active]
+  electronics:
+    title: Relative Calibration System (RCS) Electronics Side
+    description: |
+      The active redundant electronics used to control the
+      Relative Calibration System (RCS). Values may be "A" or "B" if
+      the RCS is on, and "N/A" if the RCS is off.
+    anyOf:
+      - type: string
+        enum: ["A", "B", None]
+      - type: "null"
+    maxLength: 5
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination: [WFIExposure.electronics]
+  bank:
+    title: Light Emitting Diode (LED) Bank Selection
+    description: |
+      The bank of light emitting diodes (LEDs) selected in
+      the program specification in the Astronomer's Proposal Tool
+      (APT). Values may be either "1" or "2" if the RCS is on, and
+      "N/A" if the RCS is off.
+    anyOf:
+      - type: string
+        enum: ["1", "2", None]
+      - type: "null"
+    maxLength: 5
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination: [WFIExposure.bank]
+  led:
+    title: Light Emitting Diode (LED) Passband
+    description: |
+      The light emitting diode (LED) passband selected in
+      the program specification in the Astronomer's Proposal Tool
+      (APT). Values are integer strings between "1" and "6" inclusive,
+      when the RCS is on, and "N/A" when the RCS is off.
+    anyOf:
+      - type: string
+        enum: ["1", "2", "3", "4", "5", "6", None]
+      - type: "null"
+    maxLength: 5
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination: [WFIExposure.led]
+  counts:
+    title: Light Emitting Diode (LED) Flux (DN)
+    description: |
+      The integrated number of counts of the light emitting
+      diode (LED) selected in the program specification in the
+      Astronomer's Proposal Tool (APT). Values are between 0 and
+      65,535 in units of DN.
+    type: integer
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.counts]
+propertyOrder: [active, electronics, bank, led, counts]
+flowStyle: block
+required: [active, electronics, bank, led, counts]

--- a/src/rad/resources/schemas/rcs-1.1.0.yaml
+++ b/src/rad/resources/schemas/rcs-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/rcs.yaml

--- a/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/abvegaoffset-1.0.0.yaml
@@ -1,1 +1,37 @@
-../../../../../latest/reference_files/abvegaoffset.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.0.0
+
+title: AB Vega Offset Reference File Schema
+
+datamodel_name: AbvegaoffsetRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [ABVEGAOFFSET]
+  data:
+    type: object
+    patternProperties:
+      "^(F062|F087|F106|F129|F146|F158|F184|F213|GRISM|PRISM|DARK)$":
+        type: object
+        properties:
+          abvega_offset:
+            title: AB-Vega Magntiude Offset
+            description: Magnitude difference between the AB and Vega magnitude
+              systems. Found by calculating the AB magnitude of Vega within
+              the optical element bandpass.
+            anyOf:
+              - type: number
+              - type: "null"
+        required: [abvega_offset]
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/abvegaoffset-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/abvegaoffset-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/abvegaoffset.yaml

--- a/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/apcorr-1.0.0.yaml
@@ -1,1 +1,83 @@
-../../../../../latest/reference_files/apcorr.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.0.0
+
+title: Aperture Correction Reference File Schema
+
+datamodel_name: ApcorrRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [APCORR]
+  data:
+    type: object
+    patternProperties:
+      "^(F062|F087|F106|F129|F146|F158|F184|F213|GRISM|PRISM|DARK)$":
+        type: object
+        properties:
+          ap_corrections:
+            title: Aperture Corrections
+            description: The aperture correction for each enclosed energy
+              fraction, corresponding to 1 / ee_fractions.
+            anyOf:
+              - type: "null"
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+          ee_fractions:
+            title: Enclosed Energy Fractions
+            description: Fractions of the enclosed energy of the PSF at which
+              to estimate the aperture correction and enclosed energy radii.
+            anyOf:
+              - type: "null"
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+          ee_radii:
+            title: Enclosed Energy Radii
+            description: Radius, in pixels, within which the enclosed energy
+              fractions are met. The indexing matches that of
+              "ee_fractions".
+            anyOf:
+              - type: "null"
+              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+                datatype: float64
+                exact_datatype: true
+                ndim: 1
+          sky_background_rin:
+            title: Inner Radius for the Sky Background
+            description: Inner radius, in pixels, to use when estimating the
+              local sky background within an annulus between this
+              radius and "sky_background_rout".
+            anyOf:
+              - type: number
+              - type: "null"
+          sky_background_rout:
+            title: Outer Radius for the Sky Background
+            description: Outer radius, in pixels, to use when estimating the
+              local sky background within an annulus between this
+              radius and "sky_background_rin".
+            anyOf:
+              - type: number
+              - type: "null"
+        required:
+          [
+            ap_corrections,
+            ee_fractions,
+            ee_radii,
+            sky_background_rin,
+            sky_background_rout,
+          ]
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/apcorr-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/apcorr-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/apcorr.yaml

--- a/src/rad/resources/schemas/reference_files/dark-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.1.0.yaml
@@ -1,1 +1,81 @@
-../../../../../latest/reference_files/dark.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
+
+title: Dark Reference File Schema
+
+datamodel_name: DarkRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [DARK]
+          exposure:
+            type: object
+            properties:
+              ma_table_name:
+                title: Multi-Accumulation Table Name
+                description: |
+                  The name of the MA Table used. Not a unique identifier; see
+                  ma_table_number.
+                type: string
+              ma_table_number:
+                title: Multi-Accumulation Table Number
+                description: |
+                  The unique number of the MA Table used. A modification to a MA
+                  Table that keeps the same name will have a new
+                  ma_table_number.
+                type: integer
+            required: [ma_table_name, ma_table_number]
+        required: [exposure]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+  data:
+    title: Dark Current Array
+    description: |
+      The dark current array represents the integrated number of counts due to
+      the accumulation of dark current electrons in the pixels.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: DN
+  dq:
+    title: 2-D Data Quality Array
+    description: |
+      The 2-D data quality array for the Dark Current Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dark_slope:
+    title: Dark Current Rate Array
+    description: |
+      The dark current rate array represents the slope of the integrated number
+      of counts due to the accumulation of dark current electrons in the pixels
+      calculated from slope fitting the Dark Current Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN / s
+  dark_slope_error:
+    title: Dark Current Rate Uncertainty Array
+    description: |
+      The uncertainty calculated from the slope fitting of the Dark Current
+      Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN / s
+required: [meta, data, dq, dark_slope, dark_slope_error]
+flowStyle: block
+propertyOrder: [meta, data, dq, dark_slope, dark_slope_error]

--- a/src/rad/resources/schemas/reference_files/dark-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/dark-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/dark.yaml

--- a/src/rad/resources/schemas/reference_files/distortion-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.1.0.yaml
@@ -1,1 +1,32 @@
-../../../../../latest/reference_files/distortion.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.1.0
+
+title: Distortion Reference Schema
+
+datamodel_name: DistortionRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+
+        input_units: "pixel"
+        output_units: "arcsec"
+
+        properties:
+          reftype:
+            type: string
+            enum: [DISTORTION]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+  coordinate_distortion_transform:
+    title: Distortion Transform Model with inputs in "pixel" and outputs in "arcsec"
+    description: |
+      The astropy.modeling.Model instance of of the distortion transform model.
+    type: object
+required: [meta, coordinate_distortion_transform]
+flowStyle: block
+propertyOrder: [meta, coordinate_distortion_transform]

--- a/src/rad/resources/schemas/reference_files/distortion-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/distortion-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/distortion.yaml

--- a/src/rad/resources/schemas/reference_files/epsf-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/epsf-1.1.0.yaml
@@ -1,1 +1,78 @@
-../../../../../latest/reference_files/epsf.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.1.0
+
+title: ePSF Reference File Schema
+
+datamodel_name: EpsfRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [EPSF]
+          oversample:
+            title: Oversampling Factor
+            description: Factor by which the WFI pixels have been oversampled
+              to generate the PSF.
+            type: integer
+          spectral_type:
+            title: Spectral Type
+            description: Spectral type(s) of the SEDs used to create the ePSF(s)
+              with chromatic variations. See the Roman Documentation system (RDox)
+              for more information on mapping spectral types to colors in the
+              WFI filter system.
+            type: array
+            items:
+              type: string
+          defocus:
+            title: Defocus Waves
+            description: Number of defocus waves applied to the PSF.
+            type: array
+            items:
+              type: integer
+          pixel_x:
+            title: X Position
+            description: X-axis position of the PSF models. The order of the
+              positions corresponds to the order of the PSFs in the psf array.
+            type: array
+            items:
+              type: number
+          pixel_y:
+            title: Y Position
+            description: Y-axis position of the PSF models. The order of the
+              positions corresponds to the order of the PSFs in the psf array.
+            type: array
+            items:
+              type: number
+        required: [pixel_x, pixel_y]
+  psf:
+    title: ePSF Stamps
+    description: Postage stamps of ePSF models. The 5-dimensional array is
+      ordered by (defocus, spectral_type, grid_index, y, x), where defocus
+      and spectral_type are in the file metadata, grid_index is the index
+      of the pixel_x and pixel_y positions in the file metadata, and
+      y and x are the axes of the 2-D postage stamp ePSF.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 5
+  extended_psf:
+    title: Extended ePSF Stamp
+    description: Postage stamp of a bright ePSF model with extended wings.
+      If present, a single, in-focus, monochromatic ePSF is generated at
+      the center of the detector.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+required: [meta, psf]
+flowStyle: block
+propertyOrder: [meta, psf, extended_psf]

--- a/src/rad/resources/schemas/reference_files/epsf-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/epsf-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/epsf.yaml

--- a/src/rad/resources/schemas/reference_files/flat-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.1.0.yaml
@@ -1,1 +1,49 @@
-../../../../../latest/reference_files/flat.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.1.0
+
+title: Flat Reference File Schema
+
+datamodel_name: FlatRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [FLAT]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+  data:
+    title: Flat Data Array
+    description: |
+      The Flat Data Array represents the small and large pixel-to-pixel
+      mitigations necessary to account for wavelength dependent detector
+      sensitivity and distortions in the optical path.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+  dq:
+    title: 2-D Data Quality Array
+    description: |
+      The 2-D data quality array for the Flat Data Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Flat Data Uncertainty Array
+    description: |
+      The uncertainty in the Flat Data Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+required: [meta, data, dq, err]
+flowStyle: block
+propertyOrder: [meta, data, dq, err]

--- a/src/rad/resources/schemas/reference_files/flat-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/flat-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/flat.yaml

--- a/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.0.0.yaml
@@ -1,1 +1,32 @@
-../../../../../latest/reference_files/gain.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+
+title: Gain Reference File Schema
+
+datamodel_name: GainRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [GAIN]
+  data:
+    title: Gain Data Array
+    description: |
+      The Gain Data Array represents the pixel to pixel conversion from digital
+      numbers (DN) to electrons (e). The units are e/DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: electron / DN
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/gain-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/gain-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/gain.yaml

--- a/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverselinearity-1.0.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/reference_files/inverselinearity.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.0.0
+
+title: Inverse Linearity Correction Reference Schema
+
+datamodel_name: InverselinearityRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+
+        input_units: "DN"
+        output_units: "DN"
+
+        properties:
+          reftype:
+            type: string
+            enum: [INVERSELINEARITY]
+  coeffs:
+    title: Inverse Linearity Coefficients
+    description: |
+      Contains the coefficients of a polynomial which describe the non-linear
+      response of each pixel to a linear signal. Both the input to and output
+      from the polynomial are in units of DN. The coefficients have units that
+      contain various powers of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    # Dimensions: numcoeffs, ysize, xsize
+    ndim: 3
+  dq:
+    title: Two Dimensional Data Quality Array for All Resultants
+    description: |
+      Two Dimensional data Quality Array for all Resultants
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+required: [meta, coeffs, dq]
+flowStyle: block
+propertyOrder: [meta, coeffs, dq]

--- a/src/rad/resources/schemas/reference_files/inverselinearity-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/inverselinearity-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/inverselinearity.yaml

--- a/src/rad/resources/schemas/reference_files/ipc-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ipc-1.1.0.yaml
@@ -1,1 +1,32 @@
-../../../../../latest/reference_files/ipc.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.1.0
+
+title: Interpixel Capacitance Reference File Schema
+
+datamodel_name: IpcRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [IPC]
+  data:
+    title: Interpixel Capacitance Kernel Array
+    description: |
+      The kernel array used for convolving data to correct for interpixel
+      capacitance of neighboring pixels.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/ipc-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ipc-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/ipc.yaml

--- a/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/linearity-1.0.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/reference_files/linearity.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.0.0
+
+title: Linearity Correction Reference Schema
+
+datamodel_name: LinearityRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+
+        input_units: "DN"
+        output_units: "DN"
+
+        properties:
+          reftype:
+            type: string
+            enum: [LINEARITY]
+  coeffs:
+    title: Linearity Coefficients
+    description: |
+      Contains the coefficients of a polynomial to correct the non-linear
+      response of each pixel to a linear signal. Both the input to and output
+      from the polynomial are in units of DN. The coefficients have units that
+      contain various powers of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    # Dimensions: numcoeffs, ysize, xsize
+    ndim: 3
+  dq:
+    title: Two Dimensional Data Quality Array for All Resultants
+    description: |
+      Two Dimensional data Quality Array for all Resultants
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+required: [meta, coeffs, dq]
+flowStyle: block
+propertyOrder: [meta, coeffs, dq]

--- a/src/rad/resources/schemas/reference_files/linearity-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/linearity-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/linearity.yaml

--- a/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.0.0.yaml
@@ -1,1 +1,31 @@
-../../../../../latest/reference_files/mask.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+
+title: Mask Reference File Schema
+
+datamodel_name: MaskRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [MASK]
+  dq:
+    title: Mask Data Quality Array
+    description: |
+      The Mask Data Quality Array is the pixel value of the sum of bit integer
+      dq flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+required: [meta, dq]
+flowStyle: block
+propertyOrder: [meta, dq]

--- a/src/rad/resources/schemas/reference_files/mask-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/mask-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/mask.yaml

--- a/src/rad/resources/schemas/reference_files/matable-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/matable-1.0.0.yaml
@@ -1,1 +1,282 @@
-../../../../../latest/reference_files/matable.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.0.0
+
+title: Multiple Accumulation Table Reference File Schema
+
+datamodel_name: MATableRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [MATABLE]
+  guide_window_tables:
+    title: Guide Window Tables
+    description: |
+      Dictionary of guide window MA Tables keyed by their table ID
+      (a unique string identifier combining "GW" and a four-digit,
+      zero-padded integer between 1-9999)
+    type: object
+    patternProperties:
+      "^GW([0-9]{4})$":
+        type: object
+        properties:
+          effective_pedestal_exposure_time:
+            title: Effective Pedestal Exposure Time
+            description: |
+              Time in seconds after the last pedestal reset to the arithmetic
+              mean time of all pedestal reads.
+            type: number
+          effective_signal_exposure_time:
+            title: Effective Signal Exposure Time
+            description: |
+              Time in seconds after the last pedestal reset to the arithmetic
+              mean time of all signal reads (excluding skipped signal reads).
+              This time includes the time taken to read science detector rows
+              (the number of which is defined by "science_block_size").
+            type: number
+          gw_readout_time:
+            title: Guide Window Readout Time
+            description: |
+              Time in seconds required to read out the guide window.
+            type: number
+          ma_table_description:
+            title: MA Table Description
+            description: |
+              Longer description of the MA table provided by GSFC.
+            type: string
+          ma_table_name:
+            title: MA Table Name
+            description: |
+              Name of the MA table provided by GSFC. This may not be unique.
+            type: string
+          ma_table_number:
+            title: MA Table Number
+            description: |
+              Unique integer assigned to the MA table.
+              Last 4 characters of the MA table ID. (1-9999)
+            type: integer
+          fsw_slot_number:
+            title: Flight Software Index
+            description: |
+              Integer index in the flight software where the MA table
+              information is stored on-board (0-99).
+            type: integer
+          num_gw_columns:
+            title: Number of Guide Window Columns
+            description: |
+              Number of pixels that a guide window box extends in y-space.
+            type: integer
+          num_gw_rows:
+            title: Number of Guide Window Rows
+            description: |
+              Number of pixels that a guide window box extends in x-space.
+            type: integer
+          num_pedestal_reads:
+            title: Number of Pedestal Reads
+            description: |
+              Number of frames averaged in the pedestal resultant.
+            type: integer
+          num_pre_pedestal_reset_reads:
+            title: Number of Pre-pedestal Reset Reads
+            description: |
+              Number of reset reads prior to the first pedestal frame.
+            type: integer
+          num_pre_signal_skips:
+            title: Number of Pre-Signal Skips
+            description: |
+              Number of skipped/discarded reads before the first signal frame is saved.
+            type: integer
+          num_signal_reads:
+            title: Number of Signal Reads
+            description: |
+              Number of frames averaged in the signal resultant.
+            type: integer
+          science_block_size:
+            title: Science Block Size
+            description: |
+              Number of rows to read before a guide window execution.
+            type: integer
+        required:
+          [
+            effective_pedestal_exposure_time,
+            effective_signal_exposure_time,
+            gw_readout_time,
+            ma_table_description,
+            ma_table_name,
+            ma_table_number,
+            fsw_slot_number,
+            num_gw_columns,
+            num_gw_rows,
+            num_pedestal_reads,
+            num_pre_pedestal_reset_reads,
+            num_pre_signal_skips,
+            num_signal_reads,
+            science_block_size,
+          ]
+  science_tables:
+    title: Science Tables
+    description: |
+      Dictionary of science MA Tables keyed by their table ID
+      (a unique string identifier combining "SCI" and a four-digit,
+      zero-padded integer between 1-9999)
+    type: object
+    patternProperties:
+      "^SCI([0-9]{4})$":
+        type: object
+        properties:
+          accumulated_exposure_time:
+            title: Accumulated Exposure Time
+            description: |
+              Times in seconds after the reference read to the last read in each resultant.
+            type: array
+            items:
+              type: number
+          effective_exposure_time:
+            title: Effective Exposure Time
+            description: |
+              Times in seconds after the reference read to the arithmetic mean time of
+              all reads averaged into each resultant.
+            type: array
+            items:
+              type: number
+          frame_time:
+            title: Frame Time
+            description: |
+              The MA table dependent duration, in seconds, of a single sample read.
+            type: number
+          integration_duration:
+            title: Integration Duration
+            description: |
+              Time in seconds of the last read in each resultant including
+              all reset reads and the reference read.
+            type: array
+            items:
+              type: number
+          ma_table_description:
+            title: MA Table Description
+            description: |
+              Longer description of the MA table provided by GSFC.
+            type: string
+          ma_table_name:
+            title: MA Table Name
+            description: |
+              Name of the MA table provided by GSFC. This may not be unique.
+            type: string
+          ma_table_number:
+            title: MA Table Number
+            description: |
+              Unique integer assigned to the MA table.
+              Last 4 characters of the MA table ID. (1-9999)
+            type: integer
+          fsw_slot_number:
+            title: Flight Software Index
+            description: |
+              Integer index in the flight software where the MA table
+              information is stored on-board (0-99).
+            type: integer
+          min_science_resultants:
+            title: Minimum Science Resultants
+            description: |
+              Minimum number of science resultants that is recommended for use.
+            type: integer
+          num_pre_science_reads:
+            title: Number of Pre-science Reads
+            description: |
+              Number of reference reads taken before the science reads. Almost always 0 or 1.
+            type: integer
+          num_pre_science_resultants:
+            title: Number of Pre-science Resultants
+            description: |
+              Number of reference resultants that are downlinked with the table. Almost always 0 or 1.
+            type: integer
+          num_science_resultants:
+            title: Number of Science Resultants
+            description: |
+              Maximum number of science resultants allowed in the MA table. Will be the same as the
+              length of "science_read_pattern" by definition.
+            type: integer
+          observing_mode:
+            title: Observing Mode
+            description: |
+              Fine Guidance System (FGS) mode for which the MA table should be used. Each FGS mode
+              uses a different size of guide window resulting in different frame readout times.
+              Either "DEFOCUS" for defocused mode, "WIM" for imaging mode, "WSM" for spectroscopy mode,
+              or "WIM|WSM" for mode agnostic tables.
+            type: string
+          pre_science_read_is_reference:
+            title: Pre-science Read is Reference
+            description: |
+              List of true or false to indicate which pre-science read is used as the reference read
+              to be subtracted from all science reads.
+            type: array
+            items:
+              type: boolean
+          pre_science_read_is_resultant:
+            title: Pre-science Read is Resultant
+            description: |
+              List of true or false indicating which pre-science reads are resultants and downlinked.
+            type: array
+            items:
+              type: boolean
+          pre_science_read_types:
+            title: Pre-science Read Types
+            description: |
+              List of strings for all pre-science read types. Either "reset_read" or "read".
+            type: array
+            items:
+              type: string
+          pre_science_time_after_reset:
+            title: Pre-science Time After Reset
+            description: |
+              Time in seconds between the end of the last reset read and the start of
+              the first science read.
+            type: number
+          reset_frame_time:
+            title: Reset Frame Time
+            description: |
+              WFI reset time in seconds.
+            type: number
+          science_read_pattern:
+            title: Science Read Rattern
+            description: |
+              Contains the read numbers of each resultant and numbered such that the
+              first science read is always read 1. (e.g. a read pattern starting
+              at 2 would signify the first science read is skipped)
+            type: array
+            items:
+              type: array
+              items:
+                type: integer
+        required:
+          [
+            accumulated_exposure_time,
+            effective_exposure_time,
+            frame_time,
+            integration_duration,
+            ma_table_description,
+            ma_table_name,
+            ma_table_number,
+            fsw_slot_number,
+            min_science_resultants,
+            num_pre_science_reads,
+            num_pre_science_resultants,
+            num_science_resultants,
+            observing_mode,
+            pre_science_read_is_reference,
+            pre_science_read_is_resultant,
+            pre_science_read_types,
+            pre_science_time_after_reset,
+            reset_frame_time,
+            science_read_pattern,
+          ]
+required: [meta, guide_window_tables, science_tables]
+flowStyle: block
+propertyOrder: [meta, guide_window_tables, science_tables]

--- a/src/rad/resources/schemas/reference_files/matable-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/matable-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/matable.yaml

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.1.0.yaml
@@ -1,1 +1,51 @@
-../../../../../latest/reference_files/pixelarea.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.1.0
+
+title: Pixel Area Reference Schema
+
+datamodel_name: PixelareaRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [AREA]
+          photometry:
+            type: object
+            properties:
+              pixelarea_steradians:
+                title: Pixel Area (steradians)
+                description: |
+                  The nominal pixel area in steradians.
+                anyOf:
+                  - type: number
+                    unit: sr
+                  - type: "null"
+              pixelarea_arcsecsq:
+                title: Pixel Area (arcsec^2)
+                description: The nominal pixel area in arcec^2.
+                anyOf:
+                  - type: number
+                    unit: arcsec**2
+                  - type: "null"
+            required: [pixelarea_steradians, pixelarea_arcsecsq]
+        required: [photometry]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+  data:
+    title: Pixel Area Array
+    description: |
+      Pixel area in units of of either arcseconds or steradians.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/pixelarea-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/pixelarea-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/pixelarea.yaml

--- a/src/rad/resources/schemas/reference_files/readnoise-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.1.0.yaml
@@ -1,1 +1,32 @@
-../../../../../latest/reference_files/readnoise.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
+
+title: Read Noise Reference File Schema
+
+datamodel_name: ReadnoiseRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            enum: [READNOISE]
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
+  data:
+    title: Read Noise Data Array
+    description: |
+      The pixel-by-pixel map read noise data array is used in estimating the
+      expected noise in each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/reference_files/readnoise-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/readnoise-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/readnoise.yaml

--- a/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.0.0.yaml
@@ -1,1 +1,78 @@
-../../../../../latest/reference_files/ref_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+
+title: Common Reference File Metadata Properties
+
+type: object
+properties:
+  reftype:
+    title: Reference File Type
+    description: |
+      The capitalized string of the reference file type (e.g., DARK).
+    type: string
+  pedigree:
+    title: Pedigree
+    description: |
+      The pedigree of the reference file (e.g., GROUND).
+    type: string
+    enum: [GROUND, MODEL, DUMMY, SIMULATION]
+  description:
+    title: Description
+    description: |
+      A string describing the reference file, its intended usage, etc.
+    type: string
+  author:
+    title: Author
+    description: |
+      The author of who or what created the reference file.
+    type: string
+  useafter:
+    title: Use After Date
+    description: |
+      The use after date of the reference file for CRDS best references
+      matching.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+  telescope:
+    title: Telescope
+    description: |
+      The telescope data used to select reference files, e.g. ROMAN for the
+      Nancy Grace Roman Space Telescope.
+    anyOf:
+      - tag: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+      - type: string
+        enum: [ROMAN]
+  origin:
+    title: Organization
+    description: |
+      The organization responsible for creating the file, e.g. STSCI for the
+      Space Telescope Science Institute.
+    type: string
+  instrument:
+    type: object
+    properties:
+      name:
+        title: Instrument
+        description: |
+          The Wide Field Instrument (WFI).
+        type: string
+        enum: [WFI]
+      detector:
+        allOf:
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+        title: Detector
+        description: |
+          The numbered WFI detector in the focal plane (e.g., WFI01 for SCA 01).
+    required: [name, detector]
+required:
+  [
+    reftype,
+    author,
+    description,
+    pedigree,
+    useafter,
+    telescope,
+    origin,
+    instrument,
+  ]

--- a/src/rad/resources/schemas/reference_files/ref_common-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_common-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/ref_common.yaml

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.1.0.yaml
@@ -1,1 +1,29 @@
-../../../../../latest/reference_files/ref_exposure_type.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type-1.1.0
+
+title: Exposure Type Reference Schema
+
+type: object
+properties:
+  exposure:
+    type: object
+    properties:
+      type:
+        allOf:
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/exposure_type-1.1.0
+        title: WFI Mode
+        description: |
+          The type of data taken with the WFI. Allowed values are WFI_IMAGE for
+          imaging mode, WFI_GRISM and WFI_PRISM for spectral mode, WFI_DARK for
+          dark exposures, WFI_FLAT for flat fields, and WFI_WFSC.
+      p_exptype:
+        title: WFI Mode for CRDS
+        description: |
+          The potentially multiple mode strings applied to data for reference
+          file matching in CRDS. Modes are separated by "|".
+        type: string
+        pattern: "^((WFI_IMAGE|WFI_SPECTRAL|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC|WFI_DARK|WFI_GRISM|WFI_PRISM)\\s*\\|\\s*)+$"
+    required: [type, p_exptype]
+required: [exposure]

--- a/src/rad/resources/schemas/reference_files/ref_exposure_type-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_exposure_type-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/ref_exposure_type.yaml

--- a/src/rad/resources/schemas/reference_files/ref_optical_element-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_optical_element-1.1.0.yaml
@@ -1,1 +1,16 @@
-../../../../../latest/reference_files/ref_optical_element.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_optical_element-1.1.0
+
+title: Optical Element Reference Schema
+
+type: object
+properties:
+  instrument:
+    type: object
+    properties:
+      optical_element:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+    required: [optical_element]
+required: [instrument]

--- a/src/rad/resources/schemas/reference_files/ref_optical_element-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/ref_optical_element-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/ref_optical_element.yaml

--- a/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/refpix-1.0.0.yaml
@@ -1,1 +1,50 @@
-../../../../../latest/reference_files/refpix.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.0.0
+
+title: Reference Pixel Correction Reference Schema
+
+# NOTE: this needs titles and descriptions added.
+
+datamodel_name: RefpixRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+
+        input_units: "DN"
+        output_units: "DN"
+
+        properties:
+          reftype:
+            type: string
+            enum: [REFPIX]
+
+  gamma:
+    title: Left column correction coefficients
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: complex128
+    exact_datatype: true
+    ndim: 2
+
+  zeta:
+    title: Right column correction coefficients
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: complex128
+    exact_datatype: true
+    ndim: 2
+
+  alpha:
+    title: Reference output correction coefficients
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: complex128
+    exact_datatype: true
+    ndim: 2
+
+required: [meta, gamma, zeta, alpha]
+flowStyle: block
+propertyOrder: [meta, gamma, zeta, alpha]

--- a/src/rad/resources/schemas/reference_files/refpix-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/refpix-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/refpix.yaml

--- a/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.0.0.yaml
@@ -1,1 +1,40 @@
-../../../../../latest/reference_files/saturation.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.0.0
+
+title: Saturation Reference File Schema
+
+datamodel_name: SaturationRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [SATURATION]
+  data:
+    title: Saturation Threshold Array
+    description: |
+      The pixel level threshold for determining saturation before non-linearity
+      corrections are applied.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: DN
+  dq:
+    title: 2-D Data Quality Array
+    description: |
+      The 2-D data quality array for the Saturation Threshold Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+required: [meta, data, dq]
+flowStyle: block
+propertyOrder: [meta, data, dq]

--- a/src/rad/resources/schemas/reference_files/saturation-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/saturation-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/saturation.yaml

--- a/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/superbias-1.0.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/reference_files/superbias.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.0.0
+
+title: Super-Bias Reference Schema
+
+datamodel_name: SuperbiasRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [BIAS]
+  data:
+    title: Two Dimensional Bias Array
+    description: |
+      Two Dimensional Bias Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+  dq:
+    title: Two Dimensional Quality Array for all Resultants
+    description: |
+      Two Dimensional Quality Array for all Resultants.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Two Dimensional Error Array
+    description: |
+      Two Dimensional Error Array.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+required: [meta, data, dq, err]
+flowStyle: block
+propertyOrder: [meta, data, dq, err]

--- a/src/rad/resources/schemas/reference_files/superbias-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/superbias-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/superbias.yaml

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.1.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.1.0.yaml
@@ -1,1 +1,55 @@
-../../../../../latest/reference_files/wfi_img_photom.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.1.0
+
+title: WFI Imaging Photometric Flux Conversion Data Model
+
+datamodel_name: WfiImgPhotomRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [PHOTOM]
+  phot_table:
+    title: Photometric Flux Conversion Factors Table
+    description: |
+      Table containing photometric flux conversion factors to physical units of
+      MJy / steradian.
+    type: object
+    patternProperties:
+      "^(F062|F087|F106|F129|F146|F158|F184|F213|GRISM|PRISM|DARK|NOT_CONFIGURED)$":
+        type: object
+        properties:
+          photmjsr:
+            title: Surface Brightness
+            description: |
+              Surface brightness, in MJy / steradian.
+            anyOf:
+              - type: number
+              - type: "null"
+          uncertainty:
+            title: Surface Brightness Uncertainty
+            description: |
+              Uncertainty of surface brightness, in MJy / steradian.
+            anyOf:
+              - type: number
+              - type: "null"
+          pixelareasr:
+            title: Pixel Area
+            description: |
+              The nominal pixel area, in steradian.
+            anyOf:
+              - type: number
+              - type: "null"
+        required: [photmjsr, uncertainty, pixelareasr]
+    additionalProperties: false
+required: [meta, phot_table]
+flowStyle: block
+propertyOrder: [meta, phot_table]

--- a/src/rad/resources/schemas/reference_files/wfi_img_photom-1.2.0.yaml
+++ b/src/rad/resources/schemas/reference_files/wfi_img_photom-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/wfi_img_photom.yaml

--- a/src/rad/resources/schemas/segmentation_map-1.2.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.2.0.yaml
@@ -1,1 +1,37 @@
-../../../../latest/segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.2.0
+
+title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: SegmentationMapModel
+
+archive_meta: None
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          optical_element:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+          visit:
+            title: Visit Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+        required: [optical_element, program, visit]
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/segmentation_map-1.3.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/segmentation_map.yaml

--- a/src/rad/resources/schemas/visit-1.1.0.yaml
+++ b/src/rad/resources/schemas/visit-1.1.0.yaml
@@ -1,1 +1,188 @@
-../../../../latest/visit.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/visit-1.1.0
+
+title: Visit Information
+type: object
+properties:
+  dither:
+    title: Dither Pattern Information
+    type: object
+    properties:
+      primary_name:
+        title: Primary Dither Pattern Name
+        description: |
+          Name of the primary dither pattern used for
+          the visit.
+        anyOf:
+          - type: string
+          - type: "null"
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: PSS:dms_visit.dither_type
+        maxLength: 100
+        archive_catalog:
+          datatype: nvarchar(100)
+          destination:
+            [
+              WFIExposure.dither_primary_name,
+              SourceCatalog.dither_primary_name,
+              SegmentationMap.dither_primary_name,
+            ]
+      subpixel_name:
+        title: Subpixel Dither Pattern Name
+        description: |
+          Name of the subpixel dither pattern used for
+          the visit.
+        anyOf:
+          - type: string
+          - type: "null"
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: PSS:dms_visit.subpixel_dither_type
+        maxLength: 100
+        archive_catalog:
+          datatype: nvarchar(100)
+          destination:
+            [
+              WFIExposure.dither_subpixel_name,
+              SourceCatalog.dither_subpixel_name,
+              SegmentationMap.dither_subpixel_name,
+            ]
+
+      executed_pattern:
+        title: Executed Dither Pattern Offsets (arcsec)
+        description: |
+          The combination of the primary and subpixel
+          dither patterns (if selected) in units of arcseconds. If
+          a subpixel dither pattern is selected, then all of the
+          subpixel dither offsets are performed at each of the
+          points in the primary dither pattern. Thus, the total
+          number of dither offsets executed is the product of the
+          number of points in the primary and subpixel dither
+          patterns. The array contains (X, Y) pairs of offsets in
+          the subpixel dither pattern where the X and Y
+          coordinates are defined in the ideal system. The ideal
+          coordinate system is a geomtric-distortion-corrected
+          reference frame projected onto a tangent plane. For more
+          information, see the Science Instrument Aperture File
+          (SIAF) and associated documentation. The exposure
+          identifier in meta.observation.exposure can be used to
+          index this array to obtain the relative pointing offset
+          from the initial target position for this exposure. Note
+          that the exposure identifier is 1-indexed.
+        anyOf:
+          - type: array
+            items:
+              type: number
+          - type: "null"
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        archive_catalog:
+          datatype: nvarchar(max)
+          destination:
+            [
+              WFIExposure.dither_executed_pattern,
+              SourceCatalog.dither_executed_pattern,
+              SegmentationMap.dither_executed_pattern,
+            ]
+    required: [primary_name, subpixel_name, executed_pattern]
+
+  type:
+    title: Visit Type
+    description: |
+      The type of visit from observation planning.
+    type: string
+    enum:
+      [
+        "GENERAL_ENGINEERING",
+        "GENERIC",
+        "PARALLEL",
+        "PRIME_TARGETED_FIXED",
+        "PRIME_UNTARGETED",
+      ]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.visit_type
+    maxLength: 30
+    archive_catalog:
+      datatype: nvarchar(30)
+      destination:
+        [
+          WFIExposure.visit_type,
+          GuideWindow.visit_type,
+          SourceCatalog.visit_type,
+          SegmentationMap.visit_type,
+        ]
+  start_time:
+    title: Visit Start Time (UTC)
+    description: |
+      The UTC time at the beginning of the visit. The time
+      is serialized on disk as an International Organization for
+      Standardization (ISO) 8601-compliant ISOT string, but if opened
+      in Python with the asdf-astropy package installed, it may be
+      read as an astropy.time.Time object with all of the associated
+      methods and transforms available. See the documentation for
+      astropy.time.Time objects for more information.
+    tag: tag:stsci.edu:asdf/time/time-1.*
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: datetime2
+      destination:
+        [
+          WFIExposure.visit_start_time,
+          GuideWindow.visit_start_time,
+          SourceCatalog.visit_start_time,
+          SegmentationMap.visit_start_time,
+        ]
+
+  nexposures:
+    title: Number of Planned Exposures
+    description: |
+      The total number of exposures planned within the
+      visit.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.exposures_per_dither
+    archive_catalog:
+      datatype: int
+      destination:
+        [
+          WFIExposure.visit_nexposures,
+          GuideWindow.visit_nexposures,
+          SourceCatalog.visit_nexposures,
+          SegmentationMap.visit_nexposures,
+        ]
+  internal_target:
+    title: Internal Target
+    description: |
+      A boolean indicator which, if true, indicates that the
+      target for the visit is an internal calibration target.
+    type: boolean
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.internal_target
+    archive_catalog:
+      datatype: nchar(1)
+      destination:
+        [
+          WFIExposure.visit_internal_target,
+          GuideWindow.visit_internal_target,
+          SourceCatalog.visit_internal_target,
+          SegmentationMap.visit_internal_target,
+        ]
+propertyOrder: [dither, type, start_time, nexposures, internal_target]
+flowStyle: block
+required: [dither, type, start_time, nexposures, internal_target]

--- a/src/rad/resources/schemas/visit-1.2.0.yaml
+++ b/src/rad/resources/schemas/visit-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/visit.yaml

--- a/src/rad/resources/schemas/wfi_detector-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_detector-1.0.0.yaml
@@ -1,1 +1,28 @@
-../../../../latest/wfi_detector.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+
+# Helper file to enumerate detectors for wfi_mode and ref_detector
+
+title: WFI Detector Name
+type: string
+enum:
+  - WFI01
+  - WFI02
+  - WFI03
+  - WFI04
+  - WFI05
+  - WFI06
+  - WFI07
+  - WFI08
+  - WFI09
+  - WFI10
+  - WFI11
+  - WFI12
+  - WFI13
+  - WFI14
+  - WFI15
+  - WFI16
+  - WFI17
+  - WFI18

--- a/src/rad/resources/schemas/wfi_detector-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_detector-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_detector.yaml

--- a/src/rad/resources/schemas/wfi_mode-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_mode-1.1.0.yaml
@@ -1,1 +1,67 @@
-../../../../latest/wfi_mode.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.1.0
+
+title: Wide Field Instrument (WFI) Configuration Information
+type: object
+properties:
+  name:
+    title: Instrument Name
+    description: |
+      Name of the instrument used to acquire the science
+      data.
+    type: string
+    enum: [WFI]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 5
+    archive_catalog:
+      datatype: nvarchar(5)
+      destination:
+        [
+          WFIExposure.instrument_name,
+          GuideWindow.instrument_name,
+          WFICommon.instrument_name,
+        ]
+  detector:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_detector-1.0.0
+    title: Wide Field Instrument (WFI) Detector Identifier
+    description: |
+      Name of the Wide Field Instrument (WFI) detector used
+      to take the science data in this file.
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination:
+        [WFIExposure.detector, GuideWindow.detector, WFICommon.detector]
+  optical_element:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+    title: Wide Field Instrument (WFI) Optical Element
+    description: |
+      Name of the optical element used to take the science
+      data.
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 20
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination:
+        [
+          WFIExposure.optical_element,
+          GuideWindow.optical_element,
+          WFICommon.optical_element,
+        ]
+propertyOrder: [detector, optical_element, name]
+flowStyle: block
+required: [detector, optical_element, name]

--- a/src/rad/resources/schemas/wfi_mode-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_mode-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_mode.yaml

--- a/src/rad/resources/schemas/wfi_optical_element-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_optical_element-1.1.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/wfi_optical_element.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.1.0
+
+# Helper file to enumerate filters for wfi_mode and ref_optical_element
+
+title: Optical Element
+description: |
+  Name of the filter element used. See the RDox Optical Element page for more
+  details on available optical elements and their properties.
+type: string
+enum:
+  - F062
+  - F087
+  - F106
+  - F129
+  - F146
+  - F158
+  - F184
+  - F213
+  - GRISM
+  - PRISM
+  - DARK
+  - NOT_CONFIGURED

--- a/src/rad/resources/schemas/wfi_optical_element-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_optical_element-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_optical_element.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.2.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/common-1.2.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reset_read, reset_amp33]
+flowStyle: block
+required: [meta, data, amp33]

--- a/src/rad/resources/schemas/wfi_science_raw-1.3.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/src/rad/resources/schemas/wfi_wcs-1.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.1.0.yaml
@@ -1,1 +1,83 @@
-../../../../latest/wfi_wcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
+
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/basic-1.0.0
+      - type: object
+        properties:
+          coordinates:
+            title: Name Of The Coordinate Reference Frame
+            tag: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+          ephemeris:
+            title: Ephemeris Data Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+          exposure:
+            title: Exposure Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+          instrument:
+            title: WFI Observing Configuration
+            tag: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+          observation:
+            title: Observation Identifiers
+            tag: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+          pointing:
+            title: Spacecraft Pointing Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+          program:
+            title: Program Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+          velocity_aberration:
+            title: Velocity Aberration Correction Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+          visit:
+            title: Visit Information
+            tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+          wcsinfo:
+            title: World Coordinate System (WCS) Parameters
+            tag: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
+        required:
+          [
+            coordinates,
+            ephemeris,
+            exposure,
+            instrument,
+            observation,
+            pointing,
+            program,
+            velocity_aberration,
+            visit,
+            wcsinfo,
+          ]
+  wcs_l2:
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta]

--- a/src/rad/resources/schemas/wfi_wcs-1.2.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_wcs.yaml

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -203,6 +203,17 @@ class TestSchemaContent:
         """
         assert uri in latest_uris, f"{uri} is not in the list of schemas to be tested."
 
+    def test_string_max_length(self, schema):
+        """
+        Checks that if a `maxLength` is specified, that it is specified along with a `type` of `string`.
+        """
+
+        def callback(node):
+            if isinstance(node, Mapping) and "maxLength" in node:
+                assert node.get("type") == "string", "maxLength is only valid for strings"
+
+        asdf.treeutil.walk(schema, callback)
+
     def test_varchar_length(self, schema_uri, schema, request):
         """
         Test that varchar(N) in archive_metadata for string objects

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -227,20 +227,56 @@ class TestSchemaContent:
                 )
             )
 
-        def callback(node, nvarchars=None):
-            nvarchars = nvarchars or {}
-            if not isinstance(node, dict):
-                return
-            if node.get("type", "") != "string":
-                return
-            if "archive_catalog" not in node:
-                return
-            m = match(r"^nvarchar\(([0-9]+)\)$", node["archive_catalog"]["datatype"])
-            if not m:
-                return
-            v = int(m.group(1))
-            assert "maxLength" in node, f"archive_catalog has nvarchar, schema {schema_uri} is missing maxLength"
-            assert node["maxLength"] == v, f"archive_catalog nvarchar does not match maxLength in schema {schema_uri}"
+        def callback(node):
+            if (
+                isinstance(node, Mapping)
+                and "archive_catalog" in node
+                and node["archive_catalog"]["datatype"].startswith("nvarchar(")
+            ):
+                m = match(r"^nvarchar\(([0-9]+)\)$", node["archive_catalog"]["datatype"])
+                if m:
+                    length = int(m.group(1))
+
+                    def check_max_length(node):
+                        nonlocal found
+                        nonlocal ref_uri
+                        if isinstance(node, Mapping) and "type" in node:
+                            if node["type"] == "string":
+                                msg = "archive_catalog.datatype nvarchar indicates maxLength is required"
+                                msg += f" in schema {ref_uri}" if ref_uri else ""
+                                msg += ", but it is not present"
+                                assert "maxLength" in node, msg
+                                assert node["maxLength"] == length, (
+                                    f"archive_catalog.datatype nvarchar indicates maxLength={length}, but found {node['maxLength']}."
+                                )
+                                found = True
+
+                            # Arrays may have a nvarchar described for archive, but they don't have a maxLength
+                            # json-schema descriptor so we assume that we found maxLength
+                            elif node["type"] == "array":
+                                found = True
+
+                    if "type" in node:
+                        found = False
+                        ref_uri = None
+                        asdf.treeutil.walk(node, check_max_length)
+                        assert found, "archive_catalog.datatype nvarchar indicates maxLength is required, none is found"
+                        return
+
+                    if "allOf" in node or "anyOf" in node:
+                        for sub_schema in node.get("allOf", []) + node.get("anyOf", []):
+                            if isinstance(sub_schema, Mapping):
+                                found = False
+                                ref_uri = sub_schema.get("$ref")
+                                sub_node = asdf.schema.load_schema(sub_schema["$ref"]) if "$ref" in sub_schema else sub_schema
+                                asdf.treeutil.walk(sub_node, check_max_length)
+                                assert found, (
+                                    f"archive_catalog.datatype nvarchar indicates there should be a maxLength in {sub_schema['$ref']}"
+                                )
+                                return
+
+                    # Fallback failure
+                    raise AssertionError("archive_catalog.datatype is nvarchar but no maxLength found.")
 
         asdf.treeutil.walk(schema, callback)
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -379,11 +379,11 @@ class TestVersioning:
                 f"Resource {frozen_uri} has changed between versions {rad_version} and the current changes"
             )
 
-    @pytest.mark.parametrize(("rad_version", "frozen_uri"), EXPECTED_XFAILS)
-    def test_expected_xfails_relevance(self, rad_version, frozen_uri, rad_versions, frozen_uris):
+    @pytest.mark.parametrize(("version", "uri"), EXPECTED_XFAILS)
+    def test_expected_xfails_relevance(self, version, uri, rad_versions, frozen_uris):
         """
         Test that the expected fails are relevant to the current version of RAD
         -> Smokes out when the EXPECTED_XFAILS are no longer relevant
         """
-        assert rad_version in rad_versions, f"Version {rad_version} is not a valid version of RAD"
-        assert frozen_uri in frozen_uris, f"URI {frozen_uri} is not a valid frozen URI"
+        assert version in rad_versions, f"Version {version} is not a valid version of RAD for versioning"
+        assert uri in frozen_uris, f"URI {uri} is not a valid frozen URI"


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #608

<!-- describe the changes comprising this PR here -->
This PR addresses two related but distinct issues.

1. `maxLength` should only appear on the `type: string`, as it does not make sense anywhere else.
2. If `archive_catalog.datatype = nvarchar(N)` (where `N` is some positive integer) and the `type` of the node can be a `type: string`, then that `type: string` (option) should have a `maxLength: N` decoration.

Setting `maxLength` consistently, is important so that the schemas can enforce via JSON-schema the length of the stored values so that the archive's `nvarchar` is not exceeded.

~~Note that this touches the `tvac` and `fps` schemas; however, since the versions have been bumped on those schemas there should be no issue. This also fixed a few minor issues with those schemas that were ignored in the 1.0.0 versions.~~

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
