### PR TITLE
Remove deprecated exposure types from schema definitions

### DIFF
--- a/changes/636.feature.rst
+++ b/changes/636.feature.rst
@@ -1,0 +1,1 @@
+Remove WFI_DARK, WFI_GRISM, and WFI_PRISM from exposure types.

--- a/latest/exposure_type.yaml
+++ b/latest/exposure_type.yaml
@@ -22,8 +22,4 @@ enum:
   - WFI_FLAT
   - WFI_LOLO
   - WFI_WFSC
-  # These are slated for removal in the future
-  - WFI_DARK
-  - WFI_GRISM
-  - WFI_PRISM
 maxLength: 25

--- a/latest/reference_files/ref_exposure_type.yaml
+++ b/latest/reference_files/ref_exposure_type.yaml
@@ -24,6 +24,6 @@ properties:
           The potentially multiple mode strings applied to data for reference
           file matching in CRDS. Modes are separated by "|".
         type: string
-        pattern: "^((WFI_IMAGE|WFI_SPECTRAL|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC|WFI_DARK|WFI_GRISM|WFI_PRISM)\\s*\\|\\s*)+$"
+        pattern: "^((WFI_IMAGE|WFI_SPECTRAL|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC)\\s*\\|\\s*)+$"
     required: [type, p_exptype]
 required: [exposure]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-nnnn](https://jira.stsci.edu/browse/RAD-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #606

<!-- describe the changes comprising this PR here -->

This PR removes the outdated exposure types.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
