### PR TITLE
Revert "Remove deprecated exposure types from schema definitions"

### DIFF
--- a/changes/636.feature.rst
+++ b/changes/636.feature.rst
@@ -1,1 +1,0 @@
-Remove WFI_DARK, WFI_GRISM, and WFI_PRISM from exposure types.

--- a/latest/exposure_type.yaml
+++ b/latest/exposure_type.yaml
@@ -22,4 +22,8 @@ enum:
   - WFI_FLAT
   - WFI_LOLO
   - WFI_WFSC
+  # These are slated for removal in the future
+  - WFI_DARK
+  - WFI_GRISM
+  - WFI_PRISM
 maxLength: 25

--- a/latest/reference_files/ref_exposure_type.yaml
+++ b/latest/reference_files/ref_exposure_type.yaml
@@ -24,6 +24,6 @@ properties:
           The potentially multiple mode strings applied to data for reference
           file matching in CRDS. Modes are separated by "|".
         type: string
-        pattern: "^((WFI_IMAGE|WFI_SPECTRAL|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC)\\s*\\|\\s*)+$"
+        pattern: "^((WFI_IMAGE|WFI_SPECTRAL|WFI_IM_DARK|WFI_SP_DARK|WFI_FLAT|WFI_LOLO|WFI_WFSC|WFI_DARK|WFI_GRISM|WFI_PRISM)\\s*\\|\\s*)+$"
     required: [type, p_exptype]
 required: [exposure]


### PR DESCRIPTION
Reverts spacetelescope/rad#636

This caused several regtest failures for the scheduled run:
https://github.com/spacetelescope/RegressionTests/actions/runs/16208770638

Until we have a fix for this I vote for reverting.
