### PR TITLE
SSC GDPS archive search keywords update

### DIFF
--- a/latest/SSC/GDPS/wfi_spec_catalog_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_catalog_level_4.yaml
@@ -9,10 +9,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_catalog_level_4-
 title: Level 4 Grism/Prism - Catalog
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/catalog-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/catalog-1.0.0

--- a/latest/SSC/GDPS/wfi_spec_combined_1d_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_combined_1d_level_4.yaml
@@ -9,13 +9,11 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_combined_1d_leve
 title: Level 4 Grism/Prism - 1D Combined Spectrum for each Source
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0

--- a/latest/SSC/GDPS/wfi_spec_data_quality_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_data_quality_level_4.yaml
@@ -9,10 +9,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_data_quality_lev
 title: Level 4 Grism/Prism - Data Quality
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/catalog-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/catalog-1.0.0

--- a/latest/SSC/GDPS/wfi_spec_decontaminated_2d_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_decontaminated_2d_level_4.yaml
@@ -9,13 +9,11 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_decontaminated_2
 title: Level 4 Grism/Prism - 2D Decontaminated Spectra
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0

--- a/latest/SSC/GDPS/wfi_spec_individual_1d_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_individual_1d_level_4.yaml
@@ -9,13 +9,11 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_individual_1d_le
 title: Level 4 Grism/Prism - 1D Derived Spectrum for each Source
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/calibration-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/wavelength-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/pointing-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/g2dp_common-1.0.0

--- a/latest/SSC/GDPS/wfi_spec_location_table_level_4.yaml
+++ b/latest/SSC/GDPS/wfi_spec_location_table_level_4.yaml
@@ -9,10 +9,8 @@ id: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/wfi_spec_location_table_l
 title: Level 4 Grism/Prism - Spectra Location Table
 archive_meta: Placeholder SOC file type
 type: object
-properties:
-  meta:
-    allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/location_table-1.0.0
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/instrument-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/GDPS/keywords/location_table-1.0.0

--- a/latest/SSC/ssc_basic.yaml
+++ b/latest/SSC/ssc_basic.yaml
@@ -32,7 +32,8 @@ properties:
       The file creation date as taken from the 'fileCreationTimestamp' property of the
       data availability notification (https://github.com/spacetelescope/roman-soc-ssc-common/blob/main/schemas/data_availability.json#L76)
       SSC does not need to include this in the 'metadata' object of the data availability notification.
-    tag: tag:stsci.edu:asdf/time/time-1.*
+    allOf:
+      - $ref: http://stsci.edu/schemas/asdf/time/time-1.3.0#/definitions/iso_time
     archive_catalog:
       datatype: datetime2
       destination:


### PR DESCRIPTION
This PR will be used to refine and discuss the SSC GDPS archive search keywords for SOC B20.

@jsobeck and @ejoliet to provide feedback on updates needed here.

Initial changes:
- The keywords will arrive from SSC in a flat JSON object. There is no 'meta' object, so it has been removed here.


## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
