### PR TITLE
remove ref_file maxLength

### DIFF
--- a/changes/642.bugfix.rst
+++ b/changes/642.bugfix.rst
@@ -1,0 +1,1 @@
+Remove maxLength from ref_file entries to fix ValidationError exceptions caused by long paths.

--- a/latest/common.yaml
+++ b/latest/common.yaml
@@ -37,7 +37,7 @@ allOf:
         tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
       ref_file:
         title: Reference File Information
-        tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+        tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.2.0
       rcs:
         title: Relative Calibration System Information
         tag: asdf://stsci.edu/datamodels/roman/tags/rcs-1.1.0

--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -258,8 +258,8 @@ tags:
     title: Calibration log messages
     description: |-
       Calibration log message
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.2.0
     title: Calibration reference file names.
     description: |-
       Calibration reference file names.

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -28,7 +28,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
           ref_file:
             title: Reference File Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.2.0
           visit:
             title: Visit Information
             tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -28,7 +28,7 @@ properties:
             tag: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
           ref_file:
             title: Reference File Information
-            tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+            tag: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.2.0
           visit:
             title: Visit Information
             tag: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0

--- a/latest/ref_file.yaml
+++ b/latest/ref_file.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.2.0
 
 title: Reference File Information
 type: object
@@ -59,9 +59,8 @@ properties:
       Name of the calibration reference file used to apply
       the aperture correction to the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [ScienceRefData.r_apcorr, GuideWindow.r_apcorr, WFICommon.r_apcorr]
   area:
@@ -71,9 +70,8 @@ properties:
       pixel-to-pixel estimates of the area of each detector pixel on
       the sky.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_area, GuideWindow.r_area, WFICommon.r_area]
   dark:
     title: Dark Reference File Information
@@ -81,9 +79,8 @@ properties:
       Name of the calibration reference file used to correct
       for dark current signal in the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_dark, GuideWindow.r_dark, WFICommon.r_dark]
   distortion:
     title: Distortion Reference File Information
@@ -92,9 +89,8 @@ properties:
       the geometric distortion model in the world coordinate system
       (WCS) of the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [
           ScienceRefData.r_distortion,
@@ -107,9 +103,8 @@ properties:
       Name of the calibration reference file used to apply
       the ePSF model to the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_epsf, GuideWindow.r_epsf, WFICommon.r_epsf]
   mask:
     title: Bad Pixel Mask Reference File Information
@@ -117,9 +112,8 @@ properties:
       Name of the calibration reference file used to mark
       bad pixels in the data quality array of the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_mask, GuideWindow.r_mask, WFICommon.r_mask]
   flat:
     title: Flat Reference File Information
@@ -128,9 +122,8 @@ properties:
       for element-dependent, spatially-variable sensitivity in the
       science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_flat, GuideWindow.r_flat, WFICommon.r_flat]
   gain:
     title: Gain Reference Rile Information
@@ -139,9 +132,8 @@ properties:
       between data numbers (DN) and photo-electrons in the science
       data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination: [ScienceRefData.r_gain, GuideWindow.r_gain, WFICommon.r_gain]
   inverse_linearity:
     title: Inverse Linearity Reference File Information
@@ -150,9 +142,8 @@ properties:
       simulations of Level 1 data products to imprint the effect of
       classical non-linearity in the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [
           ScienceRefData.r_inverse_linearity,
@@ -165,9 +156,8 @@ properties:
       Name of the calibration reference file used to correct
       for classical linearity in the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [
           ScienceRefData.r_linearity,
@@ -181,9 +171,8 @@ properties:
       photometric zeropoints and related information populated into
       the science product metadata.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [ScienceRefData.r_photom, GuideWindow.r_photom, WFICommon.r_photom]
   readnoise:
@@ -192,9 +181,8 @@ properties:
       Name of the calibration reference file that estimates
       the pixel-to-pixel read noise in the science data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [
           ScienceRefData.r_readnoise,
@@ -207,9 +195,8 @@ properties:
       Name of the calibration reference file used to correct
       for 1/f noise using the reference pixels.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [ScienceRefData.r_refpix, GuideWindow.r_refpix, WFICommon.r_refpix]
   saturation:
@@ -218,9 +205,8 @@ properties:
       Information about the saturation reference file used with the science
       data.
     type: string
-    maxLength: 120
     archive_catalog:
-      datatype: nvarchar(120)
+      datatype: nvarchar(max)
       destination:
         [
           ScienceRefData.r_saturation,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
 rad = "rad.integration:get_resource_mappings"
 
 [build-system]
-requires = ["setuptools >=61", "setuptools_scm[toml] >=3.4"]
+requires = ["setuptools >=77", "setuptools_scm[toml] >=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/src/rad/resources/schemas/ref_file-1.1.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.1.0.yaml
@@ -1,1 +1,250 @@
-../../../../latest/ref_file.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.1.0
+
+title: Reference File Information
+type: object
+properties:
+  crds:
+    title: Calibration Reference Data System (CRDS) Information
+    description: |
+      Calibration Reference Data System Parameters
+    type: object
+    properties:
+      version:
+        title: CRDS Software Version
+        description: |
+          Version of the Calibration Reference Data
+          System (CRDS) software package used to match calibration
+          reference files to science observations.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        maxLength: 120
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination:
+            [
+              WFIExposure.crds_version,
+              WFIMosaic.crds_version,
+              GuideWindow.crds_version,
+              WFICommon.crds_version,
+            ]
+      context:
+        title: CRDS Context
+        description: |
+          Name of the Calibration Reference Data System
+          (CRDS) context (.pmap) file used to match calibration
+          reference files to science observations.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        maxLength: 120
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination:
+            [
+              WFIExposure.crds_context,
+              WFIMosaic.crds_context,
+              GuideWindow.crds_context,
+              WFICommon.crds_context,
+            ]
+    required: [version, context]
+  apcorr:
+    title: Aperture Correction Reference File Schema
+    description: |
+      Name of the calibration reference file used to apply
+      the aperture correction to the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [ScienceRefData.r_apcorr, GuideWindow.r_apcorr, WFICommon.r_apcorr]
+  area:
+    title: Pixel Area Reference File Information
+    description: |
+      Name of the calibration reference file containing the
+      pixel-to-pixel estimates of the area of each detector pixel on
+      the sky.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_area, GuideWindow.r_area, WFICommon.r_area]
+  dark:
+    title: Dark Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for dark current signal in the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_dark, GuideWindow.r_dark, WFICommon.r_dark]
+  distortion:
+    title: Distortion Reference File Information
+    description: |
+      Name of the calibration reference file used to include
+      the geometric distortion model in the world coordinate system
+      (WCS) of the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_distortion,
+          GuideWindow.r_distortion,
+          WFICommon.r_distortion,
+        ]
+  epsf:
+    title: ePSF Reference File Information
+    description: |
+      Name of the calibration reference file used to apply
+      the ePSF model to the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_epsf, GuideWindow.r_epsf, WFICommon.r_epsf]
+  mask:
+    title: Bad Pixel Mask Reference File Information
+    description: |
+      Name of the calibration reference file used to mark
+      bad pixels in the data quality array of the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_mask, GuideWindow.r_mask, WFICommon.r_mask]
+  flat:
+    title: Flat Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for element-dependent, spatially-variable sensitivity in the
+      science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_flat, GuideWindow.r_flat, WFICommon.r_flat]
+  gain:
+    title: Gain Reference Rile Information
+    description: |
+      Name of the calibration reference file used to convert
+      between data numbers (DN) and photo-electrons in the science
+      data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_gain, GuideWindow.r_gain, WFICommon.r_gain]
+  inverse_linearity:
+    title: Inverse Linearity Reference File Information
+    description: |
+      Name of the calibration reference file used in
+      simulations of Level 1 data products to imprint the effect of
+      classical non-linearity in the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_inverse_linearity,
+          GuideWindow.r_inverse_linearity,
+          WFICommon.r_inverse_linearity,
+        ]
+  linearity:
+    title: Linearity Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for classical linearity in the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_linearity,
+          GuideWindow.r_linearity,
+          WFICommon.r_linearity,
+        ]
+  photom:
+    title: Photometry Reference File Information
+    description: |
+      Name of the calibration reference file containing
+      photometric zeropoints and related information populated into
+      the science product metadata.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [ScienceRefData.r_photom, GuideWindow.r_photom, WFICommon.r_photom]
+  readnoise:
+    title: Read Noise Reference File Information
+    description: |
+      Name of the calibration reference file that estimates
+      the pixel-to-pixel read noise in the science data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_readnoise,
+          GuideWindow.r_readnoise,
+          WFICommon.r_readnoise,
+        ]
+  refpix:
+    title: Reference Pixel Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for 1/f noise using the reference pixels.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [ScienceRefData.r_refpix, GuideWindow.r_refpix, WFICommon.r_refpix]
+  saturation:
+    title: Saturation Reference File Information
+    description: |
+      Information about the saturation reference file used with the science
+      data.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_saturation,
+          GuideWindow.r_saturation,
+          WFICommon.r_saturation,
+        ]
+required:
+  [
+    apcorr,
+    crds,
+    dark,
+    distortion,
+    epsf,
+    mask,
+    flat,
+    gain,
+    readnoise,
+    linearity,
+    inverse_linearity,
+    photom,
+    area,
+    saturation,
+    refpix,
+  ]
+flowStyle: block

--- a/src/rad/resources/schemas/ref_file-1.2.0.yaml
+++ b/src/rad/resources/schemas/ref_file-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ref_file.yaml


### PR DESCRIPTION
Closes #640

Remove `maxLength` from `ref_file` entries to fix `ValidationError` exceptions caused by long paths.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/16296067757
show many failures due to tag mismatches. Some of these will go away when https://github.com/spacetelescope/rad/pull/632 is merged (and the conflicts with this PR addressed). However this PR needs new input files (due to changes to in-development versions of schemas). Since #632 also needs new files I suggest we address that PR first then this one.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
