### PR TITLE
Clean up l3_common

### DIFF
--- a/latest/datamodels.yaml
+++ b/latest/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.3.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.3.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.4.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.4.0
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.
@@ -44,8 +44,8 @@ tags:
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.3.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.3.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.4.0
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information

--- a/latest/l3_basic.yaml
+++ b/latest/l3_basic.yaml
@@ -1,0 +1,66 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l3_basic-1.0.0
+
+title: Level 3 Basic
+
+type: object
+properties:
+  calibration_software_name:
+    title: Calibration Software Name
+    description: >
+      Name of the calibration software package used in processing this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0
+  calibration_software_version:
+    title: Calibration Software Version Number
+    description: >
+      The version number or other identifier of the calibration software used in processing this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0
+  filename:
+    title: File Name
+    description: >
+      The auto-generated name of this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
+  file_date:
+    title: File Creation Date
+    description: >
+      The date and time this file was created.
+    tag: asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0
+  model_type:
+    title: Data Model Type
+    description: >
+      The type of data model contained within this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/model_type-1.0.0
+  origin:
+    title: Institution / Organization Name
+    description: >
+      The name of the institution or organization
+      responsible for creating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/origin-1.0.0
+  product_type:
+    title: Product Type Descriptor
+    description: >
+      A descriptor of the type of data contained within this
+      file. A string beginning with "p" indicates a prompt data product,
+      while a string beginning with "r" indicates a data release product.
+      For example, "p_visit_coadd" indicates a prompt data product
+      containing a co-addition of exposures within a visit.
+    tag: asdf://stsci.edu/datamodels/roman/tags/product_type-1.0.0
+  telescope:
+    title: Telescope Name
+    description: >
+      The name of the telescope used to acquire the data.
+    tag: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+
+required:
+  [
+    calibration_software_name,
+    calibration_software_version,
+    filename,
+    file_date,
+    model_type,
+    product_type,
+    origin,
+    telescope,
+  ]

--- a/latest/l3_common.yaml
+++ b/latest/l3_common.yaml
@@ -5,578 +5,539 @@ id: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0
 
 title: Common Level 3 Metadata
 
-type: object
-properties:
-  calibration_software_name:
-    title: Calibration Software Name
-    description: >
-      Name of the calibration software package used in processing this file.
-    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0
-  calibration_software_version:
-    title: Calibration Software Version Number
-    description: >
-      The version number or other identifier of the calibration software used in processing this file.
-    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0
-  data_release_id:
-    title: Data Release Identifier
-    description: >
-      A label for the data release (if applicable). This keyword
-      is optional and only populated for data release products.
-    type: string
-    maxLength: 120
-    archive_catalog:
-      datatype: nvarchar(120)
-      destination: [WFIMosaic.data_release_id]
-  filename:
-    title: File Name
-    description: >
-      The auto-generated name of this file.
-    tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
-  file_date:
-    title: File Creation Date
-    description: >
-      The date and time this file was created.
-    tag: asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0
-  model_type:
-    title: Data Model Type
-    description: >
-      The type of data model contained within this file.
-    tag: asdf://stsci.edu/datamodels/roman/tags/model_type-1.0.0
-  origin:
-    title: Institution / Organization Name
-    description: >
-      The name of the institution or organization
-      responsible for creating this file.
-    tag: asdf://stsci.edu/datamodels/roman/tags/origin-1.0.0
-  product_type:
-    title: Product Type Descriptor
-    description: >
-      A descriptor of the type of data contained within this
-      file. A string beginning with "p" indicates a prompt data product,
-      while a string beginning with "r" indicates a data release product.
-      For example, "p_visit_coadd" indicates a prompt data product
-      containing a co-addition of exposures within a visit.
-    tag: asdf://stsci.edu/datamodels/roman/tags/product_type-1.0.0
-  telescope:
-    title: Telescope Name
-    description: >
-      The name of the telescope used to acquire the data.
-    tag: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
-
-  cal_logs:
-    title: Calibration Log Messages
-    description: >
-      String array of log messages recording the steps, failures,
-      and outputs of running pipeline steps. These log messages are typically
-      the same as those printed to the standard output (stdout) during
-      pipeline processing
-    tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
-
-  coordinates:
-    title: Celestial Coordinate Reference Frame
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/l3_basic-1.0.0
+  - type: object
     properties:
-      reference_frame:
-        title: Name of the Celestial Coordinate Reference Frame
+      data_release_id:
+        title: Data Release Identifier
         description: >
-          Name of the celestial coordinate reference frame used
-          for the World Coordinate System (WCS).
-        type: string
-        maxLength: 10
-        archive_catalog:
-          datatype: nvarchar(10)
-          destination: [WFIMosaic.reference_frame]
-        enum: [ICRS]
-    required: [reference_frame]
-
-  coadd_info:
-    title: Co-Addition Information
-    properties:
-      time_first:
-        title: Start Time of the First Exposure
-        description: >
-          The Universal Coordinated Time (UTC) start time of
-          the first exposure ordered in time used to create the
-          co-added product. The time is serialized on disk as an
-          International Organization for Standardization (ISO)
-          8601-compliant ISOT string. If opened in Python with the
-          asdf-astropy package installed, it may be read as an
-          astropy.time.Time object with all of the associated methods
-          and transforms available. See the documentation for
-          astropy.time.Time objects for more information.
-        tag: tag:stsci.edu:asdf/time/time-1.*
-        archive_catalog:
-          datatype: datetime2
-          destination: [WFIMosaic.time_first]
-      time_last:
-        title: End Time of the Last Exposure
-        description: >
-          The Universal Coordinated Time (UTC) end time of
-          the last exposure ordered in time used to create the
-          co-added product. The time is serialized on disk as an
-          International Organization for Standardization (ISO)
-          8601-compliant ISOT string. If opened in Python with the
-          asdf-astropy package installed, it may be read as an
-          astropy.time.Time object with all of the associated methods
-          and transforms available. See the documentation for
-          astropy.time.Time objects for more information.
-        tag: tag:stsci.edu:asdf/time/time-1.*
-        archive_catalog:
-          datatype: datetime2
-          destination: [WFIMosaic.time_last]
-      time_mean:
-        title: Mean Time of the Co-Added Data Product
-        description: >
-          The Universal Coordinated Time (UTC) mean start
-          time of the exposures used to create the co-added product.
-          The time is serialized on disk as an International
-          Organization for Standardization (ISO) 8601-compliant ISOT
-          string. If opened in Python with the asdf-astropy package
-          installed, it may be read as an astropy.time.Time object
-          with all of the associated methods and transforms available.
-          See the documentation for astropy.time.Time objects for more
-          information.
-        tag: tag:stsci.edu:asdf/time/time-1.*
-        archive_catalog:
-          datatype: datetime2
-          destination: [WFIMosaic.time_mean]
-      max_exposure_time:
-        title: Maximum Exposure Time (s)
-        description: >
-          Maximum exposure time of all pixels in the
-          co-added product in units of seconds. The exposure times of
-          each input pixel are drizzled onto the output frame, and
-          then the maximum is computed from all output pixels with
-          exposure time > 0 seconds.
-        type: number
-        archive_catalog:
-          datatype: float
-          destination: [WFIMosaic.max_exposure_time]
-      exposure_time:
-        title: Exposure Time (s)
-        description: >
-          A representative exposure time for the co-added
-          product in units of seconds. For Roman SOC products, the
-          exposure times of each input pixel are drizzled on the
-          output frame, and then the mean exposure time is computed
-          from all output pixels with exposure time > 0 seconds.
-          Please check the keyword meta.origin for contextual
-          information.
-        type: number
-        archive_catalog:
-          datatype: float
-          destination: [WFIMosaic.exposure_time]
-    required: [time_first, time_last, time_mean, exposure_time]
-
-  individual_image_meta:
-    title: Selected, Tabulated Input Level 2 (L2) Calibrated Rate Image Metadata
-    properties:
-      background:
-        title: Table of Background Level 2 (L2) Metadata
-        description: >
-          Table of background metadata from input calibrated rate
-          image files. Background metadata contains measured
-          sky background levels, the measurement method and
-          if the file was background corrected.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      basic:
-        title: Table of Basic Level 2 (L2) Metadata
-        description: >
-          Table of basic metadata from input calibrated rate
-          image files. Basic metadata encompass a wide variety of
-          information such as pipeline version numbers and origin of the
-          file.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      cal_step:
-        title: Table of Calibration Step Level 2 (L2) Metadata
-        description: >
-          Table of calibration step metadata from input
-          calibrated rate image files. Calibration step metadata indicate
-          which calibration steps were applied to the data during
-          detector-level processing.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      coordinates:
-        title: Table of Coordinates Level 2 (L2) Metadata
-        description: >
-          Table of coordinates metadata from input calibrated
-          rate image files. Coordinates metadata indicate the type of
-          coordinate system used (e.g., the International Celestial
-          Reference System or ICRS).
-        tag: tag:astropy.org:astropy/table/table-1.*
-      ephemeris:
-        title: Table of Ephemeris Level 2 (L2) Metadata
-        description: >
-          Table of ephemeris metadata from input calibrated rate
-          image files. Ephemeris metadata describe the location and
-          movement of the spacecraft during the observations.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      exposure:
-        title: Table of Exposure Level 2 (L2) Metadata
-        description: >
-          Table of exposure metadata from input calibrated rate
-          image files. Exposure metadata contain information about the
-          exposure such as start time and readout pattern.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      guide_star:
-        title: Table of Guide Star Level 2 (L2) Metadata
-        description: >
-          Table of guide star metadata from input calibrated
-          rate image files. Guide star metadata describe the star and
-          window used for guiding on that particular Wide Field Instrument
-          (WFI) detector.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      instrument:
-        title: Table of Instrument Level 2 (L2) Metadata
-        description: >
-          Table of instrument metadata from input calibrated
-          rate image files. Instrument metadata contain information about
-          the Wide Field Instrument (WFI) detector that the data
-          correspond to as well as the optical element used during the
-          observation.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      observation:
-        title: Table of Observation Level 2 (L2) Metadata
-        description: >
-          Table of observation metadata from input calibrated
-          rate image files. Observation metadata contain programmatic
-          identifier information such as the pass number, execution plan
-          number, and visit number.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      photometry:
-        title: Table of Photometry Level 2 (L2) Metadata
-        description: >
-          Table of photometry metadata from input calibrated rate
-          image files. Photometry metadata contains pixel
-          area information, flux density conversion factors and
-          uncertainty.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      pointing:
-        title: Table of Pointing Level 2 (L2) Metadata
-        description: >
-          Table of pointing metadata from input calibrated rate
-          image files. Pointing metadata contains information
-          about the telescope pointing.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      program:
-        title: Table of Program Level 2 (L2) Metadata
-        description: >
-          Table of program metadata from input calibrated rate
-          image files. Program metadata contains information
-          about the observing program.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      rcs:
-        title: Table of RCS Level 2 (L2) Metadata
-        description: >
-          Table of relative calibration system  metadata from
-          input calibrated rate image files. RCS metadata contains
-          information about state of the relative calibration system.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      ref_file:
-        title: Table of Reference File Level 2 (L2) Metadata
-        description: >
-          Table of reference file metadata from input calibrated rate
-          image files. Reference file metadata contains information
-          about reference files used during calibration of the
-          L2 files.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      source_catalog:
-        title: Table of Source Catalog Level 2 (L2) Metadata
-        description: >
-          Table of source catalog metadata from input calibrated rate
-          image files. Source catalog metadata contains information
-          about the measured source catalogs for the L2 files.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      velocity_aberration:
-        title: Table of Velocity Aberration Level 2 (L2) Metadata
-        description: >
-          Table of velocity aberration metadata from input calibrated rate
-          image files. Velocity aberration metadata contains information
-          about the calculated velocity aberration.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      visit:
-        title: Table of Visit Level 2 (L2) Metadata
-        description: >
-          Table of visit metadata from input calibrated rate
-          image files. Visit metadata contains information
-          about the dither, visit type, and planned exposures.
-        tag: tag:astropy.org:astropy/table/table-1.*
-      wcsinfo:
-        title: Table of WCS Info Level 2 (L2) Metadata
-        description: >
-          Table of World Coordinate System (WCS) info metadata from
-          input calibrated rate image files. WCS info metadata contains
-          summary information about the sky footprint and relationship
-          with the detectors.
-        tag: tag:astropy.org:astropy/table/table-1.*
-
-  instrument:
-    title: Wide Field Instrument (WFI) Configuration Information
-    properties:
-      name:
-        title: Instrument Name
-        description: >
-          Name of the instrument used to acquire the science data.
-        type: string
-        enum: [WFI]
-        maxLength: 5
-        archive_catalog:
-          datatype: nvarchar(5)
-          destination: [WFIMosaic.instrument_name]
-      optical_element:
-        title: Wide Field Instrument (WFI) Optical Element
-        description: >
-          Name of the optical element used to take the science
-          data. If data using multiple optical elements are combined, the
-          value of optical_element will be None.
-        anyOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(20)
-          destination: [WFIMosaic.optical_element]
-    required: [name, optical_element]
-
-  observation:
-    title: Observation Identifiers
-    properties:
-      execution_plan:
-        title: Execution Plan Number
-        description: >
-          Identifier for the execution plan. An execution plan
-          is a version of the complete set of activities for a survey. A
-          survey may include portions of multiple execution plans. A new
-          execution plan is required whenever there is a change in the
-          program. The allowed range of execution plan numbers is 01 to 99
-          inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.execution_plan]
-      exposure:
-        title: Exposure Number
-        description: |
-          An exposure is a single multi-accumulation (MA) table
-          sequence of the detector array at a single dither point in the
-          dither pattern. The allowed range of exposure numbers is 0001 to
-          9999 inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.exposure]
-      exposure_grouping:
-        title: Exposure Grouping
-        description: >
-          Conceptual type of exposure grouping used to create this coadd (e.g., by visit, or full)
+          A label for the data release (if applicable). This keyword
+          is optional and only populated for data release products.
         anyOf:
           - type: string
             maxLength: 120
           - type: "null"
         archive_catalog:
           datatype: nvarchar(120)
-          destination: [WFIMosaic.exposure_grouping]
+          destination: [WFIMosaic.data_release_id]
+
+      cal_logs:
+        title: Calibration Log Messages
+        description: >
+          String array of log messages recording the steps, failures,
+          and outputs of running pipeline steps. These log messages are typically
+          the same as those printed to the standard output (stdout) during
+          pipeline processing
+        tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+
+      coordinates:
+        title: Celestial Coordinate Reference Frame
+        properties:
+          reference_frame:
+            title: Name of the Celestial Coordinate Reference Frame
+            description: >
+              Name of the celestial coordinate reference frame used
+              for the World Coordinate System (WCS).
+            type: string
+            maxLength: 10
+            archive_catalog:
+              datatype: nvarchar(10)
+              destination: [WFIMosaic.reference_frame]
+            enum: [ICRS]
+        required: [reference_frame]
+
+      coadd_info:
+        title: Co-Addition Information
+        properties:
+          time_first:
+            title: Start Time of the First Exposure
+            description: >
+              The Universal Coordinated Time (UTC) start time of
+              the first exposure ordered in time used to create the
+              co-added product. The time is serialized on disk as an
+              International Organization for Standardization (ISO)
+              8601-compliant ISOT string. If opened in Python with the
+              asdf-astropy package installed, it may be read as an
+              astropy.time.Time object with all of the associated methods
+              and transforms available. See the documentation for
+              astropy.time.Time objects for more information.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            archive_catalog:
+              datatype: datetime2
+              destination: [WFIMosaic.time_first]
+          time_last:
+            title: End Time of the Last Exposure
+            description: >
+              The Universal Coordinated Time (UTC) end time of
+              the last exposure ordered in time used to create the
+              co-added product. The time is serialized on disk as an
+              International Organization for Standardization (ISO)
+              8601-compliant ISOT string. If opened in Python with the
+              asdf-astropy package installed, it may be read as an
+              astropy.time.Time object with all of the associated methods
+              and transforms available. See the documentation for
+              astropy.time.Time objects for more information.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            archive_catalog:
+              datatype: datetime2
+              destination: [WFIMosaic.time_last]
+          time_mean:
+            title: Mean Time of the Co-Added Data Product
+            description: >
+              The Universal Coordinated Time (UTC) mean start
+              time of the exposures used to create the co-added product.
+              The time is serialized on disk as an International
+              Organization for Standardization (ISO) 8601-compliant ISOT
+              string. If opened in Python with the asdf-astropy package
+              installed, it may be read as an astropy.time.Time object
+              with all of the associated methods and transforms available.
+              See the documentation for astropy.time.Time objects for more
+              information.
+            tag: tag:stsci.edu:asdf/time/time-1.*
+            archive_catalog:
+              datatype: datetime2
+              destination: [WFIMosaic.time_mean]
+          max_exposure_time:
+            title: Maximum Exposure Time (s)
+            description: >
+              Maximum exposure time of all pixels in the
+              co-added product in units of seconds. The exposure times of
+              each input pixel are drizzled onto the output frame, and
+              then the maximum is computed from all output pixels with
+              exposure time > 0 seconds.
+            type: number
+            archive_catalog:
+              datatype: float
+              destination: [WFIMosaic.max_exposure_time]
+          exposure_time:
+            title: Exposure Time (s)
+            description: >
+              A representative exposure time for the co-added
+              product in units of seconds. For Roman SOC products, the
+              exposure times of each input pixel are drizzled on the
+              output frame, and then the mean exposure time is computed
+              from all output pixels with exposure time > 0 seconds.
+              Please check the keyword meta.origin for contextual
+              information.
+            type: number
+            archive_catalog:
+              datatype: float
+              destination: [WFIMosaic.exposure_time]
+        required:
+          [time_first, time_last, time_mean, exposure_time, max_exposure_time]
+
+      individual_image_meta:
+        title: Selected, Tabulated Input Level 2 (L2) Calibrated Rate Image Metadata
+        properties:
+          background:
+            title: Table of Background Level 2 (L2) Metadata
+            description: >
+              Table of background metadata from input calibrated rate
+              image files. Background metadata contains measured
+              sky background levels, the measurement method and
+              if the file was background corrected.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          basic:
+            title: Table of Basic Level 2 (L2) Metadata
+            description: >
+              Table of basic metadata from input calibrated rate
+              image files. Basic metadata encompass a wide variety of
+              information such as pipeline version numbers and origin of the
+              file.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          cal_step:
+            title: Table of Calibration Step Level 2 (L2) Metadata
+            description: >
+              Table of calibration step metadata from input
+              calibrated rate image files. Calibration step metadata indicate
+              which calibration steps were applied to the data during
+              detector-level processing.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          coordinates:
+            title: Table of Coordinates Level 2 (L2) Metadata
+            description: >
+              Table of coordinates metadata from input calibrated
+              rate image files. Coordinates metadata indicate the type of
+              coordinate system used (e.g., the International Celestial
+              Reference System or ICRS).
+            tag: tag:astropy.org:astropy/table/table-1.*
+          ephemeris:
+            title: Table of Ephemeris Level 2 (L2) Metadata
+            description: >
+              Table of ephemeris metadata from input calibrated rate
+              image files. Ephemeris metadata describe the location and
+              movement of the spacecraft during the observations.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          exposure:
+            title: Table of Exposure Level 2 (L2) Metadata
+            description: >
+              Table of exposure metadata from input calibrated rate
+              image files. Exposure metadata contain information about the
+              exposure such as start time and readout pattern.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          guide_star:
+            title: Table of Guide Star Level 2 (L2) Metadata
+            description: >
+              Table of guide star metadata from input calibrated
+              rate image files. Guide star metadata describe the star and
+              window used for guiding on that particular Wide Field Instrument
+              (WFI) detector.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          instrument:
+            title: Table of Instrument Level 2 (L2) Metadata
+            description: >
+              Table of instrument metadata from input calibrated
+              rate image files. Instrument metadata contain information about
+              the Wide Field Instrument (WFI) detector that the data
+              correspond to as well as the optical element used during the
+              observation.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          observation:
+            title: Table of Observation Level 2 (L2) Metadata
+            description: >
+              Table of observation metadata from input calibrated
+              rate image files. Observation metadata contain programmatic
+              identifier information such as the pass number, execution plan
+              number, and visit number.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          photometry:
+            title: Table of Photometry Level 2 (L2) Metadata
+            description: >
+              Table of photometry metadata from input calibrated rate
+              image files. Photometry metadata contains pixel
+              area information, flux density conversion factors and
+              uncertainty.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          pointing:
+            title: Table of Pointing Level 2 (L2) Metadata
+            description: >
+              Table of pointing metadata from input calibrated rate
+              image files. Pointing metadata contains information
+              about the telescope pointing.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          program:
+            title: Table of Program Level 2 (L2) Metadata
+            description: >
+              Table of program metadata from input calibrated rate
+              image files. Program metadata contains information
+              about the observing program.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          rcs:
+            title: Table of RCS Level 2 (L2) Metadata
+            description: >
+              Table of relative calibration system  metadata from
+              input calibrated rate image files. RCS metadata contains
+              information about state of the relative calibration system.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          ref_file:
+            title: Table of Reference File Level 2 (L2) Metadata
+            description: >
+              Table of reference file metadata from input calibrated rate
+              image files. Reference file metadata contains information
+              about reference files used during calibration of the
+              L2 files.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          source_catalog:
+            title: Table of Source Catalog Level 2 (L2) Metadata
+            description: >
+              Table of source catalog metadata from input calibrated rate
+              image files. Source catalog metadata contains information
+              about the measured source catalogs for the L2 files.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          velocity_aberration:
+            title: Table of Velocity Aberration Level 2 (L2) Metadata
+            description: >
+              Table of velocity aberration metadata from input calibrated rate
+              image files. Velocity aberration metadata contains information
+              about the calculated velocity aberration.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          visit:
+            title: Table of Visit Level 2 (L2) Metadata
+            description: >
+              Table of visit metadata from input calibrated rate
+              image files. Visit metadata contains information
+              about the dither, visit type, and planned exposures.
+            tag: tag:astropy.org:astropy/table/table-1.*
+          wcsinfo:
+            title: Table of WCS Info Level 2 (L2) Metadata
+            description: >
+              Table of World Coordinate System (WCS) info metadata from
+              input calibrated rate image files. WCS info metadata contains
+              summary information about the sky footprint and relationship
+              with the detectors.
+            tag: tag:astropy.org:astropy/table/table-1.*
+
+      instrument:
+        title: Wide Field Instrument (WFI) Configuration Information
+        properties:
+          name:
+            title: Instrument Name
+            description: >
+              Name of the instrument used to acquire the science data.
+            type: string
+            enum: [WFI]
+            maxLength: 5
+            archive_catalog:
+              datatype: nvarchar(5)
+              destination: [WFIMosaic.instrument_name]
+          optical_element:
+            title: Wide Field Instrument (WFI) Optical Element
+            description: >
+              Name of the optical element used to take the science
+              data. If data using multiple optical elements are combined, the
+              value of optical_element will be None.
+            anyOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(20)
+              destination: [WFIMosaic.optical_element]
+        required: [name, optical_element]
+
       observation:
-        title: Observation Number
-        description: |
-          Identifier for the observation. An observation is a
-          single traversal of a mosaic pattern, using a single, constant
-          instrument configuration (i.e., with no element wheel moves).
-          The allowed range of observation numbers is 001 to 999
-          inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.observation]
-      pass:
-        title: Pass Number
-        description: >
-          Identifier for the pass. A pass is the collection of
-          activities generated from each iteration of a pass plan in the
-          Astronomer's Proposal Tool (APT). Multiple passes may be
-          generated from the same Pass Plan to allow repetition or execute
-          at different orientations (via special requirements). The
-          allowed range of pass numbers is 001 to 999 inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.pass]
+        title: Observation Identifiers
+        properties:
+          execution_plan:
+            title: Execution Plan Number
+            description: >
+              Identifier for the execution plan. An execution plan
+              is a version of the complete set of activities for a survey. A
+              survey may include portions of multiple execution plans. A new
+              execution plan is required whenever there is a change in the
+              program. The allowed range of execution plan numbers is 01 to 99
+              inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.execution_plan]
+          exposure:
+            title: Exposure Number
+            description: |
+              An exposure is a single multi-accumulation (MA) table
+              sequence of the detector array at a single dither point in the
+              dither pattern. The allowed range of exposure numbers is 0001 to
+              9999 inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.exposure]
+          exposure_grouping:
+            title: Exposure Grouping
+            description: >
+              Conceptual type of exposure grouping used to create this coadd (e.g., by visit, or full)
+            anyOf:
+              - type: string
+                maxLength: 120
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(120)
+              destination: [WFIMosaic.exposure_grouping]
+          observation:
+            title: Observation Number
+            description: |
+              Identifier for the observation. An observation is a
+              single traversal of a mosaic pattern, using a single, constant
+              instrument configuration (i.e., with no element wheel moves).
+              The allowed range of observation numbers is 001 to 999
+              inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.observation]
+          pass:
+            title: Pass Number
+            description: >
+              Identifier for the pass. A pass is the collection of
+              activities generated from each iteration of a pass plan in the
+              Astronomer's Proposal Tool (APT). Multiple passes may be
+              generated from the same Pass Plan to allow repetition or execute
+              at different orientations (via special requirements). The
+              allowed range of pass numbers is 001 to 999 inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.pass]
+          program:
+            title: Program Number
+            description: >
+              Identifier for the observing program. A program is an
+              approved specification for a science, calibration, or
+              engineering investigation to be pursued using Roman Space
+              Telescope mission resources. The allowed range of program
+              numbers is 00001 to 18445 inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: int
+              destination: [WFIMosaic.program]
+          segment:
+            title: Segment Number
+            description: >
+              Identifier for the segment. A segment is the sequence
+              of activities produced by each iteration of an Astronomer's
+              Proposal Tool (APT) segment plan in a pass. A segment may
+              include multiple traversals of mosaic pattern(s), with element
+              wheel moves occurring between observations. The allowed range of
+              segment numbers is 001 to 999 inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.segment]
+          visit:
+            title: Visit Number
+            description: >
+              A visit is the smallest scheduling unit for Roman,
+              which is a sequence of exposures executed without interruption,
+              including dither patterns. A visit corresponds to one tile of
+              the selected mosaic pattern. The allowed range of visit numbers
+              is 001 to 999 inclusive.
+            anyOf:
+              - type: integer
+              - type: "null"
+            archive_catalog:
+              datatype: smallint
+              destination: [WFIMosaic.visit]
+        required:
+          [
+            execution_plan,
+            exposure,
+            exposure_grouping,
+            observation,
+            pass,
+            program,
+            segment,
+            visit,
+          ]
+
       program:
-        title: Program Number
-        description: >
-          Identifier for the observing program. A program is an
-          approved specification for a science, calibration, or
-          engineering investigation to be pursued using Roman Space
-          Telescope mission resources. The allowed range of program
-          numbers is 00001 to 18445 inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: int
-          destination: [WFIMosaic.program]
-      segment:
-        title: Segment Number
-        description: >
-          Identifier for the segment. A segment is the sequence
-          of activities produced by each iteration of an Astronomer's
-          Proposal Tool (APT) segment plan in a pass. A segment may
-          include multiple traversals of mosaic pattern(s), with element
-          wheel moves occurring between observations. The allowed range of
-          segment numbers is 001 to 999 inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.segment]
-      visit:
-        title: Visit Number
-        description: >
-          A visit is the smallest scheduling unit for Roman,
-          which is a sequence of exposures executed without interruption,
-          including dither patterns. A visit corresponds to one tile of
-          the selected mosaic pattern. The allowed range of visit numbers
-          is 001 to 999 inclusive.
-        anyOf:
-          - type: integer
-          - type: "null"
-        archive_catalog:
-          datatype: smallint
-          destination: [WFIMosaic.visit]
+        title: Program Information
+        properties:
+          title:
+            title: Proposal Title
+            description: The submitted proposal title of the program.
+            anyOf:
+              - type: string
+                maxLength: 200
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(200)
+              destination: [WFIMosaic.program_title]
+          investigator_name:
+            title: Principle Investigator Name
+            description: The name of the principle investigator (PI) of the program.
+            anyOf:
+              - type: string
+                maxLength: 100
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(100)
+              destination: [WFIMosaic.investigator_name]
+          category:
+            title: Program Category
+            description: >
+              The submitted proposal category of the program. The
+              categories include calibration (CAL), core community survey
+              (CCS), coronagraph technology demonstration (CGI), observatory
+              commissioning (COM), engineering (ENG), general astrophysics
+              survey (GAS), general investigator (GI), and observing conducted
+              at the direction of the National Aeronautics and Space
+              Administration (NASA).
+            anyOf:
+              - type: string
+                maxLength: 6
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(6)
+              destination: [WFIMosaic.program_category]
+          subcategory:
+            title: Program Subcategory
+            description: >
+              The submitted proposal subcategory of the program. The
+              subcategories include calibration (CAL), coronagraph technology
+              demonstration (CGI), community research programs (CR),
+              discretionary research programs (DR), Galactic Bulge Time Domain
+              Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
+              High-Latitude Wide-Area Survey (HLWA), observational research
+              program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
+              and Control (WFSC). All subcategories belong to only a subset of
+              the meta.program.category values.
+            anyOf:
+              - type: string
+                enum:
+                  [
+                    "CAL",
+                    "CGI",
+                    "CR",
+                    "DR",
+                    "GBTD",
+                    "HLTD",
+                    "HLWA",
+                    "OR",
+                    "WFI",
+                    "WFSC",
+                    "None",
+                  ]
+                maxLength: 15
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(15)
+              destination: [WFIMosaic.program_subcategory]
+          science_category:
+            title: Science Category
+            description: >
+              The science category assigned during the Time Allocation Committee (TAC) review process.
+            anyOf:
+              - type: string
+                maxLength: 50
+              - type: "null"
+            archive_catalog:
+              datatype: nvarchar(50)
+              destination: [WFIMosaic.science_category]
+        required:
+          [title, investigator_name, category, subcategory, science_category]
+
+      statistics:
+        title: Basic Statistical Information
+        properties:
+          image_median:
+            title: Median Image Value (MJy/sr)
+            description: >
+              Median image value in units of megaJanskys per steradian (MJy/sr).
+            type: number
+          image_rms:
+            title: Image Mean Absolute Deviation (MJy/sr)
+            description: >
+              Mean absolute deviation of the image values in
+              units of megaJanskys per steradian (MJy/sr).
+            type: number
+          good_pixel_fraction:
+            title: Fraction of Good Pixels
+            description: >
+              The fraction of pixels in the output image that
+              are considered good.
+            type: number
+        required: [image_median, image_rms, good_pixel_fraction]
     required:
       [
-        execution_plan,
-        exposure,
-        exposure_grouping,
+        data_release_id,
+        cal_logs,
+        coadd_info,
+        coordinates,
+        individual_image_meta,
+        instrument,
         observation,
-        pass,
         program,
-        segment,
-        visit,
+        statistics,
       ]
-
-  program:
-    title: Program Information
-    properties:
-      title:
-        title: Proposal Title
-        description: The submitted proposal title of the program.
-        anyOf:
-          - type: string
-            maxLength: 200
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(200)
-          destination: [WFIMosaic.program_title]
-      investigator_name:
-        title: Principle Investigator Name
-        description: The name of the principle investigator (PI) of the program.
-        anyOf:
-          - type: string
-            maxLength: 100
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(100)
-          destination: [WFIMosaic.investigator_name]
-      category:
-        title: Program Category
-        description: >
-          The submitted proposal category of the program. The
-          categories include calibration (CAL), core community survey
-          (CCS), coronagraph technology demonstration (CGI), observatory
-          commissioning (COM), engineering (ENG), general astrophysics
-          survey (GAS), general investigator (GI), and observing conducted
-          at the direction of the National Aeronautics and Space
-          Administration (NASA).
-        anyOf:
-          - type: string
-            maxLength: 6
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(6)
-          destination: [WFIMosaic.program_category]
-      subcategory:
-        title: Program Subcategory
-        description: >
-          The submitted proposal subcategory of the program. The
-          subcategories include calibration (CAL), coronagraph technology
-          demonstration (CGI), community research programs (CR),
-          discretionary research programs (DR), Galactic Bulge Time Domain
-          Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
-          High-Latitude Wide-Area Survey (HLWA), observational research
-          program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
-          and Control (WFSC). All subcategories belong to only a subset of
-          the meta.program.category values.
-        anyOf:
-          - type: string
-            enum:
-              [
-                "CAL",
-                "CGI",
-                "CR",
-                "DR",
-                "GBTD",
-                "HLTD",
-                "HLWA",
-                "OR",
-                "WFI",
-                "WFSC",
-                "None",
-              ]
-            maxLength: 15
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(15)
-          destination: [WFIMosaic.program_subcategory]
-      science_category:
-        title: Science Category
-        description: >
-          The science category assigned during the Time Allocation Committee (TAC) review process.
-        anyOf:
-          - type: string
-            maxLength: 50
-          - type: "null"
-        archive_catalog:
-          datatype: nvarchar(50)
-          destination: [WFIMosaic.science_category]
-    required:
-      [title, investigator_name, category, subcategory, science_category]
-
-  statistics:
-    title: Basic Statistical Information
-    properties:
-      image_median:
-        title: Median Image Value (MJy/sr)
-        description: >
-          Median image value in units of megaJanskys per steradian (MJy/sr).
-        type: number
-      image_rms:
-        title: Image Mean Absolute Deviation (MJy/sr)
-        description: >
-          Mean absolute deviation of the image values in
-          units of megaJanskys per steradian (MJy/sr).
-        type: number
-      good_pixel_fraction:
-        title: Fraction of Good Pixels
-        description: >
-          The fraction of pixels in the output image that
-          are considered good.
-        type: number
-    required: [image_median, image_rms, good_pixel_fraction]
-required:
-  [
-    calibration_software_name,
-    calibration_software_version,
-    filename,
-    file_date,
-    model_type,
-    product_type,
-    origin,
-    telescope,
-  ]

--- a/latest/l3_common.yaml
+++ b/latest/l3_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0
 
 title: Common Level 3 Metadata
 

--- a/latest/wfi_mosaic.yaml
+++ b/latest/wfi_mosaic.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.4.0
 
 title: The schema for WFI Level 3 mosaics.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0
       - required:
           [
             cal_logs,

--- a/latest/wfi_mosaic.yaml
+++ b/latest/wfi_mosaic.yaml
@@ -13,18 +13,8 @@ properties:
   meta:
     allOf:
       - $ref: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0
-      - required:
-          [
-            cal_logs,
-            coadd_info,
-            coordinates,
-            individual_image_meta,
-            instrument,
-            observation,
-            program,
-            statistics,
-          ]
-      - properties:
+      - type: object
+        properties:
           association:
             title: Association Information
             type: object

--- a/scripts/helper/_screen.py
+++ b/scripts/helper/_screen.py
@@ -319,6 +319,7 @@ class NewScreen(_Screen[tuple[_Screen.Return, bool | None, Resource | None]]):
                     disabled=True,
                 )
                 uri_input.styles.height = "100%"
+                uri_input.styles.width = "80%"
                 yield uri_input
             yield Rule()
 

--- a/src/rad/resources/manifests/datamodels-1.3.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.3.0.yaml
@@ -1,1 +1,367 @@
-../../../../latest/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.3.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.3.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.1.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.2.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.2.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidewindow-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidewindow-1.3.0
+    title: Guide window schema
+    description: |-
+      Guide window schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.3.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.3.0
+    title: Ramp fit output schema
+    description: |-
+      Ramp fit output schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.3.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.3.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.3.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mode-1.2.0
+    title: Roman WFI Instrument Mode
+    description: |-
+      Roman WFI Instrument
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.2.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Metadata Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/exposure-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/exposure-1.3.0
+    title: Exposure information
+    description: |-
+      Exposure information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/program-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/program-1.1.0
+    title: Program information
+    description: |-
+      Program information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/observation-1.1.0
+    title: Observation information
+    description: |-
+      Observation information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ephemeris-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ephemeris-1.1.0
+    title: Ephemeris information
+    description: |-
+      Ephemeris information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/visit-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/visit-1.2.0
+    title: Visit information
+    description: |-
+      Visit information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/photometry-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/photometry-1.0.0
+    title: Photometry information
+    description: |-
+      Photometry information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/source_catalog-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/source_catalog-1.0.0
+    title: Source catalog for TweakReg
+    description: |-
+      Source catalog for TweakReg
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/coordinates-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/coordinates-1.0.0
+    title: Coordinate frame information
+    description: |-
+      Coordinate frame information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/pointing-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/pointing-1.1.0
+    title: Spacecraft Pointing information
+    description: |-
+      Spacecraft Pointing information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/rcs-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/rcs-1.1.0
+    title: Relative Calibration System Information
+    description: |-
+      Relative Calibration System Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/statistics-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/statistics-1.0.0
+    title: Basic Statistical Information
+    description: |-
+      Basic Statistical Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/velocity_aberration-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/velocity_aberration-1.0.0
+    title: Velocity aberration information
+    description: |-
+      Velocity aberration information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wcsinfo-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wcsinfo-1.1.0
+    title: Wcsinfo information
+    description: |-
+      Wcsinfo information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/guidestar-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/guidestar-1.2.0
+    title: Guidestar information
+    description: |-
+      Guidestar information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l2_cal_step-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l2_cal_step-1.2.0
+    title: Level 2 Calibration Step status information
+    description: |-
+      Level 2 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/outlier_detection-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/outlier_detection-1.0.0
+    title: Outlier Detection information
+    description: |-
+      Outlier Detection information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/sky_background-1.0.0
+    title: Sky Background Information
+    description: |-
+      Sky Background Information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_basic-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_basic-1.2.0
+    title: Basic mosaic metadata keywords
+    description: |-
+      Basic mosaic metadata keywords
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.1.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.1.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.2.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.2.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.2.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.2.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.1.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.1.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.2.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.1.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.1.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.2.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.2.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.1.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.1.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.1.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.2.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.0.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.1.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/associations-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/associations-1.0.0
+    title: Association table
+    description: |-
+      Association table
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/cal_logs-1.0.0
+    title: Calibration log messages
+    description: |-
+      Calibration log message
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ref_file-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ref_file-1.1.0
+    title: Calibration reference file names.
+    description: |-
+      Calibration reference file names.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.3.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.3.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.3.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.0.0
+    title: Multiband source catalog
+    description: |-
+      Photometry and astrometry computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.3.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.0.0
+    title: Forced image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.0.0
+    title: Forced mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  # Tagged Scalars
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/calibration_software_name-1.0.0
+    title: Calibration Software Name
+    description: |-
+      Name of the calibration software package used in
+      processing this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/calibration_software_version-1.0.0
+    title: Calibration software version
+    description: |-
+      The version number of the calibration software used in
+      processing this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/product_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/product_type-1.0.0
+    title: Product Type Descriptor
+    description: |-
+      A descriptor for the type of data contained within the
+      file. This corresponds to the standard file suffixes for
+      archival data products. Consult the documentation for the list
+      of options.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/filename-1.0.0
+    title: File Name
+    description: |-
+      The auto-generated name of this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/file_date-1.0.0
+    title: File Creation Date
+    description: |-
+      The date and time this file was created.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/model_type-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/model_type-1.0.0
+    title: Data Model Type
+    description: |-
+      The type of data model contained within this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/origin-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/origin-1.0.0
+    title: Institution / Organization Name
+    description: |-
+      The name of the institution of organization
+      responsible for creating this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/prd_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/prd_version-1.0.0
+    title: SOC PRD Version Number
+    description: |-
+      The version number of the Science Operations Center
+      (SOC) Project Reference Database (PRD) used in generating this
+      file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/sdf_software_version-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/sdf_software_version-1.0.0
+    title: SOC SDF Version Number
+    description: |-
+      The version number of the Science Operations Center
+      (SOC) Science Data Formatting (SDF) software used in generating
+      this file.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/tagged_scalars/telescope-1.0.0
+    title: Telescope Name
+    description: |-
+      The name of the telescope used to acquire the data.
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.3.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/manifests/datamodels-1.4.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/datamodels.yaml

--- a/src/rad/resources/schemas/l3_basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/l3_basic-1.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/l3_basic.yaml

--- a/src/rad/resources/schemas/l3_common-1.0.0.yaml
+++ b/src/rad/resources/schemas/l3_common-1.0.0.yaml
@@ -1,1 +1,582 @@
-../../../../latest/l3_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.0.0
+
+title: Common Level 3 Metadata
+
+type: object
+properties:
+  calibration_software_name:
+    title: Calibration Software Name
+    description: >
+      Name of the calibration software package used in processing this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0
+  calibration_software_version:
+    title: Calibration Software Version Number
+    description: >
+      The version number or other identifier of the calibration software used in processing this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0
+  data_release_id:
+    title: Data Release Identifier
+    description: >
+      A label for the data release (if applicable). This keyword
+      is optional and only populated for data release products.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [WFIMosaic.data_release_id]
+  filename:
+    title: File Name
+    description: >
+      The auto-generated name of this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
+  file_date:
+    title: File Creation Date
+    description: >
+      The date and time this file was created.
+    tag: asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0
+  model_type:
+    title: Data Model Type
+    description: >
+      The type of data model contained within this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/model_type-1.0.0
+  origin:
+    title: Institution / Organization Name
+    description: >
+      The name of the institution or organization
+      responsible for creating this file.
+    tag: asdf://stsci.edu/datamodels/roman/tags/origin-1.0.0
+  product_type:
+    title: Product Type Descriptor
+    description: >
+      A descriptor of the type of data contained within this
+      file. A string beginning with "p" indicates a prompt data product,
+      while a string beginning with "r" indicates a data release product.
+      For example, "p_visit_coadd" indicates a prompt data product
+      containing a co-addition of exposures within a visit.
+    tag: asdf://stsci.edu/datamodels/roman/tags/product_type-1.0.0
+  telescope:
+    title: Telescope Name
+    description: >
+      The name of the telescope used to acquire the data.
+    tag: asdf://stsci.edu/datamodels/roman/tags/telescope-1.0.0
+
+  cal_logs:
+    title: Calibration Log Messages
+    description: >
+      String array of log messages recording the steps, failures,
+      and outputs of running pipeline steps. These log messages are typically
+      the same as those printed to the standard output (stdout) during
+      pipeline processing
+    tag: asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0
+
+  coordinates:
+    title: Celestial Coordinate Reference Frame
+    properties:
+      reference_frame:
+        title: Name of the Celestial Coordinate Reference Frame
+        description: >
+          Name of the celestial coordinate reference frame used
+          for the World Coordinate System (WCS).
+        type: string
+        maxLength: 10
+        archive_catalog:
+          datatype: nvarchar(10)
+          destination: [WFIMosaic.reference_frame]
+        enum: [ICRS]
+    required: [reference_frame]
+
+  coadd_info:
+    title: Co-Addition Information
+    properties:
+      time_first:
+        title: Start Time of the First Exposure
+        description: >
+          The Universal Coordinated Time (UTC) start time of
+          the first exposure ordered in time used to create the
+          co-added product. The time is serialized on disk as an
+          International Organization for Standardization (ISO)
+          8601-compliant ISOT string. If opened in Python with the
+          asdf-astropy package installed, it may be read as an
+          astropy.time.Time object with all of the associated methods
+          and transforms available. See the documentation for
+          astropy.time.Time objects for more information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination: [WFIMosaic.time_first]
+      time_last:
+        title: End Time of the Last Exposure
+        description: >
+          The Universal Coordinated Time (UTC) end time of
+          the last exposure ordered in time used to create the
+          co-added product. The time is serialized on disk as an
+          International Organization for Standardization (ISO)
+          8601-compliant ISOT string. If opened in Python with the
+          asdf-astropy package installed, it may be read as an
+          astropy.time.Time object with all of the associated methods
+          and transforms available. See the documentation for
+          astropy.time.Time objects for more information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination: [WFIMosaic.time_last]
+      time_mean:
+        title: Mean Time of the Co-Added Data Product
+        description: >
+          The Universal Coordinated Time (UTC) mean start
+          time of the exposures used to create the co-added product.
+          The time is serialized on disk as an International
+          Organization for Standardization (ISO) 8601-compliant ISOT
+          string. If opened in Python with the asdf-astropy package
+          installed, it may be read as an astropy.time.Time object
+          with all of the associated methods and transforms available.
+          See the documentation for astropy.time.Time objects for more
+          information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination: [WFIMosaic.time_mean]
+      max_exposure_time:
+        title: Maximum Exposure Time (s)
+        description: >
+          Maximum exposure time of all pixels in the
+          co-added product in units of seconds. The exposure times of
+          each input pixel are drizzled onto the output frame, and
+          then the maximum is computed from all output pixels with
+          exposure time > 0 seconds.
+        type: number
+        archive_catalog:
+          datatype: float
+          destination: [WFIMosaic.max_exposure_time]
+      exposure_time:
+        title: Exposure Time (s)
+        description: >
+          A representative exposure time for the co-added
+          product in units of seconds. For Roman SOC products, the
+          exposure times of each input pixel are drizzled on the
+          output frame, and then the mean exposure time is computed
+          from all output pixels with exposure time > 0 seconds.
+          Please check the keyword meta.origin for contextual
+          information.
+        type: number
+        archive_catalog:
+          datatype: float
+          destination: [WFIMosaic.exposure_time]
+    required: [time_first, time_last, time_mean, exposure_time]
+
+  individual_image_meta:
+    title: Selected, Tabulated Input Level 2 (L2) Calibrated Rate Image Metadata
+    properties:
+      background:
+        title: Table of Background Level 2 (L2) Metadata
+        description: >
+          Table of background metadata from input calibrated rate
+          image files. Background metadata contains measured
+          sky background levels, the measurement method and
+          if the file was background corrected.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      basic:
+        title: Table of Basic Level 2 (L2) Metadata
+        description: >
+          Table of basic metadata from input calibrated rate
+          image files. Basic metadata encompass a wide variety of
+          information such as pipeline version numbers and origin of the
+          file.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      cal_step:
+        title: Table of Calibration Step Level 2 (L2) Metadata
+        description: >
+          Table of calibration step metadata from input
+          calibrated rate image files. Calibration step metadata indicate
+          which calibration steps were applied to the data during
+          detector-level processing.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      coordinates:
+        title: Table of Coordinates Level 2 (L2) Metadata
+        description: >
+          Table of coordinates metadata from input calibrated
+          rate image files. Coordinates metadata indicate the type of
+          coordinate system used (e.g., the International Celestial
+          Reference System or ICRS).
+        tag: tag:astropy.org:astropy/table/table-1.*
+      ephemeris:
+        title: Table of Ephemeris Level 2 (L2) Metadata
+        description: >
+          Table of ephemeris metadata from input calibrated rate
+          image files. Ephemeris metadata describe the location and
+          movement of the spacecraft during the observations.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      exposure:
+        title: Table of Exposure Level 2 (L2) Metadata
+        description: >
+          Table of exposure metadata from input calibrated rate
+          image files. Exposure metadata contain information about the
+          exposure such as start time and readout pattern.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      guide_star:
+        title: Table of Guide Star Level 2 (L2) Metadata
+        description: >
+          Table of guide star metadata from input calibrated
+          rate image files. Guide star metadata describe the star and
+          window used for guiding on that particular Wide Field Instrument
+          (WFI) detector.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      instrument:
+        title: Table of Instrument Level 2 (L2) Metadata
+        description: >
+          Table of instrument metadata from input calibrated
+          rate image files. Instrument metadata contain information about
+          the Wide Field Instrument (WFI) detector that the data
+          correspond to as well as the optical element used during the
+          observation.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      observation:
+        title: Table of Observation Level 2 (L2) Metadata
+        description: >
+          Table of observation metadata from input calibrated
+          rate image files. Observation metadata contain programmatic
+          identifier information such as the pass number, execution plan
+          number, and visit number.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      photometry:
+        title: Table of Photometry Level 2 (L2) Metadata
+        description: >
+          Table of photometry metadata from input calibrated rate
+          image files. Photometry metadata contains pixel
+          area information, flux density conversion factors and
+          uncertainty.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      pointing:
+        title: Table of Pointing Level 2 (L2) Metadata
+        description: >
+          Table of pointing metadata from input calibrated rate
+          image files. Pointing metadata contains information
+          about the telescope pointing.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      program:
+        title: Table of Program Level 2 (L2) Metadata
+        description: >
+          Table of program metadata from input calibrated rate
+          image files. Program metadata contains information
+          about the observing program.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      rcs:
+        title: Table of RCS Level 2 (L2) Metadata
+        description: >
+          Table of relative calibration system  metadata from
+          input calibrated rate image files. RCS metadata contains
+          information about state of the relative calibration system.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      ref_file:
+        title: Table of Reference File Level 2 (L2) Metadata
+        description: >
+          Table of reference file metadata from input calibrated rate
+          image files. Reference file metadata contains information
+          about reference files used during calibration of the
+          L2 files.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      source_catalog:
+        title: Table of Source Catalog Level 2 (L2) Metadata
+        description: >
+          Table of source catalog metadata from input calibrated rate
+          image files. Source catalog metadata contains information
+          about the measured source catalogs for the L2 files.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      velocity_aberration:
+        title: Table of Velocity Aberration Level 2 (L2) Metadata
+        description: >
+          Table of velocity aberration metadata from input calibrated rate
+          image files. Velocity aberration metadata contains information
+          about the calculated velocity aberration.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      visit:
+        title: Table of Visit Level 2 (L2) Metadata
+        description: >
+          Table of visit metadata from input calibrated rate
+          image files. Visit metadata contains information
+          about the dither, visit type, and planned exposures.
+        tag: tag:astropy.org:astropy/table/table-1.*
+      wcsinfo:
+        title: Table of WCS Info Level 2 (L2) Metadata
+        description: >
+          Table of World Coordinate System (WCS) info metadata from
+          input calibrated rate image files. WCS info metadata contains
+          summary information about the sky footprint and relationship
+          with the detectors.
+        tag: tag:astropy.org:astropy/table/table-1.*
+
+  instrument:
+    title: Wide Field Instrument (WFI) Configuration Information
+    properties:
+      name:
+        title: Instrument Name
+        description: >
+          Name of the instrument used to acquire the science data.
+        type: string
+        enum: [WFI]
+        maxLength: 5
+        archive_catalog:
+          datatype: nvarchar(5)
+          destination: [WFIMosaic.instrument_name]
+      optical_element:
+        title: Wide Field Instrument (WFI) Optical Element
+        description: >
+          Name of the optical element used to take the science
+          data. If data using multiple optical elements are combined, the
+          value of optical_element will be None.
+        anyOf:
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element-1.2.0
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(20)
+          destination: [WFIMosaic.optical_element]
+    required: [name, optical_element]
+
+  observation:
+    title: Observation Identifiers
+    properties:
+      execution_plan:
+        title: Execution Plan Number
+        description: >
+          Identifier for the execution plan. An execution plan
+          is a version of the complete set of activities for a survey. A
+          survey may include portions of multiple execution plans. A new
+          execution plan is required whenever there is a change in the
+          program. The allowed range of execution plan numbers is 01 to 99
+          inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.execution_plan]
+      exposure:
+        title: Exposure Number
+        description: |
+          An exposure is a single multi-accumulation (MA) table
+          sequence of the detector array at a single dither point in the
+          dither pattern. The allowed range of exposure numbers is 0001 to
+          9999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.exposure]
+      exposure_grouping:
+        title: Exposure Grouping
+        description: >
+          Conceptual type of exposure grouping used to create this coadd (e.g., by visit, or full)
+        anyOf:
+          - type: string
+            maxLength: 120
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIMosaic.exposure_grouping]
+      observation:
+        title: Observation Number
+        description: |
+          Identifier for the observation. An observation is a
+          single traversal of a mosaic pattern, using a single, constant
+          instrument configuration (i.e., with no element wheel moves).
+          The allowed range of observation numbers is 001 to 999
+          inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.observation]
+      pass:
+        title: Pass Number
+        description: >
+          Identifier for the pass. A pass is the collection of
+          activities generated from each iteration of a pass plan in the
+          Astronomer's Proposal Tool (APT). Multiple passes may be
+          generated from the same Pass Plan to allow repetition or execute
+          at different orientations (via special requirements). The
+          allowed range of pass numbers is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.pass]
+      program:
+        title: Program Number
+        description: >
+          Identifier for the observing program. A program is an
+          approved specification for a science, calibration, or
+          engineering investigation to be pursued using Roman Space
+          Telescope mission resources. The allowed range of program
+          numbers is 00001 to 18445 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: int
+          destination: [WFIMosaic.program]
+      segment:
+        title: Segment Number
+        description: >
+          Identifier for the segment. A segment is the sequence
+          of activities produced by each iteration of an Astronomer's
+          Proposal Tool (APT) segment plan in a pass. A segment may
+          include multiple traversals of mosaic pattern(s), with element
+          wheel moves occurring between observations. The allowed range of
+          segment numbers is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.segment]
+      visit:
+        title: Visit Number
+        description: >
+          A visit is the smallest scheduling unit for Roman,
+          which is a sequence of exposures executed without interruption,
+          including dither patterns. A visit corresponds to one tile of
+          the selected mosaic pattern. The allowed range of visit numbers
+          is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination: [WFIMosaic.visit]
+    required:
+      [
+        execution_plan,
+        exposure,
+        exposure_grouping,
+        observation,
+        pass,
+        program,
+        segment,
+        visit,
+      ]
+
+  program:
+    title: Program Information
+    properties:
+      title:
+        title: Proposal Title
+        description: The submitted proposal title of the program.
+        anyOf:
+          - type: string
+            maxLength: 200
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(200)
+          destination: [WFIMosaic.program_title]
+      investigator_name:
+        title: Principle Investigator Name
+        description: The name of the principle investigator (PI) of the program.
+        anyOf:
+          - type: string
+            maxLength: 100
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(100)
+          destination: [WFIMosaic.investigator_name]
+      category:
+        title: Program Category
+        description: >
+          The submitted proposal category of the program. The
+          categories include calibration (CAL), core community survey
+          (CCS), coronagraph technology demonstration (CGI), observatory
+          commissioning (COM), engineering (ENG), general astrophysics
+          survey (GAS), general investigator (GI), and observing conducted
+          at the direction of the National Aeronautics and Space
+          Administration (NASA).
+        anyOf:
+          - type: string
+            maxLength: 6
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(6)
+          destination: [WFIMosaic.program_category]
+      subcategory:
+        title: Program Subcategory
+        description: >
+          The submitted proposal subcategory of the program. The
+          subcategories include calibration (CAL), coronagraph technology
+          demonstration (CGI), community research programs (CR),
+          discretionary research programs (DR), Galactic Bulge Time Domain
+          Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
+          High-Latitude Wide-Area Survey (HLWA), observational research
+          program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
+          and Control (WFSC). All subcategories belong to only a subset of
+          the meta.program.category values.
+        anyOf:
+          - type: string
+            enum:
+              [
+                "CAL",
+                "CGI",
+                "CR",
+                "DR",
+                "GBTD",
+                "HLTD",
+                "HLWA",
+                "OR",
+                "WFI",
+                "WFSC",
+                "None",
+              ]
+            maxLength: 15
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(15)
+          destination: [WFIMosaic.program_subcategory]
+      science_category:
+        title: Science Category
+        description: >
+          The science category assigned during the Time Allocation Committee (TAC) review process.
+        anyOf:
+          - type: string
+            maxLength: 50
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(50)
+          destination: [WFIMosaic.science_category]
+    required:
+      [title, investigator_name, category, subcategory, science_category]
+
+  statistics:
+    title: Basic Statistical Information
+    properties:
+      image_median:
+        title: Median Image Value (MJy/sr)
+        description: >
+          Median image value in units of megaJanskys per steradian (MJy/sr).
+        type: number
+      image_rms:
+        title: Image Mean Absolute Deviation (MJy/sr)
+        description: >
+          Mean absolute deviation of the image values in
+          units of megaJanskys per steradian (MJy/sr).
+        type: number
+      good_pixel_fraction:
+        title: Fraction of Good Pixels
+        description: >
+          The fraction of pixels in the output image that
+          are considered good.
+        type: number
+    required: [image_median, image_rms, good_pixel_fraction]
+required:
+  [
+    calibration_software_name,
+    calibration_software_version,
+    filename,
+    file_date,
+    model_type,
+    product_type,
+    origin,
+    telescope,
+  ]

--- a/src/rad/resources/schemas/l3_common-1.1.0.yaml
+++ b/src/rad/resources/schemas/l3_common-1.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/l3_common.yaml

--- a/src/rad/resources/schemas/wfi_mosaic-1.3.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.3.0.yaml
@@ -1,1 +1,393 @@
-../../../../latest/wfi_mosaic.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.3.0
+
+title: The schema for WFI Level 3 mosaics.
+
+datamodel_name: MosaicModel
+archive_meta: None
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.0.0
+      - required:
+          [
+            cal_logs,
+            coadd_info,
+            coordinates,
+            individual_image_meta,
+            instrument,
+            observation,
+            program,
+            statistics,
+          ]
+      - properties:
+          association:
+            title: Association Information
+            type: object
+            properties:
+              name:
+                title: Association File Name
+                description: >
+                  Name of the association file used to generate the data product.
+                type: string
+            required: [name]
+          cal_step:
+            title: Level 3 Calibration Status
+            type: object
+            properties:
+              flux:
+                title: Flux Scale Application Step
+                description: >
+                  Step in romancal that applies the scaling factor(s)
+                  necessary to convert from units of data numbers per second
+                  (DN/s) to megaJanskys per steradian (MJy/sr).
+                allOf:
+                  - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
+                archive_catalog:
+                  datatype: nvarchar(15)
+                  destination: [ScienceRefData.s_flux]
+              outlier_detection:
+                title: Outlier Detection Step
+                description: >
+                  Step in romancal that detects and flags outliers in a stack of rate images.
+                allOf:
+                  - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
+                archive_catalog:
+                  datatype: nvarchar(15)
+                  destination: [ScienceRefData.s_outlier_detection]
+              skymatch:
+                title: Sky Matching Step
+                description: >
+                  Step in romancal that matches sky background levels of
+                  each input image and derives scaling factors to equalize
+                  overlapping regions.
+                allOf:
+                  - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
+                archive_catalog:
+                  datatype: nvarchar(15)
+                  destination: [ScienceRefData.s_skymatch]
+              resample:
+                title: Resampling Step
+                description: >
+                  Step in romancal which resamples and coadds each input 2D image based on its WCS
+                  onto a grid, in order to combine multiple images into a single coadded product.
+                allOf:
+                  - $ref: asdf://stsci.edu/datamodels/roman/schemas/cal_step_flag-1.0.0
+                archive_catalog:
+                  datatype: nvarchar(15)
+                  destination: [ScienceRefData.s_resample]
+            required: [flux, outlier_detection, resample, skymatch]
+          resample:
+            title: Resample Parameters
+            type: object
+            properties:
+              good_bits:
+                title: Bit Mask
+                description: >
+                  Bit mask used in the resample step. This key contains
+                  strings that correspond to bits in the data quality (DQ) arrays
+                  of calibrated rate images. Bits are combined using plus signs
+                  (+) and use the bitwise operator tilde (~) to denote exclusion.
+                  For example, the string "~DO_NOT_USE+NON_SCIENCE" means to allow
+                  all data quality bits except DO_NOT_USE and NON_SCIENCE to be
+                  included in the final product. Conversely, a string of "GOOD"
+                  would only allow pixels with DQ bits equal to 0 in the
+                  calibrated rate images to be included in the final product.
+                type: string
+              pixel_scale_ratio:
+                title: Pixel Scale Ratio
+                description: >
+                  The ratio of the pixel scale compared to the native
+                  detector pixel scale. For example, a pixel scale of 0.9 will
+                  produce a resampled image with smaller pixels compared to the
+                  input calibrated rate images.
+                type: number
+              pixfrac:
+                title: Pixel Fraction
+                description: The fraction of a pixel to use for pixel convolution.
+                type: number
+              pointings:
+                title: Number of Input Images
+                description: >
+                  The number of input images combined with resample into an output product.
+                type: integer
+              members:
+                title: Resample Input Filenames
+                description: >
+                  Names of the calibrated rate image files input into
+                  the resample code to create the output product.
+                type: array
+                items:
+                  type: string
+              weight_type:
+                title: Weight Type
+                description: >
+                  The weight type used by the drizzle algorithm in the
+                  resample step. The two weight options available are exposure
+                  time ("exptime") and inverse variance map ("ivm") weighting.
+                type: string
+            required:
+              [
+                good_bits,
+                members,
+                pixel_scale_ratio,
+                pixfrac,
+                pointings,
+                weight_type,
+              ]
+          wcs:
+            title: World Coordinate System (WCS)
+            tag: tag:stsci.edu:gwcs/wcs-*
+          wcsinfo:
+            title: WCS Information
+            type: object
+            properties:
+              ra_ref:
+                title: Right Ascension of Projection Region Center (deg)
+                description: >
+                  Right ascension in units of degrees at the center of
+                  the projection region over which the world coordinate system
+                  (WCS) of this image is defined. If this product does not use the
+                  Roman sky tessellation, then this keyword will be equal to
+                  meta.wcsinfo.ra.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.ra_ref]
+              dec_ref:
+                title: Declination of Projection Region Center (deg)
+                description: >
+                  Declination in units of degrees at the center of the
+                  projection region over which the world coordinate system (WCS)
+                  of this image is defined. If this product does not use the Roman
+                  sky tessellation, then this keyword will be equal to
+                  meta.wcsinfo.dec.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.dec_ref]
+              x_ref:
+                title: X Coordinate of Projection Region Center
+                description: >
+                  Pixel X coordinate at the center of the projection
+                  region over which the world coordinate system (WCS) of this
+                  image is defined. If the projection region is larger than the
+                  image contained within this file, then the value of x_ref may or
+                  may not be contained within the boundaries of the data array in
+                  this file.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.x_ref]
+              y_ref:
+                title: Y Coordinate of Projection Region Center
+                description: >
+                  Pixel Y coordinate at the center of the projection
+                  region over which the world coordinate system (WCS) of this
+                  image is defined. If the projection region is larger than the
+                  image contained within this file, then the value of y_ref may or
+                  may not be contained within the boundaries of the data array in
+                  this file.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.y_ref]
+              pixel_scale_ref:
+                title: Pixel Scale at Projection Region Center (arcseconds per pixel)
+                description: >
+                  Pixel scale in units of arcseconds per pixel at the
+                  center of the projection region. If this product does not use
+                  the Roman sky tessellation, then this keyword will be equal to
+                  meta.wcsinfo.pixel_scale.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.pixel_scale_ref]
+              pixel_scale:
+                title: Pixel Scale at Image Center (arcseconds per pixel)
+                description: >
+                  Pixel scale in units of arcseconds per pixel at the center of the image in this file.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.pixel_scale]
+              projection:
+                title: Projection Type
+                description: >
+                  Type of projection used for the world coordinate
+                  system (WCS). A value of "TAN" indicates a tangent plane projection.
+                type: string
+                enum: ["TAN"]
+                maxLength: 50
+                archive_catalog:
+                  datatype: nvarchar(50)
+                  destination: [WFIMosaic.projection]
+              s_region:
+                title: Spatial Extent of the Image
+                description: >
+                  The region of the sky enclosed by the pixel data
+                  contained within this file. This is given as a polygon stored as
+                  a string with the vertices defined by a list of right ascension
+                  and declination pairs in units of degrees.
+                type: string
+                archive_catalog:
+                  datatype: nvarchar(max)
+                  destination: [WFIMosaic.s_region]
+              image_shape:
+                title: Shape of Image (pixels)
+                description: Shape of the image (nx, ny) in units of pixels.
+                type: array
+                minItems: 2
+                maxItems: 2
+                items:
+                  type: integer
+                archive_catalog:
+                  datatype: nvarchar(50)
+                  destination: [WFIMosaic.image_shape]
+              ra:
+                title: Right Ascension of Image Center (deg)
+                description: Right ascension in units of degrees at the center of the image.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.ra]
+              dec:
+                title: Declination of Image Center (deg)
+                description: Declination in units of degrees at the center of the image.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.dec]
+              orientation:
+                title: Image Orientation (deg)
+                description: >
+                  Angle in units of degrees between celestial North and
+                  the image y-axis at the center of the image turning positive in
+                  the direction of increasing right ascension.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.orientation]
+              orientation_ref:
+                title: Projection Region Orientation (deg)
+                description: >
+                  Angle in units of degrees between celestial North and
+                  the image y-axis at the center of the projection region turning
+                  positive in the direction of increasing right ascension. If this
+                  product does not use the Roman sky tessellation, then this
+                  keyword will be equal to meta.wcsinfo.orientation.
+                type: number
+                archive_catalog:
+                  datatype: float
+                  destination: [WFIMosaic.orientation_ref]
+              skycell_name:
+                title: Skycell Name
+                description: >
+                  Name of the skycell in the Roman sky tessellation to
+                  which this product corresponds. If this product is not a skycell
+                  product, this field will be None.
+                anyOf:
+                  - type: string
+                    maxLength: 30
+                  - type: "null"
+                archive_catalog:
+                  datatype: nvarchar(30)
+                  destination: [WFIMosaic.skycell_name]
+              rotation_matrix:
+                title: 2x2 rotation matrix
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: number
+                sdf:
+                  special_processing: VALUE_REQUIRED
+                  source:
+                    origin: TBD
+                archive_catalog:
+                  datatype: nvarchar(3500)
+                  destination: [WFIMosaic.rotation_matrix]
+            required:
+              [
+                ra_ref,
+                dec_ref,
+                x_ref,
+                y_ref,
+                pixel_scale_ref,
+                pixel_scale,
+                projection,
+                s_region,
+                image_shape,
+                ra,
+                dec,
+                orientation,
+                orientation_ref,
+                skycell_name,
+                rotation_matrix,
+              ]
+        required: [association, cal_step, resample, wcs, wcsinfo]
+  data:
+    title: Science Data (MJy / steradian)
+    description: |
+      The science data array, excluding the border reference pixels in units of
+      MJy / steradian.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy.sr**-1"
+  err:
+    title: Error Data (MJy / steradian)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy.sr**-1"
+  context:
+    title: Context Data
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 3
+  weight:
+    title: Weight Data
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+  var_poisson:
+    title: Poisson Variability (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_rnoise:
+    title: Read Noise Variance (MJy^2 / steradian^2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_flat:
+    title: Flat Field Variance (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_sky:
+    title: Sky Variance (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+propertyOrder:
+  [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat, var_sky]
+flowStyle: block
+required: [meta, data, context, err, weight, var_poisson, var_rnoise]

--- a/src/rad/resources/schemas/wfi_mosaic-1.4.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_mosaic.yaml

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -22,11 +22,9 @@ VARCHAR_XFAILS = (
 
 REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.0.0",)
 
-ARRAY_TAG_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.1.0",)
-
-REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.4.0",)
-
-NESTED_REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0",)
+ARRAY_TAG_XFAILS = (
+    # <resource uri>
+)
 
 
 class TestSchemaContent:
@@ -57,8 +55,6 @@ class TestSchemaContent:
         """
         Checks that all required properties are present in the schema
         """
-        if schema["id"] in REQUIRED_SKIPS:
-            pytest.skip(f"skipped required keyword test for {schema['id']}")
 
         def callback(node):
             """Callback for required properties being present"""
@@ -126,12 +122,12 @@ class TestSchemaContent:
         asdf.treeutil.walk(schema, callback)
 
     @pytest.mark.parametrize("uri", ARRAY_TAG_XFAILS)
-    def test_array_tag_xfail_relevant(self, uri, schema_uris):
+    def test_array_tag_xfail_relevant(self, uri, latest_uris):
         """
         Test that URIS that are marked as failing the array tagging are still relevant (in use).
         -> Smokes out when ARRAY_TAG_XFAILS is not relevant anymore.
         """
-        assert uri in schema_uris, f"{uri} is not in the list of schemas to be tested."
+        assert uri in latest_uris, f"{uri} is not in the list of schemas to be tested."
 
     def test_ref_loneliness(self, schema):
         """
@@ -181,9 +177,6 @@ class TestSchemaContent:
                     reason=f"{schema_uri} is not being altered to ensure required lists for archive metadata, due to it being in either tvac or fps."
                 )
             )
-
-        if schema_uri in NESTED_REQUIRED_SKIPS:
-            pytest.skip(f"skipping nested required keyword test for {schema_uri}")
 
         def callback(node):
             if isinstance(node, Mapping) and "properties" in node:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -22,14 +22,11 @@ VARCHAR_XFAILS = (
 
 REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.0.0",)
 
-ARRAY_TAG_XFAILS = (
-    "asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.0.0",
-    "asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.1.0",
-)
+ARRAY_TAG_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.1.0",)
 
-REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.3.0",)
+REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.4.0",)
 
-NESTED_REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.0.0",)
+NESTED_REQUIRED_SKIPS = ("asdf://stsci.edu/datamodels/roman/schemas/l3_common-1.1.0",)
 
 
 class TestSchemaContent:


### PR DESCRIPTION
PR #632 made some odd decisions for the handling of required attributes that ran a bit contrary to the rest of RAD. This was so that SSC could use the `l3_common` schema as part of their schemas but not be required to fill some of our `meta` attributes`.

Following the pattern for the level 1 and level 2 schemas, I split the attributes that we want required for SSC into a `l3_basic` schema and then built the `l3_common` schema on top of this. This is just a shuffling of information within the files, of what is being described should not change.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
