### PR TITLE
RAD-220: Remove versioning and ASDF packaging of SSC schemas

### DIFF
--- a/changes/686.misc.rst
+++ b/changes/686.misc.rst
@@ -1,0 +1,2 @@
+Remove direct ASDF packaging of the SSC schemas, and modify the versioning tests
+so that they no longer apply to the SSC schemas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,27 @@ addopts = [
 testpaths = ["tests", "src/rad/resources/schemas"]
 filterwarnings = ["error"]
 asdf_schema_tests_enabled = "true"
-asdf_schema_skip_tests = "src/rad/resources/schemas/rad_schema-1.0.0.yaml"
+asdf_schema_skip_tests = ["src/rad/resources/schemas/rad_schema-1.0.0.yaml"]
+# All the SSC schemas with a $ref have to be xfailed due to asdf-format/pytest-asdf-plugin#9
+asdf_schema_xfail_tests = [
+  "src/rad/resources/schemas/SSC/CGI/cgi_ancillary-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/CGI/cgi_level_1-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/CGI/cgi_level_2a-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/CGI/cgi_level_2b-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/CGI/cgi_level_3-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/CGI/cgi_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_combined_1d_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_data_quality_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_decontaminated_2d_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_individual_1d_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_location_table_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_event_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_light_curve_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_reference_frame_level_3-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_variability_catalog_level_4-1.0.0.yaml",
+]
 asdf_schema_root = "src/rad/resources/schemas"
 
 [tool.ruff]

--- a/src/rad/integration.py
+++ b/src/rad/integration.py
@@ -3,6 +3,23 @@ import importlib.resources as importlib_resources
 from asdf.resource import DirectoryResourceMapping
 
 
+class RadDirectoryResourceMapping(DirectoryResourceMapping):
+    """
+    A Custom DirectoryResourceMapping that avoids the SSC schemas.
+
+    Note:
+        DirectryResourceMapping uses fnmatch on the file's name not its full path
+        so it is not easy to exclude the files from the SSC directory using the
+        filename_pattern argument. So we override the _iterate_files method to
+        filter out any files in the SSC directory.
+    """
+
+    def _iterate_files(self, directory, path_components):
+        for file, components in super()._iterate_files(directory, path_components):
+            if "SSC" not in str(file):
+                yield file, components
+
+
 def get_resource_mappings():
     """
     Get the resource mapping instances for the datamodel schemas
@@ -18,6 +35,6 @@ def get_resource_mappings():
     resources_root = importlib_resources.files(resources)
 
     return [
-        DirectoryResourceMapping(resources_root / "schemas", "asdf://stsci.edu/datamodels/roman/schemas/", recursive=True),
+        RadDirectoryResourceMapping(resources_root / "schemas", "asdf://stsci.edu/datamodels/roman/schemas/", recursive=True),
         DirectoryResourceMapping(resources_root / "manifests", "asdf://stsci.edu/datamodels/roman/manifests/"),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,24 @@ def schema_path(request):
     return request.param
 
 
+@pytest.fixture(scope="session", params=(importlib_resources.files(resources) / "schemas" / "SSC").glob("**/*.yaml"))
+def ssc_schema_path(request):
+    """
+    Get a path to an SSC schema file directly from the python package, rather than ASDF
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def ssc_schema_uri(ssc_schema_path):
+    """
+    Get a URI for an SSC schema
+    """
+    content = ssc_schema_path.read_bytes()
+    schema = yaml.safe_load(content)
+    return schema["id"]
+
+
 ### Fixtures for working with only the latest schemas
 @pytest.fixture(scope="session")
 def latest_paths():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ Test that the asdf library integration is working properly.
 import importlib.resources as importlib_resources
 
 import asdf
+import pytest
 import yaml
 
 from rad import resources
@@ -30,8 +31,15 @@ def test_schema_integration(schema_path, schema_uris, metaschema_uri):
     schema = yaml.safe_load(content)
     uri = schema["id"]
 
-    assert uri in schema_uris or uri == metaschema_uri
-    assert content == asdf.get_config().resource_manager[uri]
+    # If the schema is in the SSC directory then it should not be available through
+    # ASDF
+    if "SSC" in str(schema_path):
+        assert uri not in schema_uris and uri != metaschema_uri
+        with pytest.raises(KeyError, match=r"Resource unavailable for URI: .*"):
+            asdf.get_config().resource_manager[uri]
+    else:
+        assert uri in schema_uris or uri == metaschema_uri
+        assert content == asdf.get_config().resource_manager[uri]
 
 
 def test_schema_filename(schema_path):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -508,7 +508,7 @@ def asdf_ssc_config():
         yield config
 
     # Clear the schema cache to avoid issues with other tests
-    #   ASDF normally caches the loaded schemas so they don't have to be relo
+    #   ASDF normally caches the loaded schemas so they don't have to be reloaded
     #   but this creates a problem for the asdf-pytest-plugin, if those tests
     #   are run after these tests because the loaded schemas will then be cached
     #   and not fail. But if they are run before these tests then asdf-pytest-plugin

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -303,6 +303,10 @@ def _get_frozen_schemas_for_all_versions():
         version_schemas = _get_frozen_schemas(version)
         schemas[version] = version_schemas
         for uri in version_schemas:
+            if "SSC" in uri:
+                # SSC schemas are not under versioning
+                continue
+
             if uri not in uris:
                 uris.append(uri)
 


### PR DESCRIPTION
Resolves [RAD-220](https://jira.stsci.edu/browse/RAD-220)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #672

<!-- describe the changes comprising this PR here -->

This PR removes the versioning testing from the SSC schemas and removes ASDF's direct packaging of those schemas. I currently does not remove any of the additional testing such as the `required` testing for now as I think we need to carefully review which of those unit tests we wish to apply.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
