### PR TITLE
RAD-221: Add statistics to the FPS schema

### DIFF
--- a/changes/685.bugfix.rst
+++ b/changes/685.bugfix.rst
@@ -1,0 +1,1 @@
+Update fps schema to include reference to the statistics tag in its ``meta`` section.

--- a/src/rad/resources/schemas/fps-1.0.0.yaml
+++ b/src/rad/resources/schemas/fps-1.0.0.yaml
@@ -19,6 +19,8 @@ properties:
         properties:
           groundtest:
             tag: asdf://stsci.edu/datamodels/roman/tags/fps/groundtest-1.0.0
+          statistics:
+            tag: asdf://stsci.edu/datamodels/roman/tags/fps/statistics-1.0.0
         required: [groundtest]
 
   data:

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -60,7 +60,11 @@ with (REPO_PATH / "pyproject.toml").open("rb") as f:
 
 # Any expected versioning failures should be added here
 EXPECTED_XFAILS = (
-    # ("<version>", "<uri>"),
+    # FPS schema change has been requested, investigation of RITA data indicates
+    # that the change made will not effect any existing data, so this should be safe
+    ("0.25.0", "asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0"),
+    ("0.26.0", "asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0"),
+    ("0.27.0", "asdf://stsci.edu/datamodels/roman/schemas/fps-1.0.0"),
 )
 
 # The keywords in the schemas that we claim don't matter for schema versioning


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-221](https://jira.stsci.edu/browse/RAD-221)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #679

<!-- describe the changes comprising this PR here -->

After careful investigation of the FPS_SAMPLE files for RITA, I have determined that it is "safe" to adjust the FPS schema so that it does in fact reference the fps statistics schema without fear of breaking the existing files that RITA has. This PR makes that change to the schema.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
