### PR TITLE
Bump the datamodels to v1.3.0 now that rad 0.25 is released

### DIFF
--- a/changes/612.feature.rst
+++ b/changes/612.feature.rst
@@ -1,0 +1,2 @@
+Bump manifest to 1.3.0 now that RAD 0.25.0 has been released with manifest version
+1.2.0.

--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.2.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.2.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.3.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.3.0
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.

--- a/src/rad/resources/manifests/datamodels-1.2.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.2.0.yaml
@@ -1,1 +1,541 @@
-../../../../latest/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.2.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.2.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.1.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.1.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.1.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.2.0
+    title: Guide window schema
+    description: |-
+      Guide window schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.2.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.2.0
+    title: Ramp fit output schema
+    description: |-
+      Ramp fit output schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.2.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.2.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.2.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.1.0
+    title: Roman WFI Instrument Mode
+    description: |-
+      Roman WFI Instrument
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.1.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Metadata Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.2.0
+    title: Exposure information
+    description: |-
+      Exposure information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/program-1.1.0
+    title: Program information
+    description: |-
+      Program information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.0.0
+    title: Observation information
+    description: |-
+      Observation information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ephemeris-1.1.0
+    title: Ephemeris information
+    description: |-
+      Ephemeris information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.1.0
+    title: Visit information
+    description: |-
+      Visit information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/photometry-1.0.0
+    title: Photometry information
+    description: |-
+      Photometry information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/source_catalog-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/source_catalog-1.0.0
+    title: Source catalog for TweakReg
+    description: |-
+      Source catalog for TweakReg
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/coordinates-1.0.0
+    title: Coordinate frame information
+    description: |-
+      Coordinate frame information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/pointing-1.1.0
+    title: Spacecraft Pointing information
+    description: |-
+      Spacecraft Pointing information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/rcs-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.0.0
+    title: Relative Calibration System Information
+    description: |-
+      Relative Calibration System Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/statistics-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/statistics-1.0.0
+    title: Basic Statistical Information
+    description: |-
+      Basic Statistical Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/velocity_aberration-1.0.0
+    title: Velocity aberration information
+    description: |-
+      Velocity aberration information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wcsinfo-1.1.0
+    title: Wcsinfo information
+    description: |-
+      Wcsinfo information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.1.0
+    title: Guidestar information
+    description: |-
+      Guidestar information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l2_cal_step-1.1.0
+    title: Level 2 Calibration Step status information
+    description: |-
+      Level 2 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l3_cal_step-1.1.0
+    title: Level 3 Calibration Step status information
+    description: |-
+      Level 3 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/outlier_detection-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/outlier_detection-1.0.0
+    title: Outlier Detection information
+    description: |-
+      Outlier Detection information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/sky_background-1.0.0
+    title: Sky Background Information
+    description: |-
+      Sky Background Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/resample-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/resample-1.0.0
+    title: Resample information
+    description: |-
+      Resample information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/individual_image_meta-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/individual_image_meta-1.0.0
+    title: Combined level 2 metadata
+    description: |-
+      Combined level 2 metadata
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.1.0
+    title: Basic mosaic metadata keywords
+    description: |-
+      Basic mosaic metadata keywords
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_associations-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_associations-1.0.0
+    title: Mosaic associations metadata keywords
+    description: |-
+      Mosaic associations metadata keywords
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_wcsinfo-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_wcsinfo-1.0.0
+    title: Mosaic WCS parameters
+    description: |-
+      Mosaic WCS parameters
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.0.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.0.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.1.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.1.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.1.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.1.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.0.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.0.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.1.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.0.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.0.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.1.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.1.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.0.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.0.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.0.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.1.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.0.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.0.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/associations-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/associations-1.0.0
+    title: Association table
+    description: |-
+      Association table
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/cal_logs-1.0.0
+    title: Calibration log messages
+    description: |-
+      Calibration log message
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.1.0
+    title: Calibration reference file names.
+    description: |-
+      Calibration reference file names.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.2.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.2.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.2.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.2.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  # Tagged Scalars
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/calibration_software_name-1.0.0
+    title: Calibration Software Name
+    description: |-
+      Name of the calibration software package used in
+      processing this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/calibration_software_version-1.0.0
+    title: Calibration software version
+    description: |-
+      The version number of the calibration software used in
+      processing this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/product_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/product_type-1.0.0
+    title: Product Type Descriptor
+    description: |-
+      A descriptor for the type of data contained within the
+      file. This corresponds to the standard file suffixes for
+      archival data products. Consult the documentation for the list
+      of options.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/filename-1.0.0
+    title: File Name
+    description: |-
+      The auto-generated name of this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/file_date-1.0.0
+    title: File Creation Date
+    description: |-
+      The date and time this file was created.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/model_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/model_type-1.0.0
+    title: Data Model Type
+    description: |-
+      The type of data model contained within this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/origin-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/origin-1.0.0
+    title: Institution / Organization Name
+    description: |-
+      The name of the institution of organization
+      responsible for creating this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/prd_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/prd_version-1.0.0
+    title: SOC PRD Version Number
+    description: |-
+      The version number of the Science Operations Center
+      (SOC) Project Reference Database (PRD) used in generating this
+      file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/sdf_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/sdf_software_version-1.0.0
+    title: SOC SDF Version Number
+    description: |-
+      The version number of the Science Operations Center
+      (SOC) Science Data Formatting (SDF) software used in generating
+      this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/telescope-1.0.0
+    title: Telescope Name
+    description: |-
+      The name of the telescope used to acquire the data.
+  # FPS Schemas
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0
+    title: FPS schema
+    description: |-
+      FPS test data
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/cal_step-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/cal_step-1.0.0
+    title: FPS Level 2 Calibration Step status information
+    description: |-
+      FPS Level 2 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/exposure-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/exposure-1.0.0
+    title: FPS Exposure information
+    description: |-
+      FPS Exposure information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/groundtest-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/groundtest-1.0.0
+    title: FPS Ground Test Information
+    description: |-
+      FPS Ground test description.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/guidestar-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/guidestar-1.0.0
+    title: FPS Guidestar information
+    description: |-
+      FPS Guidestar information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/statistics-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/statistics-1.0.0
+    title: FPS Summary Statistics
+    description: |-
+      FPS Summary Statistics
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/ref_file-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/ref_file-1.0.0
+    title: FPS Calibration reference file names.
+    description: |-
+      FPS Calibration reference file names.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/wfi_mode-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/wfi_mode-1.0.0
+    title: FPS Roman WFI Instrument Mode
+    description: |-
+      FPS Roman WFI Instrument
+  # FPS Tagged Scalars
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/calibration_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/calibration_software_version-1.0.0
+    title: FPS Calibration software version
+    description: |-
+      FPS Calibration software version number
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/filename-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/filename-1.0.0
+    title: FPS Name of the file
+    description: |-
+      FPS Name of the file
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/file_date-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/file_date-1.0.0
+    title: FPS Date this file was created (UTC)
+    description: |-
+      FPS Date this file was created (UTC)
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/model_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/model_type-1.0.0
+    title: FPS Type of data model
+    description: |-
+      FPS Type of data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/origin-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/origin-1.0.0
+    title: FPS Organization responsible for creating file
+    description: |-
+      FPS Organization responsible for creating file
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/prd_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/prd_software_version-1.0.0
+    title: FPS S&OC PRD version number used in data processing
+    description: |-
+      FPS S&OC PRD version number used in data processing
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/sdf_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/sdf_software_version-1.0.0
+    title: FPS SDF software version number
+    description: |-
+      FPS SDF software version number
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/fps/telescope-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/fps/tagged_scalars/telescope-1.0.0
+    title: FPS Telescope used to acquire the data
+    description: |-
+      FPS Telescope used to acquire the data
+  # TVAC Schemas
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac-1.0.0
+    title: TVAC schema
+    description: |-
+      TVAC test data
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/cal_step-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/cal_step-1.0.0
+    title: TVAC Level 2 Calibration Step status information
+    description: |-
+      TVAC Level 2 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/exposure-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/exposure-1.0.0
+    title: TVAC Exposure information
+    description: |-
+      TVAC Exposure information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/groundtest-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/groundtest-1.0.0
+    title: TVAC Ground Test Information
+    description: |-
+      TVAC Ground test description.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/guidestar-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/guidestar-1.0.0
+    title: TVAC Guidestar information
+    description: |-
+      TVAC Guidestar information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/statistics-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/statistics-1.0.0
+    title: TVAC Summary Statistics
+    description: |-
+      TVAC Summary Statistics
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/ref_file-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/ref_file-1.0.0
+    title: TVAC Calibration reference file names.
+    description: |-
+      TVAC Calibration reference file names.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/wfi_mode-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0
+    title: TVAC Roman WFI Instrument Mode
+    description: |-
+      TVAC Roman WFI Instrument
+  # TVAC Tagged Scalars
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/calibration_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/calibration_software_version-1.0.0
+    title: TVAC Calibration software version
+    description: |-
+      TVAC Calibration software version number
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/filename-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/filename-1.0.0
+    title: TVAC Name of the file
+    description: |-
+      TVAC Name of the file
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/file_date-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/file_date-1.0.0
+    title: TVAC Date this file was created (UTC)
+    description: |-
+      TVAC Date this file was created (UTC)
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/model_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/model_type-1.0.0
+    title: TVAC Type of data model
+    description: |-
+      TVAC Type of data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/origin-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/origin-1.0.0
+    title: TVAC Organization responsible for creating file
+    description: |-
+      TVAC Organization responsible for creating file
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/prd_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/prd_software_version-1.0.0
+    title: TVAC S&OC PRD version number used in data processing
+    description: |-
+      TVAC S&OC PRD version number used in data processing
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/sdf_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/sdf_software_version-1.0.0
+    title: TVAC SDF software version number
+    description: |-
+      TVAC SDF software version number
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/tvac/telescope-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tvac/tagged_scalars/telescope-1.0.0
+    title: TVAC Telescope used to acquire the data
+    description: |-
+      TVAC Telescope used to acquire the data
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.2.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/manifests/datamodels-1.3.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/datamodels.yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import importlib.resources as importlib_resources
 from itertools import chain
 from pathlib import Path
 from re import compile, match
+from types import MappingProxyType
 
 import asdf
 import pytest
@@ -10,51 +11,260 @@ from semantic_version import Version
 
 from rad import resources
 
-RAD_URI_PREFIX = "asdf://stsci.edu/datamodels/roman/"
 
-MANIFEST_URI_PREFIX = f"{RAD_URI_PREFIX}manifests/"
-MANIFEST_PATHS = tuple((importlib_resources.files(resources) / "manifests").glob("**/*.yaml"))
-MANIFEST_URIS = tuple(yaml.safe_load(manifest_path.read_bytes())["id"] for manifest_path in MANIFEST_PATHS)
-MANIFESTS = tuple(yaml.safe_load(asdf.get_config().resource_manager[manifest_uri]) for manifest_uri in MANIFEST_URIS)
-MANIFEST_ENTRIES = tuple(chain(*[manifest["tags"] for manifest in MANIFESTS]))
-
-TAG_URI_PREFIX = f"{RAD_URI_PREFIX}tags/"
-
-SCHEMA_URI_PREFIX = f"{RAD_URI_PREFIX}schemas/"
-METASCHEMA_URI = f"{SCHEMA_URI_PREFIX}rad_schema-1.0.0"
-SCHEMA_URIS = tuple(u for u in asdf.get_config().resource_manager if u.startswith(SCHEMA_URI_PREFIX) and u != METASCHEMA_URI)
-TAGGED_SCHEMA_URIS = set(entry["schema_uri"] for entry in MANIFEST_ENTRIES)
-UNTAGGED_URIS = tuple(uri for uri in SCHEMA_URIS if uri not in TAGGED_SCHEMA_URIS)
-
-TAG_DEFS = tuple(tag_def for manifest in MANIFESTS for tag_def in manifest["tags"])
-REF_FILE_TAG_DEFS = tuple(tag_def for tag_def in TAG_DEFS if "/reference_files" in tag_def["schema_uri"])
-ALLOWED_SCHEMA_TAG_VALIDATORS = (
-    "tag:stsci.edu:asdf/time/time-1.*",
-    "tag:stsci.edu:asdf/core/ndarray-1.*",
-    "tag:stsci.edu:asdf/unit/quantity-1.*",
-    "tag:stsci.edu:asdf/unit/unit-1.*",
-    "tag:astropy.org:astropy/units/unit-1.*",
-    "tag:astropy.org:astropy/table/table-1.*",
-    "tag:stsci.edu:gwcs/wcs-*",
-)
-
-LATEST_PATHS = tuple((Path(__file__).parent.parent.absolute() / "latest").glob("**/*.yaml"))
-LATEST_URIS = tuple(yaml.safe_load(latest_path.read_bytes())["id"] for latest_path in LATEST_PATHS)
+@pytest.fixture(scope="session", params=(importlib_resources.files(resources) / "manifests").glob("**/*.yaml"))
+def manifest_path(request):
+    """
+    Get the paths to the manifest files directly from python package, rather than ASDF
+    """
+    return request.param
 
 
-CURRENT_RESOURCES = {
-    uri: yaml.safe_load(asdf.get_config().resource_manager[uri])
-    for uri in sorted(SCHEMA_URIS + MANIFEST_URIS + (METASCHEMA_URI,))
-}
+@pytest.fixture(scope="session", params=(importlib_resources.files(resources) / "schemas").glob("**/*.yaml"))
+def schema_path(request):
+    """
+    Get the paths to the schema files directly from python package, rather than ASDF
+    """
+    return request.param
 
 
-def get_latest_uri(prefix):
+# Defined directly so that the value can be reused to find the URIs from the ASDF resource manager
+# outside of a pytest fixture
+_RAD_URI_PREFIX = "asdf://stsci.edu/datamodels/roman/"
+_MANIFEST_URI_PREFIX = f"{_RAD_URI_PREFIX}manifests/"
+_SCHEMA_URI_PREFIX = f"{_RAD_URI_PREFIX}schemas/"
+_METASCHEMA_URI = f"{_SCHEMA_URI_PREFIX}rad_schema-1.0.0"
+
+
+@pytest.fixture(scope="session")
+def rad_uri_prefix():
+    """
+    Get the RAD URI prefix.
+    """
+    return _RAD_URI_PREFIX
+
+
+@pytest.fixture(scope="session")
+def manifest_uri_prefix():
+    """
+    Get the manifest URI prefix.
+    """
+    return _MANIFEST_URI_PREFIX
+
+
+@pytest.fixture(scope="session")
+def schema_uri_prefix():
+    return _SCHEMA_URI_PREFIX
+
+
+@pytest.fixture(scope="session")
+def metaschema_uri():
+    """
+    Get the metaschema URI.
+    """
+    return _METASCHEMA_URI
+
+
+@pytest.fixture(scope="session")
+def tag_uri_prefix(rad_uri_prefix):
+    return f"{rad_uri_prefix}tags/"
+
+
+# Get all the schema URIs from the ASDF resource manager cached to the current session
+# to avoid loading them multiple times
+_MANIFEST_URIS = tuple(uri for uri in asdf.get_config().resource_manager if uri.startswith(_MANIFEST_URI_PREFIX))
+_SCHEMA_URIS = tuple(u for u in asdf.get_config().resource_manager if u.startswith(_SCHEMA_URI_PREFIX) and u != _METASCHEMA_URI)
+_URIS = _SCHEMA_URIS + _MANIFEST_URIS + (_METASCHEMA_URI,)
+
+
+@pytest.fixture(scope="session")
+def manifest_uris():
+    """
+    Get the manifest URIs.
+    """
+    return _MANIFEST_URIS
+
+
+@pytest.fixture(scope="session", params=_MANIFEST_URIS)
+def manifest_uri(request):
+    """
+    Get the URIs of the manifest files from the ASDF resource manager.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def schema_uris():
+    """
+    Get all the URIs of RAD from the ASDF resource manager.
+    """
+    return _SCHEMA_URIS
+
+
+@pytest.fixture(scope="session", params=_SCHEMA_URIS)
+def schema_uri(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def uris():
+    """
+    Get all the URIs of RAD from the ASDF resource manager.
+    """
+    return _URIS
+
+
+@pytest.fixture(scope="session", params=_URIS)
+def uri(request):
+    """
+    Get the URIs of the manifest files from the ASDF resource manager.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session", params=tuple(uri for uri in _SCHEMA_URIS if "/reference_files" in uri))
+def ref_file_uri(request):
+    """
+    Get the reference file schema URI from the request.
+    """
+    return request.param
+
+
+# load all the schemas from the ASDF resource manager
+_CURRENT_CONTENT = MappingProxyType({uri: asdf.get_config().resource_manager[uri] for uri in _URIS})
+_CURRENT_RESOURCES = MappingProxyType({uri: yaml.safe_load(content) for uri, content in _CURRENT_CONTENT.items()})
+_MANIFEST_ENTRIES = tuple(chain(*[_CURRENT_RESOURCES[uri]["tags"] for uri in _MANIFEST_URIS]))
+
+
+@pytest.fixture(scope="session")
+def current_content(uri):
+    """
+    Get the current content from the ASDF resource manager.
+    """
+    return _CURRENT_CONTENT[uri]
+
+
+@pytest.fixture(scope="session")
+def current_resources():
+    """
+    Get the current resources from the ASDF resource manager.
+    """
+    return _CURRENT_RESOURCES
+
+
+@pytest.fixture(scope="session")
+def manifest(manifest_uri, current_resources):
+    """
+    Get the manifests for the given uris.
+    """
+    return current_resources[manifest_uri]
+
+
+@pytest.fixture(scope="session", params=_MANIFEST_ENTRIES)
+def manifest_entry(request):
+    """
+    Get the manifest entry for the given request.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def manifest_by_schema(manifest_uris, current_resources):
+    """
+    Get the text of the manifests.
+    """
+    return MappingProxyType(
+        {
+            uri: MappingProxyType({entry["schema_uri"]: entry["tag_uri"] for entry in current_resources[uri]["tags"]})
+            for uri in manifest_uris
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+def manifest_by_tag(manifest_by_schema):
+    """
+    Get the text of the manifests.
+    """
+    return MappingProxyType(
+        {uri: MappingProxyType({value: key for key, value in entry.items()}) for uri, entry in manifest_by_schema.items()}
+    )
+
+
+@pytest.fixture(scope="session")
+def schema_tag_map(manifest_by_schema):
+    """
+    Get the schema tag map.
+    """
+    return MappingProxyType(
+        {schema_uri: tag_uri for schema_tag_map in manifest_by_schema.values() for schema_uri, tag_uri in schema_tag_map.items()}
+    )
+
+
+@pytest.fixture(scope="session")
+def schema(schema_uri, current_resources):
+    """
+    Return the yaml loaded schema for the given schema URI.
+    """
+    return current_resources[schema_uri]
+
+
+@pytest.fixture(scope="session")
+def ref_file_schema(ref_file_uri, current_resources):
+    """
+    Get the reference file tag URI from the request.
+    """
+    return current_resources[ref_file_uri]
+
+
+@pytest.fixture(scope="session")
+def manifest_entries():
+    """
+    Get the manifest entries.
+    """
+    return _MANIFEST_ENTRIES
+
+
+@pytest.fixture(scope="session")
+def tagged_schema_uris():
+    """
+    Get the tags from the manifest entries.
+    """
+    return frozenset(entry["schema_uri"] for entry in _MANIFEST_ENTRIES)
+
+
+@pytest.fixture(scope="session")
+def allowed_schema_tag_validators():
+    """
+    Get the allowed schema tag validators.
+    """
+    return frozenset(
+        (
+            "tag:stsci.edu:asdf/time/time-1.*",
+            "tag:stsci.edu:asdf/core/ndarray-1.*",
+            "tag:stsci.edu:asdf/unit/quantity-1.*",
+            "tag:stsci.edu:asdf/unit/unit-1.*",
+            "tag:astropy.org:astropy/units/unit-1.*",
+            "tag:astropy.org:astropy/table/table-1.*",
+            "tag:stsci.edu:gwcs/wcs-*",
+        )
+    )
+
+
+@pytest.fixture(scope="session")
+def valid_tag_uris(manifest_entries, allowed_schema_tag_validators):
+    uris = set(entry["tag_uri"] for entry in manifest_entries)
+    uris.update(allowed_schema_tag_validators)
+    return frozenset(uris)
+
+
+def _get_latest_uri(prefix):
     """
     Get the latest exposure type URI.
     """
     pattern = rf"{prefix}-\d+\.\d+\.\d+$"
     uris = []
-    for uri in CURRENT_RESOURCES:
+    for uri in _CURRENT_RESOURCES:
         if match(pattern, uri):
             uris.append(uri)
 
@@ -70,145 +280,37 @@ def get_latest_uri(prefix):
     return latest_uri
 
 
-EXPOSURE_TYPE_ELEMENTS = tuple(
-    CURRENT_RESOURCES[get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/exposure_type")]["enum"]
-)
-P_EXPTYPE_PATTERN = CURRENT_RESOURCES[
-    get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type")
-]["properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
-OPTICAL_ELEMENTS = tuple(
-    CURRENT_RESOURCES[get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element")]["enum"]
-)
-PHOT_TABLE_KEY_PATTERN = next(
+_PHOT_TABLE_KEY_PATTERN = next(
     iter(
-        CURRENT_RESOURCES[get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom")][
+        _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom")][
             "properties"
         ]["phot_table"]["patternProperties"]
     )
 )
 
 
-@pytest.fixture(scope="session", params=MANIFEST_PATHS)
-def manifest_path(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=MANIFEST_ENTRIES)
-def manifest_entry(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=MANIFESTS)
-def manifest(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=(importlib_resources.files(resources) / "schemas").glob("**/*.yaml"))
-def schema_path(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=SCHEMA_URIS)
-def schema_uri(request):
-    return request.param
-
-
 @pytest.fixture(scope="session")
-def schema_content(schema_uri):
-    return asdf.get_config().resource_manager[schema_uri]
-
-
-@pytest.fixture(scope="session")
-def schema(schema_uri):
-    return CURRENT_RESOURCES[schema_uri]
-
-
-@pytest.fixture(scope="session")
-def valid_tag_uris():
-    uris = {t["tag_uri"] for manifest in MANIFESTS for t in manifest["tags"]}
-    uris.update(ALLOWED_SCHEMA_TAG_VALIDATORS)
-    return uris
-
-
-@pytest.fixture(scope="session", params=REF_FILE_TAG_DEFS)
-def ref_file_schema(request):
-    return yaml.safe_load(asdf.get_config().resource_manager[request.param["schema_uri"]])
-
-
-@pytest.fixture(scope="session", params=REF_FILE_TAG_DEFS)
-def ref_file_uris(request):
-    return request.param["tag_uri"], request.param["schema_uri"]
-
-
-@pytest.fixture(scope="session", params=LATEST_PATHS)
-def latest_path(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=LATEST_URIS)
-def latest_uri(request):
-    return request.param
-
-
-@pytest.fixture(scope="session")
-def latest_manifest_uri():
-    latest_manifest_uris = tuple(uri for uri in LATEST_URIS if "manifests" in uri)
-    assert len(latest_manifest_uris) == 1, "There should be exactly one latest manifest"
-    return latest_manifest_uris[0]
-
-
-@pytest.fixture(scope="session")
-def latest_schemas():
+def phot_table_key_pattern():
     """
-    Get the text of the latest schemas.
+    Get the pattern for the photometry table key used by the reference files.
     """
-    return {latest_uri: latest_path.read_text() for latest_uri, latest_path in zip(LATEST_URIS, LATEST_PATHS, strict=True)}
+    return compile(_PHOT_TABLE_KEY_PATTERN)
 
 
-@pytest.fixture(scope="session")
-def latest_schema_tags(latest_manifest_uri, latest_schemas):
+@pytest.fixture(scope="session", params=_PHOT_TABLE_KEY_PATTERN.split(")$")[0].split("(")[-1].split("|"))
+def phot_table_key(request):
     """
-    Get the latest schema tags from the latest manifest.
-    """
-    tag_entries = yaml.safe_load(latest_schemas[latest_manifest_uri])["tags"]
-    schema_tags = {entry["schema_uri"]: entry["tag_uri"] for entry in tag_entries}
-    assert len(schema_tags) == len(tag_entries), "There should be no duplicate tags for a schema"
-    return schema_tags
-
-
-@pytest.fixture(scope="session", params=EXPOSURE_TYPE_ELEMENTS)
-def exposure_type(request):
-    """
-    Get the exposure type from the request.
+    Get the photometry table key from the request.
     """
     return request.param
 
 
-@pytest.fixture(scope="session")
-def exposure_types():
-    """
-    Get the exposure types from the request.
-    """
-    return EXPOSURE_TYPE_ELEMENTS
+_OPTICAL_ELEMENTS = tuple(
+    _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element")]["enum"]
+)
 
 
-@pytest.fixture(scope="session")
-def p_exptype_pattern():
-    """
-    Get the pattern for the exposure type used by the reference files.
-    """
-    return compile(P_EXPTYPE_PATTERN)
-
-
-@pytest.fixture(scope="session", params=P_EXPTYPE_PATTERN.split(")\\s*\\|\\s*)+$")[0].split("((")[-1].split("|"))
-def p_exptype(request):
-    """
-    Get the exposure type from the request.
-    """
-    return request.param
-
-
-@pytest.fixture(scope="session", params=OPTICAL_ELEMENTS)
+@pytest.fixture(scope="session", params=_OPTICAL_ELEMENTS)
 def optical_element(request):
     """
     Get the optical element from the request.
@@ -221,20 +323,111 @@ def optical_elements():
     """
     Get the optical elements from the request.
     """
-    return OPTICAL_ELEMENTS
+    return _OPTICAL_ELEMENTS
+
+
+_EXPOSURE_TYPE_ELEMENTS = tuple(
+    _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/exposure_type")]["enum"]
+)
+
+
+@pytest.fixture(scope="session", params=_EXPOSURE_TYPE_ELEMENTS)
+def exposure_type(request):
+    """
+    Get the exposure type from the request.
+    """
+    return request.param
 
 
 @pytest.fixture(scope="session")
-def phot_table_key_pattern():
+def exposure_types():
     """
-    Get the pattern for the photometry table key used by the reference files.
+    Get the exposure types from the request.
     """
-    return compile(PHOT_TABLE_KEY_PATTERN)
+    return _EXPOSURE_TYPE_ELEMENTS
 
 
-@pytest.fixture(scope="session", params=PHOT_TABLE_KEY_PATTERN.split(")$")[0].split("(")[-1].split("|"))
-def phot_table_key(request):
+_P_EXPTYPE_PATTERN = _CURRENT_RESOURCES[
+    _get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_exposure_type")
+]["properties"]["exposure"]["properties"]["p_exptype"]["pattern"]
+
+
+@pytest.fixture(scope="session")
+def p_exptype_pattern():
     """
-    Get the photometry table key from the request.
+    Get the pattern for the exposure type used by the reference files.
+    """
+    return compile(_P_EXPTYPE_PATTERN)
+
+
+@pytest.fixture(scope="session", params=_P_EXPTYPE_PATTERN.split(")\\s*\\|\\s*)+$")[0].split("((")[-1].split("|"))
+def p_exptype(request):
+    """
+    Get the exposure type from the request.
     """
     return request.param
+
+
+_LATEST_PATHS = tuple((Path(__file__).parent.parent.absolute() / "latest").glob("**/*.yaml"))
+_LATEST_URIS = tuple(yaml.safe_load(latest_path.read_bytes())["id"] for latest_path in _LATEST_PATHS)
+
+
+@pytest.fixture(scope="session")
+def latest_paths():
+    """
+    Get the paths to the latest schemas.
+    """
+    return _LATEST_PATHS
+
+
+@pytest.fixture(scope="session", params=_LATEST_PATHS)
+def latest_path(request):
+    """
+    Get a latest resource path
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def latest_uris():
+    """
+    Get the URIs of the latest schemas.
+    """
+    return _LATEST_URIS
+
+
+@pytest.fixture(scope="session", params=_LATEST_URIS)
+def latest_uri(request):
+    """
+    Get a latest resource URI
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def latest_manifest_uri(latest_uris):
+    """
+    Get the latest manifest URI.
+    """
+    latest_manifest_uris = tuple(uri for uri in latest_uris if "manifests" in uri)
+    assert len(latest_manifest_uris) == 1, "There should be exactly one latest manifest"
+    return latest_manifest_uris[0]
+
+
+@pytest.fixture(scope="session")
+def latest_schemas(latest_paths, latest_uris):
+    """
+    Get the text of the latest schemas.
+    """
+    return {latest_uri: latest_path.read_text() for latest_uri, latest_path in zip(latest_uris, latest_paths, strict=True)}
+
+
+@pytest.fixture(scope="session")
+def latest_schema_tags(latest_manifest_uri, latest_schemas):
+    """
+    Get the latest schema tags from the latest manifest.
+    """
+    tag_entries = yaml.safe_load(latest_schemas[latest_manifest_uri])["tags"]
+    schema_tags = {entry["schema_uri"]: entry["tag_uri"] for entry in tag_entries}
+    assert len(schema_tags) == len(tag_entries), "There should be no duplicate tags for a schema"
+    return schema_tags

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,18 +10,28 @@ import yaml
 from rad import resources
 
 
-def test_manifest_integration(manifest_path):
+def test_manifest_integration(manifest_path, manifest_uris):
+    """
+    Check that the manifest is properly integrated with the asdf library.
+    """
     content = manifest_path.read_bytes()
     manifest = yaml.safe_load(content)
-    asdf_content = asdf.get_config().resource_manager[manifest["id"]]
-    assert asdf_content == content
+    uri = manifest["id"]
+
+    assert uri in manifest_uris
+    assert content == asdf.get_config().resource_manager[uri]
 
 
-def test_schema_integration(schema_path):
+def test_schema_integration(schema_path, schema_uris, metaschema_uri):
+    """
+    Check that the schema is properly integrated with the asdf library.
+    """
     content = schema_path.read_bytes()
     schema = yaml.safe_load(content)
-    asdf_content = asdf.get_config().resource_manager[schema["id"]]
-    assert asdf_content == content
+    uri = schema["id"]
+
+    assert uri in schema_uris or uri == metaschema_uri
+    assert content == asdf.get_config().resource_manager[uri]
 
 
 def test_schema_filename(schema_path):

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -12,19 +12,17 @@ import yaml
 
 from rad import resources
 
-from .conftest import LATEST_PATHS
-
 DIRECT_URL = json.loads(Distribution.from_name("rad").read_text("direct_url.json"))
 # Needs to be a bit complicated because tox still creates a wheel, it just does it a bit differently
 # to preserve editable installs
 IS_EDITABLE = DIRECT_URL["dir_info"].get("editable", False) if "dir_info" in DIRECT_URL else "editable" in DIRECT_URL["url"]
 
 
-def test_smoke_latest_paths():
+def test_smoke_latest_paths(latest_paths):
     """
     Smoke test to make sure that the latest paths are not empty.
     """
-    assert LATEST_PATHS
+    assert latest_paths
 
 
 def test_latest_filename(latest_path):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,8 +5,6 @@ to schemas that exist.
 
 import asdf
 
-from .conftest import MANIFEST_URI_PREFIX, RAD_URI_PREFIX, SCHEMA_URI_PREFIX, TAG_URI_PREFIX
-
 
 def test_manifest_valid(manifest):
     """
@@ -20,18 +18,64 @@ def test_manifest_valid(manifest):
     assert "description" in manifest
 
 
-def test_manifest_uris(manifest):
+def test_manifest_uris(manifest, rad_uri_prefix, manifest_uri_prefix):
     """
     Check that the two URIs in the manifest are consistent with each other
         That is check that the uri suffixes are the same for the id and the extension_uri
     """
-    uri_suffix = manifest["id"].split(MANIFEST_URI_PREFIX)[-1]
-    extension_uri_suffix = manifest["extension_uri"].split(f"{RAD_URI_PREFIX}extensions/")[-1]
+    uri_suffix = manifest["id"].split(manifest_uri_prefix)[-1]
+    extension_uri_suffix = manifest["extension_uri"].split(f"{rad_uri_prefix}extensions/")[-1]
 
     assert uri_suffix == extension_uri_suffix
 
 
-def test_manifest_entries(manifest_entry):
+def test_manifest_tag_uris(manifest):
+    """
+    Check that no tags are repeated in the manifest
+    """
+
+    tag_uri = {entry["tag_uri"] for entry in manifest["tags"]}
+    assert len(tag_uri) == len(manifest["tags"]), "Duplicate tags found in the manifest"
+
+
+def test_manifest_schema_uris(manifest):
+    """
+    Check that no schema uris are repeated in the manifest
+    """
+    schema_uris = {entry["schema_uri"] for entry in manifest["tags"]}
+    assert len(schema_uris) == len(manifest["tags"]), "Duplicate schema URIs found in the manifest"
+
+
+def test_manifest_consistency(manifest_uri, manifest_by_schema, manifest_by_tag):
+    """
+    Check that if a schema or tag is in a manifest and repeated in another
+    manifest, that the schema and tag are the same.
+    """
+    # sanity check
+    assert manifest_uri in manifest_by_schema
+    assert manifest_uri in manifest_by_tag
+
+    # Check each map in the current manifest against the other maps
+    for schema_uri, tag_uri in manifest_by_schema[manifest_uri].items():
+        for (manifest_uri, schema_map), tag_map in zip(manifest_by_schema.items(), manifest_by_tag.values(), strict=True):
+            if schema_uri in schema_map:
+                assert tag_uri in tag_map, (
+                    f"Manifest {manifest_uri} has schema {schema_uri} but no tag {tag_uri} as unlike manifest {manifest_uri}, which does"
+                )
+                assert tag_uri == schema_map[schema_uri], (
+                    f"Manifest {manifest_uri} maps schema {schema_uri} to tag {schema_map[schema_uri]} unlike manifest {manifest_uri}, which maps it to {tag_uri}"
+                )
+
+            if tag_uri in tag_map:
+                assert schema_uri in schema_map, (
+                    f"Manifest {manifest_uri} has tag {tag_uri} but no schema {schema_uri} as unlike manifest {manifest_uri}, which does"
+                )
+                assert schema_uri == tag_map[tag_uri], (
+                    f"Manifest {manifest_uri} maps tag {tag_uri} to schema {tag_map[tag_uri]} unlike manifest {manifest_uri}, which maps it to {schema_uri}"
+                )
+
+
+def test_manifest_entries(manifest_entry, schema_uri_prefix, tag_uri_prefix):
     """
     Check that the manifest entries are valid and consistent
     """
@@ -43,11 +87,11 @@ def test_manifest_entries(manifest_entry):
     assert "description" in manifest_entry
 
     # Check the URIs
-    assert manifest_entry["tag_uri"].startswith(TAG_URI_PREFIX)
-    uri_suffix = manifest_entry["tag_uri"].split(TAG_URI_PREFIX)[-1]
+    assert manifest_entry["tag_uri"].startswith(tag_uri_prefix)
+    uri_suffix = manifest_entry["tag_uri"].split(tag_uri_prefix)[-1]
     # Remove tagged scalars from the uri string
     schema_uri = manifest_entry["schema_uri"]
     if "tagged_scalars" in schema_uri.split("/"):
         schema_uri = schema_uri.replace("tagged_scalars/", "")
     assert schema_uri.endswith(uri_suffix)
-    assert schema_uri.startswith(SCHEMA_URI_PREFIX)
+    assert schema_uri.startswith(schema_uri_prefix)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,20 +2,14 @@
 Test features of the schemas not covered by the metaschema.
 """
 
-import re
 from collections.abc import Mapping
+from re import match
 
 import asdf
 import asdf.treeutil
 import pytest
 from crds.config import is_crds_name
 
-from .conftest import CURRENT_RESOURCES, MANIFESTS, METASCHEMA_URI, SCHEMA_URIS, TAG_DEFS
-
-WFI_OPTICAL_ELEMENTS = tuple(
-    asdf.schema.load_schema("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.0.0")["enum"]
-)
-EXPECTED_COMMON_REFERENCE = {"$ref": "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0"}
 METADATA_FORCING_REQUIRED = ("archive_catalog", "sdf")
 
 METADATA_FORCE_XFAILS = (
@@ -53,363 +47,366 @@ VARCHAR_XFAILS = (
     "asdf://stsci.edu/datamodels/roman/schemas/tvac/wfi_mode-1.0.0",
 )
 
-
-def test_required_properties(schema):
-    assert schema["$schema"] == METASCHEMA_URI
-    assert "id" in schema
-    assert "title" in schema
+REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.0.0",)
 
 
-def test_schema_style(schema_content):
-    assert schema_content.startswith(b"%YAML 1.1\n---\n")
-    assert b"\t" not in schema_content
-    assert not any(line != line.rstrip() for line in schema_content.split(b"\n"))
+class TestSchemaContent:
+    """
+    Basic tests for schema content and formatting
+    """
 
+    def test_required_properties(self, schema, metaschema_uri):
+        """
+        Check that all schemas have the required properties
+        -> id, title, and $schema
+        """
+        assert schema["$schema"] == metaschema_uri
+        assert "id" in schema
+        assert "title" in schema
 
-def test_property_order(schema):
-    is_tag_schema = schema["id"] in {t["schema_uri"] for t in TAG_DEFS}
+    def test_schema_style(self, current_content):
+        """
+        Make sure that the schema has the correct style
+        -> YAML 1.1
+        Note the rest of the checks should be covered by the autoformatter
+        """
+        assert current_content.startswith(b"%YAML 1.1\n---\n")
+        assert b"\t" not in current_content
+        assert not any(line != line.rstrip() for line in current_content.split(b"\n"))
 
-    if is_tag_schema:
+    def test_required(self, schema):
+        """
+        Checks that all required properties are present in the schema
+        """
 
         def callback(node):
-            if isinstance(node, Mapping) and "propertyOrder" in node:
+            """Callback for required properties being present"""
+            if isinstance(node, Mapping) and "required" in node:
                 assert node.get("type") == "object"
                 property_names = set(node.get("properties", {}).keys())
-                property_order_names = set(node["propertyOrder"])
-                if property_order_names != property_names:
-                    missing_list = ", ".join(property_order_names - property_names)
-                    extra_list = ", ".join(property_names - property_order_names)
-                    message = (
-                        "propertyOrder does not match list of properties:\n\n"
-                        "missing properties: " + missing_list + "\n"
-                        "extra properties: " + extra_list
-                    )
+                required_names = set(node["required"])
+                if not required_names.issubset(property_names):
+                    message = f"required references names that do not exist: {','.join(required_names - property_names)}"
                     raise ValueError(message)
 
         asdf.treeutil.walk(schema, callback)
-    else:
+
+    def test_exact_datatype(self, schema):
+        """Confirm that `datatype` and `exact_datatype` is defined for all arrays"""
+
+        def callback_ndarray(node, entry):
+            """
+            Identify and check ndarray nodes (entry passed in for error messages)
+            """
+            if isinstance(node, Mapping) and "tag" in node and node["tag"].startswith("tag:stsci.edu:asdf/core/ndarray-"):
+                assert "datatype" in node, f"datatype not found for ndarray entry {entry}"
+                assert "exact_datatype" in node, f"exact_datatype not found for ndarray entry {entry}"
+                assert node["exact_datatype"] is True, f"exact_datatype not True for ndarray entry {entry}"
 
         def callback(node):
+            """
+            Identify and check all nodes, note that we loop over the entries for better error messages
+            """
             if isinstance(node, Mapping):
-                assert "propertyOrder" not in node, "Only schemas associated with a tag may specify propertyOrder"
+                for entry, sub_node in node.items():
+                    callback_ndarray(sub_node, entry)
 
         asdf.treeutil.walk(schema, callback)
 
+    def test_ref_loneliness(self, schema):
+        """
+        An object with a $ref should contain no other items
+        """
 
-def test_required(schema):
-    """
-    Checks that all properties are required if there is a required list.
-    """
+        def callback(node):
+            if not isinstance(node, dict):
+                return
+            if "$ref" not in node:
+                return
+            assert len(node) == 1
 
-    def callback(node):
-        if isinstance(node, Mapping) and "required" in node:
-            assert node.get("type") == "object"
-            property_names = set(node.get("properties", {}).keys())
-            required_names = set(node["required"])
-            if not required_names.issubset(property_names):
-                missing_list = ", ".join(required_names - property_names)
-                message = "required references names that do not exist: " + missing_list
-                raise ValueError(message)
+        asdf.treeutil.walk(schema, callback)
 
-    asdf.treeutil.walk(schema, callback)
+    def test_absolute_ref(self, schema):
+        """
+        Test that all $ref are absolute URIs matching those registered with ASDF
+        """
+        resources = asdf.config.get_config().resource_manager
 
+        def callback(node):
+            if not isinstance(node, dict):
+                return
+            if "$ref" not in node:
+                return
 
-@pytest.mark.parametrize(
-    "uri",
-    [
-        pytest.param(
-            uri,
-            marks=pytest.mark.xfail(
-                reason=f"{uri} is not being altered to ensure required lists for archive metadata, "
-                "due to it being in either tvac or fps."
-            ),
-        )
-        if uri in METADATA_FORCE_XFAILS
-        else uri
-        for uri in SCHEMA_URIS
-    ],
-)
-def test_metadata_force_required(uri):
-    """
-    Test that if certain properties have certain metadata entries, that they are in a required list.
-    """
+            # Check that the $ref is a full URI registered with ASDF
+            assert node["$ref"] in resources
 
-    def callback(node):
-        if isinstance(node, Mapping) and "properties" in node:
-            for prop_name, prop in node["properties"].items():
-                # Test that if a subnode has a required list, that the parent has a required list
-                if isinstance(prop, Mapping) and "required" in prop:
-                    assert "required" in node
-                    assert prop_name in node["required"]
+        asdf.treeutil.walk(schema, callback)
 
-                # Test that if a subnode has certain metadata entries, that the parent has a required list
-                for metadata in METADATA_FORCING_REQUIRED:
-                    if isinstance(prop, Mapping) and metadata in prop:
-                        assert "required" in node, f"metadata {metadata} in {prop_name} requires required list"
+    def test_metadata_force_required(self, schema_uri, schema, request):
+        """
+        Test that if certain properties have certain metadata entries, that they are in a required list.
+        -> Also checks that once required is present in a subnode it is present in the parent node for mappings
+        """
+        # Apply the xfail marker if we expect the test to fail
+        if schema_uri in METADATA_FORCE_XFAILS:
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason=f"{schema_uri} is not being altered to ensure required lists for archive metadata, due to it being in either tvac or fps."
+                )
+            )
+
+        def callback(node):
+            if isinstance(node, Mapping) and "properties" in node:
+                for prop_name, prop in node["properties"].items():
+                    # Test that if a subnode has a required list, that the parent has a required list
+                    if isinstance(prop, Mapping) and "required" in prop:
+                        assert "required" in node
                         assert prop_name in node["required"]
 
-    asdf.treeutil.walk(CURRENT_RESOURCES[uri], callback)
-
-
-@pytest.mark.parametrize("uri", METADATA_FORCE_XFAILS)
-def test_metadata_force_xfail_relevant(uri):
-    """
-    Test that URIS that are marked as failing the metadata are still relevant (in use).
-    -> Smokes out when METADATA_FORCE_XFAILS is not relevant anymore.
-    """
-    assert uri in SCHEMA_URIS, f"{uri} is not in the list of schemas to be tested."
-
-
-def test_flowstyle(schema):
-    is_tag_schema = False
-
-    for manifest in MANIFESTS:
-        if is_tag_schema := schema["id"] in {t["schema_uri"] for t in manifest["tags"]}:
-            break
-
-    if is_tag_schema:
-        found_flowstyle = False
-
-        def callback(node):
-            nonlocal found_flowstyle
-            if isinstance(node, Mapping) and node.get("flowStyle") == "block":
-                found_flowstyle = True
+                    # Test that if a subnode has certain metadata entries, that the parent has a required list
+                    for metadata in METADATA_FORCING_REQUIRED:
+                        if isinstance(prop, Mapping) and metadata in prop:
+                            assert "required" in node, f"metadata {metadata} in {prop_name} requires required list"
+                            assert prop_name in node["required"]
 
         asdf.treeutil.walk(schema, callback)
 
-        assert found_flowstyle, "Schemas associated with a tag must specify flowStyle: block"
-    else:
+    @pytest.mark.parametrize("uri", METADATA_FORCE_XFAILS)
+    def test_metadata_force_xfail_relevant(self, uri, schema_uris):
+        """
+        Test that URIS that are marked as failing the metadata are still relevant (in use).
+        -> Smokes out when METADATA_FORCE_XFAILS is not relevant anymore.
+        """
+        assert uri in schema_uris, f"{uri} is not in the list of schemas to be tested."
+
+    def test_varchar_length(self, schema_uri, schema, request):
+        """
+        Test that varchar(N) in archive_metadata for string objects
+        has a matching maxLength: N validation keyword
+        """
+        # Apply the xfail marker if we expect the test to fail
+        if schema_uri in VARCHAR_XFAILS:
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason=f"{schema_uri} is not being altered to ensure varchar consistency, due to it being in either tvac or fps."
+                )
+            )
+
+        def callback(node, nvarchars=None):
+            nvarchars = nvarchars or {}
+            if not isinstance(node, dict):
+                return
+            if node.get("type", "") != "string":
+                return
+            if "archive_catalog" not in node:
+                return
+            m = match(r"^nvarchar\(([0-9]+)\)$", node["archive_catalog"]["datatype"])
+            if not m:
+                return
+            v = int(m.group(1))
+            assert "maxLength" in node, f"archive_catalog has nvarchar, schema {schema_uri} is missing maxLength"
+            assert node["maxLength"] == v, f"archive_catalog nvarchar does not match maxLength in schema {schema_uri}"
+
+        asdf.treeutil.walk(schema, callback)
+
+    @pytest.mark.parametrize("uri", METADATA_FORCE_XFAILS)
+    def test_varchar_xfail_relevant(self, uri, schema_uris):
+        """
+        Test that URIS that are marked as failing for varchar length are still relevant (in use).
+        -> Smokes out when VARCHAR_XFAILS is not relevant anymore.
+        """
+        assert uri in schema_uris, f"{uri} is not in the list of schemas to be tested."
+
+
+class TestTaggedSchemaContent:
+    """
+    Tests for content related to schemas and their tags
+    """
+
+    def test_tag(self, schema, valid_tag_uris):
+        """
+        Check that the tags in the schema are valid
+        """
 
         def callback(node):
-            if isinstance(node, Mapping):
-                assert "flowStyle" not in node, "Only schemas associated with a tag may specify flowStyle"
+            """Callback to check for valid tags"""
+            if isinstance(node, Mapping) and "tag" in node:
+                assert node["tag"] in valid_tag_uris
+
+        asdf.treeutil.walk(schema, callback)
+
+    def test_property_order(self, schema_uri, schema, tagged_schema_uris):
+        """
+        Check that the propertyOrder is consistent with the properties and is only used in the tag schemas
+        """
+        if schema_uri in tagged_schema_uris:
+
+            def callback(node):
+                """Callback for tagged schemas"""
+                if isinstance(node, Mapping) and "propertyOrder" in node:
+                    assert node.get("type") == "object"
+                    property_names = set(node.get("properties", {}).keys())
+                    property_order_names = set(node["propertyOrder"])
+                    if property_order_names != property_names:
+                        missing_list = ", ".join(property_order_names - property_names)
+                        extra_list = ", ".join(property_names - property_order_names)
+                        message = (
+                            "propertyOrder does not match list of properties:\n\n"
+                            "missing properties: " + missing_list + "\n"
+                            "extra properties: " + extra_list
+                        )
+                        raise ValueError(message)
+        else:
+
+            def callback(node):
+                """Callback for non-tagged schemas"""
+                if isinstance(node, Mapping):
+                    assert "propertyOrder" not in node, "Only schemas associated with a tag may specify propertyOrder"
+
+        asdf.treeutil.walk(schema, callback)
+
+    def test_flowstyle(self, schema_uri, schema, tagged_schema_uris):
+        """
+        Test that tagged schemas have flowStyle: block
+        -> untagged schemas should not have flowStyle
+        """
+        if schema_uri in tagged_schema_uris:
+            found_flowstyle = False
+
+            def callback(node):
+                """Callback for tagged schemas"""
+                nonlocal found_flowstyle
+                if isinstance(node, Mapping) and node.get("flowStyle") == "block":
+                    found_flowstyle = True
+
+            asdf.treeutil.walk(schema, callback)
+
+            assert found_flowstyle, "Schemas associated with a tag must specify flowStyle: block"
+        else:
+
+            def callback(node):
+                """Callback for non-tagged schemas"""
+                if isinstance(node, Mapping):
+                    assert "flowStyle" not in node, "Only schemas associated with a tag may specify flowStyle"
+
+            asdf.treeutil.walk(schema, callback)
+
+    def test_datamodel_name(self, schema_uri, schema):
+        def callback(node):
+            if isinstance(node, Mapping) and "datamodel_name" in node:
+                schema_name = schema_uri.split("/")[-1].split("-")[0]
+                class_name = "".join([p.capitalize() for p in schema_name.split("_")])
+                if schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/reference_files/"):
+                    class_name += "Ref"
+
+                if class_name not in ["WfiWcs"]:  # Names to be unmodified
+                    if class_name.startswith("Wfi") and "Ref" not in class_name:
+                        class_name = class_name.split("Wfi")[-1]
+                    elif class_name.startswith("MatableRef"):
+                        class_name = "MATableRef" + class_name.split("MatableRef")[-1]
+
+                datamodel_name = f"{class_name}Model"
+                assert node["datamodel_name"] == datamodel_name, (
+                    f"datamodel_name {node['datamodel_name']} does not match expected {datamodel_name}"
+                )
 
         asdf.treeutil.walk(schema, callback)
 
 
-def test_tag(schema, valid_tag_uris):
-    def callback(node):
-        if isinstance(node, Mapping) and "tag" in node:
-            assert node["tag"] in valid_tag_uris
+class TestReferenceFileSchemas:
+    """Reference file schema specific tests"""
 
-    asdf.treeutil.walk(schema, callback)
+    def get_reftype(self, schema):
+        """
+        Extract the reftype from the schema
+        """
+        all_of = schema["properties"]["meta"]["allOf"]
 
+        for sub_schema in all_of:
+            if "properties" in sub_schema:
+                assert "reftype" in sub_schema["properties"], "A defined reftype is required"
+                assert "enum" in sub_schema["properties"]["reftype"], "The reftype must be enumerated"
+                assert len(sub_schema["properties"]["reftype"]["enum"]) == 1, "The reftype must be a single value"
+                return sub_schema["properties"]["reftype"]["enum"][0]
 
-def _model_name_from_schema_uri(schema_uri):
-    schema_name = schema_uri.split("/")[-1].split("-")[0]
-    class_name = "".join([p.capitalize() for p in schema_name.split("_")])
-    if schema_uri.startswith("asdf://stsci.edu/datamodels/roman/schemas/reference_files/"):
-        class_name += "Ref"
+        raise ValueError("No reftype found in schema")
 
-    if class_name not in ["WfiWcs"]:  # Names to be unmodified
-        if class_name.startswith("Wfi") and "Ref" not in class_name:
-            class_name = class_name.split("Wfi")[-1]
-        elif class_name.startswith("MatableRef"):
-            class_name = "MATableRef" + class_name.split("MatableRef")[-1]
+    def test_reftype(self, ref_file_schema):
+        """
+        Check that the reftype is valid for CRDS
+        """
 
-    return f"{class_name}Model"
+        def callback(node):
+            if (
+                isinstance(node, Mapping)
+                and "properties" in node
+                and "meta" in node["properties"]
+                and "allOf" in node["properties"]["meta"]
+            ):
+                reftype = self.get_reftype(node)
+                assert is_crds_name(f"roman_wfi_{reftype.lower()}_0000.asdf"), f"Invalid reftype {reftype} for CRDS"
 
+        asdf.treeutil.walk(ref_file_schema, callback)
 
-def test_datamodel_name(schema):
-    if "datamodel_name" in schema:
-        assert _model_name_from_schema_uri(schema["id"]) == schema["datamodel_name"]
+    def test_reftype_tag(self, ref_file_uri, schema_tag_map, ref_file_schema):
+        """
+        Check that the URIs match the reftype for a valid CRDS check
+        """
 
+        if ref_file_uri in schema_tag_map:
+            reftype = self.get_reftype(ref_file_schema).lower()
+            ref_file_tag_uri = schema_tag_map[ref_file_uri]
+            assert asdf.util.uri_match(f"asdf://stsci.edu/datamodels/roman/tags/reference_files/*{reftype}-*", ref_file_tag_uri)
+            assert asdf.util.uri_match(f"asdf://stsci.edu/datamodels/roman/schemas/reference_files/*{reftype}-*", ref_file_uri)
 
-def test_phot_table_keys_have_optical_element_entry(phot_table_key_pattern, optical_element):
-    """
-    Confirm that the optical_element filter in wfi_img_photom.yaml matches WFI_OPTICAL_ELEMENTS
-    """
-    assert phot_table_key_pattern.search(optical_element), f"phot_table_key pattern is missing {optical_element}."
+    def test_ref_file_meta_common(self, ref_file_uri, ref_file_schema, schema_tag_map, request):
+        """
+        Test that the meta for all reference files contains a reference to `ref_common`
+        """
+        # Apply the xfail marker if we expect the test to fail
+        if ref_file_uri in REF_COMMON_XFAILS:
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason=f"{ref_file_uri}, does not have a ref_common entry in the meta because it is inconsistent with the skycell formulation."
+                )
+            )
 
+        if ref_file_uri in schema_tag_map:
+            for item in ref_file_schema["properties"]["meta"]["allOf"]:
+                if isinstance(item, dict) and "$ref" in item:
+                    assert item["$ref"].startswith("asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-")
+                    return
 
-def test_optical_elements_have_phot_table_key(phot_table_key, optical_elements):
-    """
-    Confirm that the optical_element filter in wfi_img_photom.yaml matches WFI_OPTICAL_ELEMENTS
-    """
-    assert phot_table_key in optical_elements, f"phot_table_key {phot_table_key} not found in optical_elements."
+            raise ValueError("ref_common not found in meta")
 
-
-def test_p_exptype_entries_have_exposure_type(p_exptype_pattern, exposure_type):
-    """Confirm that the p_keyword version of exposure type match the enum version."""
-    assert p_exptype_pattern.search(f"{exposure_type}|"), f"p_exptype pattern is missing {exposure_type}."
-
-
-def test_exposure_types_have_p_exptype_entry(p_exptype, exposure_types):
-    """Confirm that the p_exptype entry is in the exposure_types enum."""
-    assert p_exptype in exposure_types, f"p_exptype {p_exptype} not found in exposure_types."
-
-
-def _find_ndarrays(key, schema):
-    """
-    Find all the ndarray entries in the schema
-    """
-    entries = []
-    if isinstance(schema, dict):
-        for new_key, value in schema.items():
-            if isinstance(value, str) and value.startswith("tag:stsci.edu:asdf/core/ndarray-"):
-                entries.append((key,))
-            else:
-                entries.extend((key, *key_) for key_ in _find_ndarrays(new_key, value))
-    elif isinstance(schema, list):
-        for index, value in enumerate(schema):
-            entries.extend((key, *key_) for key_ in _find_ndarrays(index, value))
-
-    return entries
-
-
-def _get_ndarray_entry(schema, entry):
-    """
-    Get the ndarray portion of the schema for the entry
-    """
-    current = schema
-
-    for key in entry[1:]:
-        current = current[key]
-
-    return current
+    @pytest.mark.parametrize("uri", REF_COMMON_XFAILS)
+    def test_ref_common_xfail_relevant(self, uri, schema_uris):
+        """
+        Test that URIS that are marked as failing the ref_common are still relevant (in use).
+        -> Smokes out when REF_COMMON_XFAILS is not relevant anymore.
+        """
+        assert uri in schema_uris, f"{uri} is not in the list of schemas to be tested."
 
 
-def test_exact_datatype(schema):
-    """Confirm that `exact_datatype` is defined for all arrays"""
-    entries = _find_ndarrays("", schema)
+class TestPatternElementConsistency:
+    def test_phot_table_keys_have_optical_element_entry(self, phot_table_key_pattern, optical_element):
+        """
+        Confirm that the optical_element filter in wfi_img_photom.yaml matches optical_element
+        """
+        assert phot_table_key_pattern.search(optical_element), f"phot_table_key pattern is missing {optical_element}."
 
-    if entries:
-        for entry in entries:
-            if "datatype" in (ndarray_entry := _get_ndarray_entry(schema, entry)):
-                assert "exact_datatype" in ndarray_entry, f"extact_datatype needed for {'.'.join(entry[1:])}"
-                assert ndarray_entry["exact_datatype"] is True
-            else:
-                raise ValueError(f"datatype not found for {'.'.join(entry[1:])}")
+    def test_optical_elements_have_phot_table_key(self, phot_table_key, optical_elements):
+        """
+        Confirm that the optical_element filter in wfi_img_photom.yaml matches optical_element
+        """
+        assert phot_table_key in optical_elements, f"phot_table_key {phot_table_key} not found in optical_elements."
 
+    def test_p_exptype_entries_have_exposure_type(self, p_exptype_pattern, exposure_type):
+        """Confirm that the p_keyword version of exposure type match the enum version."""
+        assert p_exptype_pattern.search(f"{exposure_type}|"), f"p_exptype pattern is missing {exposure_type}."
 
-def _get_reftype(schema):
-    """
-    Extract the reftype from the schema
-    """
-    all_of = schema["properties"]["meta"]["allOf"]
-
-    for sub_schema in all_of:
-        if "properties" in sub_schema:
-            return sub_schema["properties"]["reftype"]["enum"][0]
-
-
-def test_reftype(ref_file_schema):
-    """
-    Check that the reftype is valid for CRDS
-    """
-    reftype = _get_reftype(ref_file_schema)
-    assert is_crds_name(f"roman_wfi_{reftype.lower()}_0000.asdf")
-
-
-def test_reftype_tag(ref_file_uris):
-    """
-    Check that the URIs match the reftype for a valid CRDS check
-    """
-    tag_uri = ref_file_uris[0]
-    schema_uri = ref_file_uris[1]
-
-    schema = CURRENT_RESOURCES[schema_uri]
-
-    reftype = _get_reftype(schema).lower()
-
-    assert asdf.util.uri_match(f"asdf://stsci.edu/datamodels/roman/tags/reference_files/*{reftype}-*", tag_uri)
-    assert asdf.util.uri_match(f"asdf://stsci.edu/datamodels/roman/schemas/reference_files/*{reftype}-*", schema_uri)
-
-
-def test_ref_file_meta_common(ref_file_schema):
-    """
-    Test that the meta for all reference files contains a reference to `ref_common`
-    """
-    all_of = ref_file_schema["properties"]["meta"]["allOf"]
-
-    if ref_file_schema["id"].find("skycells") >= 0:
-        return
-
-    for item in all_of:
-        if item == EXPECTED_COMMON_REFERENCE:
-            break
-    else:
-        raise ValueError("ref_common not found in meta")
-
-
-@pytest.mark.parametrize(
-    "uri",
-    [
-        pytest.param(
-            uri,
-            marks=pytest.mark.xfail(
-                reason=f"{uri} is not being altered to ensure varchar consistency, due to it being in either tvac or fps."
-            ),
-        )
-        if uri in VARCHAR_XFAILS
-        else uri
-        for uri in SCHEMA_URIS
-    ],
-)
-def test_varchar_length(uri):
-    """
-    Test that varchar(N) in archive_metadata for string objects
-    has a matching maxLength: N validation keyword
-    """
-    schema = CURRENT_RESOURCES[uri]
-
-    def callback(node, nvarchars=None):
-        nvarchars = nvarchars or {}
-        if not isinstance(node, dict):
-            return
-        if node.get("type", "") != "string":
-            return
-        if "archive_catalog" not in node:
-            return
-        m = re.match(r"^nvarchar\(([0-9]+)\)$", node["archive_catalog"]["datatype"])
-        if not m:
-            return
-        v = int(m.group(1))
-        assert "maxLength" in node, f"archive_catalog has nvarchar, schema {uri} is missing maxLength"
-        assert node["maxLength"] == v, f"archive_catalog nvarchar does not match maxLength in schema {uri}"
-
-    asdf.treeutil.walk(schema, callback)
-
-
-@pytest.mark.parametrize("uri", METADATA_FORCE_XFAILS)
-def test_varchar_xfail_relevant(uri):
-    """
-    Test that URIS that are marked as failing for varchar length are still relevant (in use).
-    -> Smokes out when VARCHAR_XFAILS is not relevant anymore.
-    """
-    assert uri in SCHEMA_URIS, f"{uri} is not in the list of schemas to be tested."
-
-
-def test_ref_loneliness(schema_uri):
-    """
-    An object with a $ref should contain no other items
-    """
-    schema = asdf.schema.load_schema(schema_uri)
-
-    def callback(node):
-        if not isinstance(node, dict):
-            return
-        if "$ref" not in node:
-            return
-        assert len(node) == 1
-
-    asdf.treeutil.walk(schema, callback)
-
-
-def test_absolute_ref(schema_uri):
-    """
-    Test that all $ref are absolute URIs matching those registered with ASDF
-    """
-    schema = asdf.schema.load_schema(schema_uri)
-    resources = asdf.config.get_config().resource_manager
-
-    def callback(node):
-        if not isinstance(node, dict):
-            return
-        if "$ref" not in node:
-            return
-
-        # Check that the $ref is a full URI registered with ASDF
-        assert node["$ref"] in resources
-
-    asdf.treeutil.walk(schema, callback)
+    def test_exposure_types_have_p_exptype_entry(self, p_exptype, exposure_types):
+        """Confirm that the p_exptype entry is in the exposure_types enum."""
+        assert p_exptype in exposure_types, f"p_exptype {p_exptype} not found in exposure_types."

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -34,7 +34,6 @@ for x-failing given comparisons, so we can ignore potential false positives.
 from collections.abc import Mapping
 from contextlib import suppress
 from io import BytesIO
-from itertools import product
 from pathlib import Path
 from re import findall
 
@@ -44,13 +43,11 @@ from asdf.treeutil import walk_and_modify
 from git import Repo
 from semantic_version import Version
 
-from .conftest import CURRENT_RESOURCES
-
 # Using a python library load the actual RAD repository data into python
 # object which can be interacted with.
 REPO = Repo(Path(__file__).parent.parent)
 RAD_URLS = (
-    "https://github.com/spacetelescope/rad.git",
+    "https://github.com/spacetelescope/rad",
     "git@github.com:spacetelescope/rad.git",
 )
 
@@ -71,6 +68,97 @@ IGNORED_KEYWORDS = (
     "description",
     "propertyOrder",
 )
+
+
+def _update_tags():
+    """
+    Pull all the tags from the RAD Repository.
+    """
+
+    for remote in REPO.remotes:
+        with suppress(AttributeError):
+            url = remote.url
+            if url in RAD_URLS:
+                remote.fetch(tags=True)
+                return
+
+    raise ValueError(
+        f"Unable to find the main RAD repository remote. Please add a remote with one of the following URLs: {RAD_URLS}"
+    )
+
+
+def _get_versions():
+    """
+    Get all release versions for RAD that are under schema versioning.
+
+    Note
+    ----
+    This bases things off the git repository itself for the RAD repository, meaning
+    that this will only work when the tests are run with this file within the RAD
+    repository.
+
+    This assumes that the current tagging scheme for RAD (release versions: 0.23.1, 0.24.0, etc.)
+    is followed, and that these tags exactly correspond to the released version of
+    the RAD on PyPi.
+
+    Returns
+    -------
+    tuple[str]
+        A tuple of all the release versions for RAD that are under schema versioning
+        in order of the version number.
+
+    Returns
+    -------
+    tuple[str]
+        A tuple of all the release versions for RAD that are under schema versioning
+        in order of the version number.
+    """
+    _update_tags()
+    # Note that the `$` means that it will only match if the version number is the
+    # end of the string, this eliminates the possibility of detecting `dev` tags
+    #     That is this will match `0.23.1` and `0.24.0` but not `0.25.0.dev`
+    pattern = r"\d+\.\d+\.\d+$"
+
+    # Set to avoid duplicates
+    versions = set()
+    # Loop over all the tags in the repository
+    for tag in REPO.tags:
+        # Regex match the tag version to get the version number, there should
+        # only be one match. Ideally this should fail
+        if matches := findall(pattern, tag.name):
+            # This should never be the case based on the regex pattern but
+            # its better to be safe than sorry.
+            if len(matches) != 1:
+                raise ValueError(f"Tag {tag.name} does not match the versioning scheme")
+
+            # Turn the version into a semantic version object so that we can compare
+            # it to the base (oldest) release version
+            version = Version(matches[0])
+            if version >= BASE_RELEASE:
+                versions.add(version)
+
+    # Sort the versions in order of the version number
+    return tuple(str(v) for v in sorted(versions))
+
+
+# Read out all the versioins for RAD.
+_VERSIONS = _get_versions()
+
+
+@pytest.fixture(scope="module")
+def rad_versions():
+    """
+    Fixture to get the RAD versions for the tests.
+    """
+    return _VERSIONS
+
+
+@pytest.fixture(scope="module", params=_VERSIONS)
+def rad_version(request):
+    """
+    Fixture to get a RAD version to test against.
+    """
+    return request.param
 
 
 def filter_ignored_keys(tree):
@@ -109,84 +197,15 @@ def filter_ignored_keys(tree):
 
 
 # Get the current resources read through the conftest file and flatten them
-FILTERED_CURRENT_RESOURCES = {uri: filter_ignored_keys(schema) for uri, schema in CURRENT_RESOURCES.items()}
-
-
-def update_tags():
+@pytest.fixture(scope="module")
+def filtered_current_resources(current_resources):
     """
-    Pull all the tags from the RAD Repository.
+    Fixture to get the current resources for the tests.
     """
-
-    for remote in REPO.remotes:
-        with suppress(AttributeError):
-            url = remote.url
-            if url in RAD_URLS:
-                remote.fetch(tags=True)
-                return
-
-    raise ValueError(
-        f"Unable to find the main RAD repository remote. Please add a remote with one of the following URLs: {RAD_URLS}"
-    )
+    return {uri: filter_ignored_keys(schema) for uri, schema in current_resources.items()}
 
 
-def get_versions():
-    """
-    Get all release versions for RAD that are under schema versioning.
-
-    Note
-    ----
-    This bases things off the git repository itself for the RAD repository, meaning
-    that this will only work when the tests are run with this file within the RAD
-    repository.
-
-    This assumes that the current tagging scheme for RAD (release versions: 0.23.1, 0.24.0, etc.)
-    is followed, and that these tags exactly correspond to the released version of
-    the RAD on PyPi.
-
-    Returns
-    -------
-    tuple[str]
-        A tuple of all the release versions for RAD that are under schema versioning
-        in order of the version number.
-
-    Returns
-    -------
-    tuple[str]
-        A tuple of all the release versions for RAD that are under schema versioning
-        in order of the version number.
-    """
-    # Note that the `$` means that it will only match if the version number is the
-    # end of the string, this eliminates the possibility of detecting `dev` tags
-    #     That is this will match `0.23.1` and `0.24.0` but not `0.25.0.dev`
-    pattern = r"\d+\.\d+\.\d+$"
-
-    # Set to avoid duplicates
-    versions = set()
-    # Loop over all the tags in the repository
-    for tag in REPO.tags:
-        # Regex match the tag version to get the version number, there should
-        # only be one match. Ideally this should fail
-        if matches := findall(pattern, tag.name):
-            # This should never be the case based on the regex pattern but
-            # its better to be safe than sorry.
-            if len(matches) != 1:
-                raise ValueError(f"Tag {tag.name} does not match the versioning scheme")
-
-            # Turn the version into a semantic version object so that we can compare
-            # it to the base (oldest) release version
-            version = Version(matches[0])
-            if version >= BASE_RELEASE:
-                versions.add(version)
-
-    # Sort the versions in order of the version number
-    return tuple(str(v) for v in sorted(versions))
-
-
-# Read out all the versioins for RAD.
-VERSIONS = get_versions()
-
-
-def get_frozen_schemas(version):
+def _get_frozen_schemas(version):
     """
     Returns the frozen schemas for a given version.
 
@@ -262,7 +281,7 @@ def get_frozen_schemas(version):
     return {uri: schemas[uri] for uri in sorted(schemas.keys())}
 
 
-def get_frozen_schemas_for_all_versions():
+def _get_frozen_schemas_for_all_versions():
     """
     Find all the frozen schema versions for all the releases post BASE_RELEASE.
 
@@ -276,8 +295,8 @@ def get_frozen_schemas_for_all_versions():
     """
     schemas = {}
     uris = []
-    for version in VERSIONS:
-        version_schemas = get_frozen_schemas(version)
+    for version in _VERSIONS:
+        version_schemas = _get_frozen_schemas(version)
         schemas[version] = version_schemas
         for uri in version_schemas:
             if uri not in uris:
@@ -287,10 +306,18 @@ def get_frozen_schemas_for_all_versions():
 
 
 # Get all the frozen schema information and the set of frozen schema URIs
-FROZEN_VERSIONS, FROZEN_URIS = get_frozen_schemas_for_all_versions()
+_FROZEN_VERSIONS, _FROZEN_URIS = _get_frozen_schemas_for_all_versions()
 
 
-@pytest.fixture(scope="module", params=FROZEN_URIS)
+@pytest.fixture(scope="module")
+def frozen_uris():
+    """
+    Fixture to get the frozen schema URIs for the tests.
+    """
+    return _FROZEN_URIS
+
+
+@pytest.fixture(scope="module", params=_FROZEN_URIS)
 def frozen_uri(request):
     """
     Fixture to get a frozen schema URI to test against.
@@ -298,12 +325,20 @@ def frozen_uri(request):
     return request.param
 
 
+@pytest.fixture(scope="module")
+def frozen_resources(rad_version):
+    """
+    Fixture to get the frozen schemas for a specific RAD version.
+    """
+    return _FROZEN_VERSIONS[rad_version]
+
+
 class TestVersioning:
     """
     Test to verify that schema versioning has not been violated
     """
 
-    def test_no_lost_uris(self, frozen_uri):
+    def test_no_lost_uris(self, frozen_uri, current_resources):
         """
         Test that all previously frozen schema uris are present in the current version
 
@@ -312,29 +347,20 @@ class TestVersioning:
         If we decide to create an archive, we can simply include a check to a listing
         of those resources as part of the test.
         """
-        assert frozen_uri in CURRENT_RESOURCES, f"Schema {frozen_uri} is not present in the current version"
+        assert frozen_uri in current_resources, f"Schema {frozen_uri} is not present in the current version"
 
-    @pytest.mark.parametrize(
-        ("rad_version", "frozen_uri"),
-        [
-            pytest.param(
-                *item,
-                marks=pytest.mark.xfail(
-                    reason=f"Schema {item[1]} is expected to have changed between {item[0]} and the current changes"
-                ),
-            )
-            if item in EXPECTED_XFAILS
-            else item
-            for item in product(VERSIONS, FROZEN_URIS)
-        ],
-    )
-    def test_resource_changes(self, rad_version, frozen_uri):
+    def test_resource_changes(self, rad_version, frozen_resources, frozen_uri, filtered_current_resources, request):
         """
         Test that frozen schemas have not been changed between version including the
         current state of the repository
         """
-        # Get the resources for both the frozen and current versions
-        frozen_resources = FROZEN_VERSIONS[rad_version]
+
+        if (rad_version, frozen_uri) in EXPECTED_XFAILS:
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason=f"Schema {frozen_uri} is expected to have changed between {rad_version} and the current changes"
+                )
+            )
 
         # We need to check that the frozen_uri is in the set of frozen resources
         # under consideration. This is because a frozen_uri may be added in a subsequent
@@ -343,7 +369,7 @@ class TestVersioning:
         if frozen_uri in frozen_resources:
             # Get the flattened dictionary representation of both schemas
             frozen_resource = frozen_resources[frozen_uri]
-            current_resource = FILTERED_CURRENT_RESOURCES[frozen_uri]
+            current_resource = filtered_current_resources[frozen_uri]
 
             # Check that the frozen resource is the same as the current resource
             assert frozen_resource == current_resource, (
@@ -351,10 +377,10 @@ class TestVersioning:
             )
 
     @pytest.mark.parametrize(("rad_version", "frozen_uri"), EXPECTED_XFAILS)
-    def test_expected_xfails_relevance(self, rad_version, frozen_uri):
+    def test_expected_xfails_relevance(self, rad_version, frozen_uri, rad_versions, frozen_uris):
         """
         Test that the expected fails are relevant to the current version of RAD
         -> Smokes out when the EXPECTED_XFAILS are no longer relevant
         """
-        assert rad_version in VERSIONS, f"Version {rad_version} is not a valid version of RAD"
-        assert frozen_uri in FROZEN_URIS, f"URI {frozen_uri} is not a valid frozen URI"
+        assert rad_version in rad_versions, f"Version {rad_version} is not a valid version of RAD"
+        assert frozen_uri in frozen_uris, f"URI {frozen_uri} is not a valid frozen URI"


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR bumps the datamodels manifest so that we can start making changes for the next version.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
