### PR TITLE
Small bugfix for the rad resource helper

### DIFF
--- a/scripts/helper/_manager.py
+++ b/scripts/helper/_manager.py
@@ -73,6 +73,7 @@ class _Manager:
         self._key_map = key_map or {}
 
         self._frozen = frozen or frozen_uris(path)
+        self._walk_resources()
 
     def __getitem__(self, item: Path | str) -> Resource:
         """
@@ -340,6 +341,14 @@ class _Manager:
 
             if (update.uri in resource.body or update.tag_uri in resource.body) and resource.frozen:
                 yield Bump(resource, self._resources_to_update(resource.path))
+
+    def _walk_resources(self) -> None:
+        """
+        Walk through the resources in the repository and add them to the manager.
+        --> This is used to initialize the manager with the resources in the repository.
+        """
+        for path in (self._repository / "latest").glob("**/*.yaml"):
+            self._add_resource(path)
 
 
 class Manager(_Manager, DirectoryTree):


### PR DESCRIPTION
The manager was not populating the sub directories without the user interacting directly with that subdirectory in the app widget. This fixes that by forcing it to walk the entire thing.
## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
