### PR TITLE
Updates to  archive destinations for CGI schemas

### DIFF
--- a/changes/655.feature.rst
+++ b/changes/655.feature.rst
@@ -1,0 +1,1 @@
+Fill in the placeholder values in the archive desinatations for the CGI schemas.

--- a/latest/SSC/CGI/keywords/cgi_ancillary.yaml
+++ b/latest/SSC/CGI/keywords/cgi_ancillary.yaml
@@ -15,7 +15,7 @@ properties:
     maxLength: 30
     archive_catalog:
       datatype: nvarchar(30)
-      destination: [CGIPlaceholder.ancillary_source]
+      destination: [CGIAncillary.ancillary_source]
 
   PKTUTC:
     title: Packet timestamp
@@ -23,7 +23,7 @@ properties:
     tag: tag:stsci.edu:asdf/time/time-1.*
     archive_catalog:
       datatype: datetime2
-      destination: [CGIPlaceholder.packet_timestamp]
+      destination: [CGIAncillary.packet_timestamp]
 
   INSTRUME:
     title: Instrument
@@ -32,6 +32,6 @@ properties:
     maxLength: 8
     archive_catalog:
       datatype: nvarchar(8)
-      destination: [CGIPlaceholder.instrument_name]
+      destination: [CGIAncillary.instrument_name]
 
 required: [SOURCE, PKTUTC, INSTRUME]

--- a/latest/SSC/CGI/keywords/cgi_common.yaml
+++ b/latest/SSC/CGI/keywords/cgi_common.yaml
@@ -15,7 +15,7 @@ properties:
     maxLength: 8
     archive_catalog:
       datatype: nvarchar(8)
-      destination: [CGIPlaceholder.instrument_name]
+      destination: [CGIExposure.instrument_name, CGIMosaic.instrument_name]
   PROGNUM:
     title: Program number
     description: ID number (integer) assigned to the proposal
@@ -23,7 +23,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.program]
+      destination: [CGIExposure.program, CGIMosaic.program]
   SEGMENT:
     title: Segment number
     description: The sequence of activities produced by each iteration of a Segment Plan (Observation Sequence) in a Pass
@@ -31,7 +31,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.segment]
+      destination: [CGIExposure.segment, CGIMosaic.segment]
   VISNUM:
     title: Visit number
     description: Visit number within a program
@@ -39,24 +39,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.visit]
-  DATALVL:
-    title: Product Levels
-    description: Product levels, 1 is raw uncalibrated images, 2a is calibrated images, 2b is coadded calibrated images, 3 is photometric-, astrometric-, and wavelength-calibrated images, 4 is PSF-subtracted and/or spectrally extracted data
-    type: string
-    maxLength: 16
-    archive_catalog:
-      datatype: nvarchar(16)
-      destination: [CGIPlaceholder.product_level]
-  DATASET: # SOC Proposed
-    # NOTE: The dataset field should be the string that defines the fileset at MAST, typically the first part of the file name. Work with SOC to confirm if fileset should include the timestamp part of the name or not.
-    title: Dataset ID
-    description: Dataset name
-    type: string
-    maxLength: 100
-    archive_catalog:
-      datatype: nvarchar(100)
-      destination: [CGIPlaceholder.file_set_name]
+      destination: [CGIExposure.visit, CGIMosaic.visit]
   # The following fields are NOT required, but they would be nice to have as explicitly specified values to fill in for our cross-mission search. If not relevant or not provided these will just be null values at MAST.
   DETECTOR: # SOC Proposed
     title: Detector
@@ -65,7 +48,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.detector]
+      destination: [CGIExposure.detector, CGIMosaic.detector]
   APERTURE: # SOC Proposed
     title: Aperture
     description: The CGI aperture name
@@ -73,7 +56,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.aperture]
+      destination: [CGIExposure.aperture, CGIMosaic.aperture]
   PINAME: # SOC Proposed
     title: PI Last Name
     description: Principal Investigator (PI) last name; uppercase (e.g., FORD, LEMMON)
@@ -81,7 +64,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.pi_name]
+      destination: [CGIExposure.pi_name, CGIMosaic.pi_name]
   PROGTITLE: # SOC Proposed
     title: Program Title
     description: The title of the program
@@ -89,7 +72,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.program_title]
+      destination: [CGIExposure.program_title, CGIMosaic.program_title]
   CALVER: # SOC Proposed
     title: Calibration Version
     description: The version of the calibration software used
@@ -97,7 +80,11 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.calibration_software_version]
+      destination:
+        [
+          CGIExposure.calibration_software_version,
+          CGIMosaic.calibration_software_version,
+        ]
 
 required:
   [
@@ -105,8 +92,6 @@ required:
     PROGNUM,
     SEGMENT,
     VISNUM,
-    DATALVL,
-    DATASET,
     DETECTOR,
     APERTURE,
     PINAME,

--- a/latest/SSC/CGI/keywords/cgi_exposure.yaml
+++ b/latest/SSC/CGI/keywords/cgi_exposure.yaml
@@ -14,7 +14,7 @@ properties:
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.exposure_time]
+      destination: [CGIExposure.exposure_time, CGIMosaic.exposure_time]
   ARRTYPE:
     title: Readout size
     description: Readout size
@@ -22,7 +22,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.readout_size]
+      destination: [CGIExposure.readout_size, CGIMosaic.readout_size]
   # For both the Roman CGI Search and the MAST Cross-Mission Search, sending these fields will permit time-range-based searches.
   EXPSTART: # SOC Proposed
     title: Start Time
@@ -30,14 +30,14 @@ properties:
     tag: tag:stsci.edu:asdf/time/time-1.*
     archive_catalog:
       datatype: datetime2
-      destination: [CGIPlaceholder.visit_start_time]
+      destination: [CGIExposure.visit_start_time, CGIMosaic.visit_start_time]
   EXPEND: # SOC Proposed
     title: End Time
     description: Observation end time (UTC)
     tag: tag:stsci.edu:asdf/time/time-1.*
     archive_catalog:
       datatype: datetime2
-      destination: [CGIPlaceholder.visit_end_time]
+      destination: [CGIExposure.visit_end_time, CGIMosaic.visit_end_time]
   # NOTE: MAST uses MJD for start and end times in our cross-mission search. We can convert from datetime strings, but if they are included in the manifest separately it would eliminate the need to do the conversion on the MAST side.
   MJDSTART: # SOC Proposed
     title: Start Time MJD
@@ -45,13 +45,15 @@ properties:
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.visit_start_time_mjd]
+      destination:
+        [CGIExposure.visit_start_time_mjd, CGIMosaic.visit_start_time_mjd]
   MJDEND: # SOC Proposed
     title: End Time MJD
     description: Observation end time in MJD
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.visit_end_time_mjd]
+      destination:
+        [CGIExposure.visit_end_time_mjd, CGIMosaic.visit_end_time_mjd]
 
 required: [EXPTIME, ARRTYPE, EXPSTART, EXPEND, MJDSTART, MJDEND]

--- a/latest/SSC/CGI/keywords/cgi_mechanism_named_settings.yaml
+++ b/latest/SSC/CGI/keywords/cgi_mechanism_named_settings.yaml
@@ -15,7 +15,7 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.spamname]
+      destination: [CGIExposure.spamname, CGIMosaic.spamname]
   FPAMNAME:
     title: Closest Focal Plane Alignment Mechanism named setting
     description: Closest focal plan alignment mechanism setting
@@ -23,7 +23,7 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.fpamname]
+      destination: [CGIExposure.fpamname, CGIMosaic.fpamname]
   LSAMNAME:
     title: Closest Lyot Stop Alignment Mechanism named setting
     description: Closest Lyot stop alignment mechanism setting
@@ -31,7 +31,7 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.lsamname]
+      destination: [CGIExposure.lsamname, CGIMosaic.lsamname]
   FSAMNAME:
     title: Closest Field Stop Alignment Mechanism named setting
     description: Closest field stop alignment mechanism setting
@@ -39,7 +39,7 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.fsamname]
+      destination: [CGIExposure.fsamname, CGIMosaic.fsamname]
   CFAMNAME:
     title: Closest Color Filter Alignment Mechanism named setting
     description: Closest filter alignment mechanism setting
@@ -47,7 +47,7 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.cfamname]
+      destination: [CGIExposure.cfamname, CGIMosaic.cfamname]
   DPAMNAME:
     title: Closest Dispersion Polarizer Alignment Mechanism named setting
     description: Closest dispersion polarizer alignment mechanism setting
@@ -55,6 +55,6 @@ properties:
     maxLength: 128
     archive_catalog:
       datatype: nvarchar(128)
-      destination: [CGIPlaceholder.dpamname]
+      destination: [CGIExposure.dpamname, CGIMosaic.dpamname]
 
 required: [SPAMNAME, FPAMNAME, LSAMNAME, FSAMNAME, CFAMNAME, DPAMNAME]

--- a/latest/SSC/CGI/keywords/cgi_pointing.yaml
+++ b/latest/SSC/CGI/keywords/cgi_pointing.yaml
@@ -14,14 +14,14 @@ properties:
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.ra_ref]
+      destination: [CGIExposure.ra_ref, CGIMosaic.ra_ref]
   DEC:
     title: Dec (J2000)
     description: Declination (J2000), from -90 to +90, in degrees
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.dec_ref]
+      destination: [CGIExposure.dec_ref, CGIMosaic.dec_ref]
   TARGET:
     title: Target Name
     description: Name of the source pointed at by the telescope
@@ -29,7 +29,7 @@ properties:
     maxLength: 256
     archive_catalog:
       datatype: nvarchar(256)
-      destination: [CGIPlaceholder.target_name]
+      destination: [CGIExposure.target_name, CGIMosaic.target_name]
   REFFRAME: # SOC Proposed
     # This is optional, if not provided MAST will just assume ICRS, but best to explicitly provide.
     title: Reference Frame
@@ -38,7 +38,7 @@ properties:
     maxLength: 16
     archive_catalog:
       datatype: nvarchar(16)
-      destination: [CGIPlaceholder.reference_frame]
+      destination: [CGIExposure.reference_frame, CGIMosaic.reference_frame]
   EQUINOX: # SOC Proposed
     # This is optional, if not provided MAST will just assume 2000.0, but best to explicitly provide.
     title: Equinox
@@ -46,6 +46,6 @@ properties:
     type: number
     archive_catalog:
       datatype: float
-      destination: [CGIPlaceholder.equinox]
+      destination: [CGIExposure.equinox, CGIMosaic.equinox]
 
 required: [RA, DEC, TARGET, REFFRAME, EQUINOX]

--- a/latest/SSC/CGI/keywords/cgi_region.yaml
+++ b/latest/SSC/CGI/keywords/cgi_region.yaml
@@ -17,6 +17,6 @@ properties:
     type: string
     archive_catalog:
       datatype: nvarchar(max)
-      destination: [CGIPlaceholder.s_region]
+      destination: [CGIExposure.s_region, CGIMosaic.s_region]
 
 required: [S_REGION]

--- a/latest/SSC/CGI/keywords/cgi_states.yaml
+++ b/latest/SSC/CGI/keywords/cgi_states.yaml
@@ -15,7 +15,7 @@ properties:
     maxLength: 32
     archive_catalog:
       datatype: nvarchar(32)
-      destination: [CGIPlaceholder.opmode]
+      destination: [CGIExposure.opmode, CGIMosaic.opmode]
   FSMPRFL:
     title: FSM profile
     description: The FSM profile
@@ -23,6 +23,6 @@ properties:
     maxLength: 32
     archive_catalog:
       datatype: nvarchar(32)
-      destination: [CGIPlaceholder.fsmprofile]
+      destination: [CGIExposure.fsmprofile, CGIMosaic.fsmprofile]
 
 required: [OPMODE, FSMPRFL]

--- a/latest/SSC/CGI/keywords/cgi_visit.yaml
+++ b/latest/SSC/CGI/keywords/cgi_visit.yaml
@@ -15,6 +15,6 @@ properties:
     maxLength: 30
     archive_catalog:
       datatype: nvarchar(30)
-      destination: [CGIPlaceholder.vistype]
+      destination: [CGIExposure.vistype]
 
 required: [VISTYPE]

--- a/latest/SSC/ssc_basic.yaml
+++ b/latest/SSC/ssc_basic.yaml
@@ -24,7 +24,8 @@ properties:
     maxLength: 1024
     archive_catalog:
       datatype: nvarchar(1024)
-      destination: [CGIPlaceholder.filename]
+      destination:
+        [CGIExposure.filename, CGIMosaic.filename, CGIAncillary.filename]
   file_date:
     title: File Creation Date (UTC)
     description: |
@@ -34,7 +35,8 @@ properties:
     tag: tag:stsci.edu:asdf/time/time-1.*
     archive_catalog:
       datatype: datetime2
-      destination: [CGIPlaceholder.filedate]
+      destination:
+        [CGIExposure.filedate, CGIMosaic.filedate, CGIAncillary.filedate]
   origin:
     title: Institution / Organization Name
     description: |
@@ -45,6 +47,6 @@ properties:
     maxLength: 15
     archive_catalog:
       datatype: nvarchar(15)
-      destination: [CGIPlaceholder.origin]
+      destination: [CGIExposure.origin, CGIMosaic.origin, CGIAncillary.origin]
 
 required: [filename, file_date, origin]


### PR DESCRIPTION
This PR fills in some of the placeholders for the CGI schema archive destinations.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
