### PR TITLE
Fix the readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Roman Attribute Dictionary
 
-[![CI](https://github.com/spacetelescope/rad/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/rad/actions/workflows/ci.yml)
+[![Tests](https://github.com/spacetelescope/rad/actions/workflows/tests.yml/badge.svg)](https://github.com/spacetelescope/rad/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/rad/badge/?version=latest)](https://rad.readthedocs.io/en/latest/?badge=latest)
-[![Weekly CI](https://github.com/spacetelescope/rad/actions/workflows/ci_cron.yml/badge.svg)](https://github.com/spacetelescope/rad/actions/workflows/ci_cron.yml)
+[![Extra Tests](https://github.com/spacetelescope/rad/actions/workflows/tests_extra.yml/badge.svg)](https://github.com/spacetelescope/rad/actions/workflows/tests_extra.yml)
 [![Powered by STScI Badge](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16048573.svg)](https://doi.org/10.5281/zenodo.16048573)
 


### PR DESCRIPTION
I noticed that some of the readme badges were broken this PR fixes that.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
