### PR TITLE
Bugfix for creating new resources with rad script

### DIFF
--- a/scripts/helper/_app.py
+++ b/scripts/helper/_app.py
@@ -204,13 +204,13 @@ class RadApp(App):
 
         if tagged:
             if self._manager.datamodels_manifest.frozen:
-                match await self._bump_resources(BumpScreen(self._manager.init_bump(self._manager.datamodels_manifest))):
+                match await self._bump_resources(BumpScreen(self._manager.init_bump(self._manager.datamodels_manifest.path))):
                     case BumpScreen.Return.BUMP:
                         self.notify("Resources bumped successfully.", severity="success")
                     case BumpScreen.Return.RETURN:
                         self.notify("Could not bump the manifest, aborting resource creation", severity="error")
                         return
-            self._manager.datamodels_manifest.add_tag_entry(new_resource.tag_entry)
+            self._manager.add_tag_entry(new_resource.tag_entry)
 
         self._manager.add_new_resource(state, new_resource.create(tagged))
 

--- a/scripts/helper/_edit.py
+++ b/scripts/helper/_edit.py
@@ -280,7 +280,7 @@ class EditTab(TabPane):
         self._manager.reload()
         match event.state:
             case BumpScreen.Return.BUMP:
-                if not self._manager[self._selection].frozen:
+                if not (self._selection and self._manager[self._selection].frozen):
                     self.query_one("#bump_resource", Button).disabled = True
 
             case NewScreen.Return.CREATE:

--- a/scripts/helper/_frozen.py
+++ b/scripts/helper/_frozen.py
@@ -16,7 +16,7 @@ from semantic_version import Version
 from yaml import safe_load
 
 _RAD_URLS = (
-    "https://github.com/spacetelescope/rad",
+    "https://github.com/spacetelescope/rad.git",
     "git@github.com:spacetelescope/rad.git",
 )
 

--- a/scripts/helper/_manager.py
+++ b/scripts/helper/_manager.py
@@ -166,7 +166,9 @@ class _Manager:
         Resource
             The datamodels manifest resource.
         """
-        manifests = [resource for resource in self._resources.values() if resource.is_manifest and "datamodels" in resource.uri]
+        manifests = [
+            resource for resource in self._resources.values() if resource.is_manifest and "manifests/datamodels" in resource.uri
+        ]
         if len(manifests) != 1:
             raise RuntimeError("Found more than one datamodels manifest resource.")
 
@@ -313,6 +315,25 @@ class _Manager:
 
                 # Update the resource in the manager
                 self._resources[new_resource.uri] = new_resource
+
+    def add_tag_entry(self, entry: str) -> None:
+        """
+        Add a tag entry to the resource's tag URI.
+        --> This is used to add a new tag entry to the resource's tag URI.
+
+        Parameters
+        ----------
+        entry : str
+            The tag entry to add to the resource's tag URI.
+        """
+        # Update the resource with the new tag entry
+        new_manifest = self.datamodels_manifest.add_tag_entry(entry)
+
+        if new_manifest.uri != self.datamodels_manifest.uri:
+            raise RuntimeError("This method should not be used to change the URI of a manifest.")
+
+        # Update the resource in the manager
+        self._resources[new_manifest.uri] = new_manifest
 
     def _resources_to_update(self, path: Path | str) -> Generator[Bump, None, None]:
         """

--- a/scripts/helper/_resource.py
+++ b/scripts/helper/_resource.py
@@ -466,9 +466,17 @@ class _Resource:
         if tagged:
             body += "\nflowStyle: block\n"
 
+        # Create the parent directory(s) if they don't exist
+        if not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+
         # Create the resource file at its path (in latest)
         with self.path.open("w") as f:
             f.write(body)
+
+        # Create the symlink parent directory(s) if they don't exist
+        if not self.symlink.parent.exists():
+            self.symlink.parent.mkdir(parents=True, exist_ok=True)
 
         # Create the symlink for the resource
         self.symlink.symlink_to(self.symlink_target)


### PR DESCRIPTION
This PR addresses a couple of minor bugs I have discovered with the helper script. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
