### PR TITLE
Update the reference file schemas to use explicit entries

### DIFF
--- a/changes/712.feature.rst
+++ b/changes/712.feature.rst
@@ -1,0 +1,2 @@
+Make the ``patternProperties`` used for optical elements in the reference file schemas explicit.
+and add tests to ensure all optical elements in these schemas are accounted for.

--- a/latest/reference_files/abvegaoffset.yaml
+++ b/latest/reference_files/abvegaoffset.yaml
@@ -7,6 +7,20 @@ title: AB Vega Offset Reference File Schema
 
 datamodel_name: AbvegaoffsetRefModel
 
+definitions:
+  data_entry:
+    type: object
+    properties:
+      abvega_offset:
+        title: AB-Vega Magntiude Offset
+        description: Magnitude difference between the AB and Vega magnitude
+          systems. Found by calculating the AB magnitude of Vega within
+          the optical element bandpass.
+        anyOf:
+          - type: number
+          - type: "null"
+    required: [abvega_offset]
+
 type: object
 properties:
   meta:
@@ -19,19 +33,34 @@ properties:
             enum: [ABVEGAOFFSET]
   data:
     type: object
-    patternProperties:
-      "^(F062|F087|F106|F129|F146|F158|F184|F213|GRISM|PRISM|DARK)$":
-        type: object
-        properties:
-          abvega_offset:
-            title: AB-Vega Magntiude Offset
-            description: Magnitude difference between the AB and Vega magnitude
-              systems. Found by calculating the AB magnitude of Vega within
-              the optical element bandpass.
-            anyOf:
-              - type: number
-              - type: "null"
-        required: [abvega_offset]
+    properties:
+      F062:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F087:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F106:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F129:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F146:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F158:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F184:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      F213:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      GRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      PRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      DARK:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+      NOT_CONFIGURED:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.2.0#/definitions/data_entry
+    required:
+      [F062, F087, F106, F129, F146, F158, F184, F213, GRISM, PRISM, DARK]
+
 required: [meta, data]
 flowStyle: block
 propertyOrder: [meta, data]

--- a/latest/reference_files/apcorr.yaml
+++ b/latest/reference_files/apcorr.yaml
@@ -7,6 +7,66 @@ title: Aperture Correction Reference File Schema
 
 datamodel_name: ApcorrRefModel
 
+definitions:
+  data_entry:
+    type: object
+    properties:
+      ap_corrections:
+        title: Aperture Corrections
+        description: The aperture correction for each enclosed energy
+          fraction, corresponding to 1 / ee_fractions.
+        anyOf:
+          - type: "null"
+          - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float64
+            exact_datatype: true
+            ndim: 1
+      ee_fractions:
+        title: Enclosed Energy Fractions
+        description: Fractions of the enclosed energy of the PSF at which
+          to estimate the aperture correction and enclosed energy radii.
+        anyOf:
+          - type: "null"
+          - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float64
+            exact_datatype: true
+            ndim: 1
+      ee_radii:
+        title: Enclosed Energy Radii
+        description: Radius, in pixels, within which the enclosed energy
+          fractions are met. The indexing matches that of
+          "ee_fractions".
+        anyOf:
+          - type: "null"
+          - tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float64
+            exact_datatype: true
+            ndim: 1
+      sky_background_rin:
+        title: Inner Radius for the Sky Background
+        description: Inner radius, in pixels, to use when estimating the
+          local sky background within an annulus between this
+          radius and "sky_background_rout".
+        anyOf:
+          - type: number
+          - type: "null"
+      sky_background_rout:
+        title: Outer Radius for the Sky Background
+        description: Outer radius, in pixels, to use when estimating the
+          local sky background within an annulus between this
+          radius and "sky_background_rin".
+        anyOf:
+          - type: number
+          - type: "null"
+    required:
+      [
+        ap_corrections,
+        ee_fractions,
+        ee_radii,
+        sky_background_rin,
+        sky_background_rout,
+      ]
+
 type: object
 properties:
   meta:
@@ -19,65 +79,33 @@ properties:
             enum: [APCORR]
   data:
     type: object
-    patternProperties:
-      "^(F062|F087|F106|F129|F146|F158|F184|F213|GRISM|PRISM|DARK)$":
-        type: object
-        properties:
-          ap_corrections:
-            title: Aperture Corrections
-            description: The aperture correction for each enclosed energy
-              fraction, corresponding to 1 / ee_fractions.
-            anyOf:
-              - type: "null"
-              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float64
-                exact_datatype: true
-                ndim: 1
-          ee_fractions:
-            title: Enclosed Energy Fractions
-            description: Fractions of the enclosed energy of the PSF at which
-              to estimate the aperture correction and enclosed energy radii.
-            anyOf:
-              - type: "null"
-              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float64
-                exact_datatype: true
-                ndim: 1
-          ee_radii:
-            title: Enclosed Energy Radii
-            description: Radius, in pixels, within which the enclosed energy
-              fractions are met. The indexing matches that of
-              "ee_fractions".
-            anyOf:
-              - type: "null"
-              - tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float64
-                exact_datatype: true
-                ndim: 1
-          sky_background_rin:
-            title: Inner Radius for the Sky Background
-            description: Inner radius, in pixels, to use when estimating the
-              local sky background within an annulus between this
-              radius and "sky_background_rout".
-            anyOf:
-              - type: number
-              - type: "null"
-          sky_background_rout:
-            title: Outer Radius for the Sky Background
-            description: Outer radius, in pixels, to use when estimating the
-              local sky background within an annulus between this
-              radius and "sky_background_rin".
-            anyOf:
-              - type: number
-              - type: "null"
-        required:
-          [
-            ap_corrections,
-            ee_fractions,
-            ee_radii,
-            sky_background_rin,
-            sky_background_rout,
-          ]
+    properties:
+      F062:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F087:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F106:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F129:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F146:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F158:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F184:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      F213:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      GRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      PRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      DARK:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+      NOT_CONFIGURED:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.2.0#/definitions/data_entry
+    required:
+      [F062, F087, F106, F129, F146, F158, F184, F213, GRISM, PRISM, DARK]
 required: [meta, data]
 flowStyle: block
 propertyOrder: [meta, data]

--- a/latest/reference_files/wfi_img_photom.yaml
+++ b/latest/reference_files/wfi_img_photom.yaml
@@ -44,6 +44,78 @@ definitions:
         wavelength,
         effective_area,
       ]
+  filter_phot_table_entry:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
+      - type: object
+        properties:
+          photmjsr:
+            type: number
+            unit: "(MJy/sr) / (DN/s)"
+          uncertainty:
+            type: number
+            unit: "(MJy/sr) / (DN/s)"
+          pixelareasr:
+            type: number
+            unit: "sr"
+          collecting_area:
+            type: number
+            unit: "m^2"
+          wavelength:
+            tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float32
+            exact_datatype: true
+            ndim: 1
+            unit: "microns"
+          effective_area:
+            tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float32
+            exact_datatype: true
+            ndim: 1
+            unit: "m^2"
+  spectral_phot_table_entry:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
+      - type: object
+        properties:
+          photmjsr:
+            type: "null"
+          uncertainty:
+            type: "null"
+          pixelareasr:
+            type: "null"
+          collecting_area:
+            type: number
+            unit: "m^2"
+          wavelength:
+            tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float32
+            exact_datatype: true
+            ndim: 1
+            unit: "microns"
+          effective_area:
+            tag: tag:stsci.edu:asdf/core/ndarray-1.*
+            datatype: float32
+            exact_datatype: true
+            ndim: 1
+            unit: "m^2"
+  empty_phot_table_entry:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
+      - type: object
+        properties:
+          photmjsr:
+            type: "null"
+          uncertainty:
+            type: "null"
+          pixelareasr:
+            type: "null"
+          collecting_area:
+            type: "null"
+          wavelength:
+            type: "null"
+          effective_area:
+            type: "null"
 
 type: object
 properties:
@@ -60,80 +132,49 @@ properties:
     description: |
       Table containing photometric properties of the WFI optical elements.
     type: object
-    patternProperties:
-      "^(F062|F087|F106|F129|F146|F158|F184|F213)$":
-        allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
-          - type: object
-            properties:
-              photmjsr:
-                type: number
-                unit: "(MJy/sr) / (DN/s)"
-              uncertainty:
-                type: number
-                unit: "(MJy/sr) / (DN/s)"
-              pixelareasr:
-                type: number
-                unit: "sr"
-              collecting_area:
-                type: number
-                unit: "m^2"
-              wavelength:
-                tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float32
-                exact_datatype: true
-                ndim: 1
-                unit: "microns"
-              effective_area:
-                tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float32
-                exact_datatype: true
-                ndim: 1
-                unit: "m^2"
+    properties:
+      F062:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F087:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F106:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F129:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F146:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F158:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F184:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      F213:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/filter_phot_table_entry
+      GRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/spectral_phot_table_entry
       # GRISM_0 is a special optical element case that is only used for this reference file
-      "^(GRISM|GRISM_0|PRISM)$":
-        allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
-          - type: object
-            properties:
-              photmjsr:
-                type: "null"
-              uncertainty:
-                type: "null"
-              pixelareasr:
-                type: "null"
-              collecting_area:
-                type: number
-                unit: "m^2"
-              wavelength:
-                tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float32
-                exact_datatype: true
-                ndim: 1
-                unit: "microns"
-              effective_area:
-                tag: tag:stsci.edu:asdf/core/ndarray-1.*
-                datatype: float32
-                exact_datatype: true
-                ndim: 1
-                unit: "m^2"
-      "^(DARK|NOT_CONFIGURED)$":
-        allOf:
-          - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/basic_phot_table_entry
-          - type: object
-            properties:
-              photmjsr:
-                type: "null"
-              uncertainty:
-                type: "null"
-              pixelareasr:
-                type: "null"
-              collecting_area:
-                type: "null"
-              wavelength:
-                type: "null"
-              effective_area:
-                type: "null"
+      GRISM_0:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/spectral_phot_table_entry
+      PRISM:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/spectral_phot_table_entry
+      DARK:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/empty_phot_table_entry
+      NOT_CONFIGURED:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.3.0#/definitions/empty_phot_table_entry
+    required:
+      [
+        F062,
+        F087,
+        F106,
+        F129,
+        F146,
+        F158,
+        F184,
+        F213,
+        GRISM,
+        GRISM_0,
+        PRISM,
+        DARK,
+      ]
     additionalProperties: false
 required: [meta, phot_table]
 flowStyle: block

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -524,9 +524,21 @@ def _get_latest_uri(prefix):
     return _find_latest(uris)
 
 
-_PHOT_TABLE_KEY_PATTERNS = _CURRENT_RESOURCES[
-    _get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom")
-]["properties"]["phot_table"]["patternProperties"]
+_PHOT_TABLE_KEYS = tuple(
+    _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom")]["properties"][
+        "phot_table"
+    ]["properties"].keys()
+)
+_ABVEGAOFFSET_KEYS = tuple(
+    _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset")]["properties"][
+        "data"
+    ]["properties"].keys()
+)
+_APCORR_KEYS = tuple(
+    _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr")]["properties"]["data"][
+        "properties"
+    ].keys()
+)
 _OPTICAL_ELEMENTS = tuple(
     _CURRENT_RESOURCES[_get_latest_uri("asdf://stsci.edu/datamodels/roman/schemas/wfi_optical_element")]["enum"]
 )
@@ -539,20 +551,49 @@ _P_EXPTYPE_PATTERN = _CURRENT_RESOURCES[
 
 
 @pytest.fixture(scope="session")
-def phot_table_key_patterns():
+def phot_table_keys():
     """
     Get the pattern for the photometry table key used by the reference files.
     """
-    return tuple(compile(pattern) for pattern in _PHOT_TABLE_KEY_PATTERNS.keys())
+    return _PHOT_TABLE_KEYS
 
 
-@pytest.fixture(
-    scope="session",
-    params=tuple(p for pattern in _PHOT_TABLE_KEY_PATTERNS.keys() for p in pattern.split(")$")[0].split("(")[-1].split("|")),
-)
+@pytest.fixture(scope="session", params=_PHOT_TABLE_KEYS)
 def phot_table_key(request):
     """
     Get the photometry table key from the request.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def abvegaoffset_keys():
+    """
+    Get the keys for the abvegaoffset reference file.
+    """
+    return _ABVEGAOFFSET_KEYS
+
+
+@pytest.fixture(scope="session", params=_ABVEGAOFFSET_KEYS)
+def abvegaoffset_key(request):
+    """
+    Get the abvegaoffset key from the request.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def apcorr_keys():
+    """
+    Get the keys for the apcorr reference file.
+    """
+    return _APCORR_KEYS
+
+
+@pytest.fixture(scope="session", params=_APCORR_KEYS)
+def apcorr_key(request):
+    """
+    Get the apcorr key from the request.
     """
     return request.param
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -520,25 +520,45 @@ class TestReferenceFileSchemas:
 
 
 class TestPatternElementConsistency:
-    def test_phot_table_keys_have_optical_element_entry(self, phot_table_key_patterns, optical_element):
+    def test_phot_table_keys_have_optical_element_entry(self, phot_table_keys, optical_element):
         """
-        Confirm that the optical_element filter in wfi_img_photom.yaml matches optical_element
+        Confirm that each optical_element corresponds to a phot_table_key in wfi_img_photom
         """
-        for pattern in phot_table_key_patterns:
-            if pattern.search(optical_element):
-                return
-
-        raise AssertionError(f"phot_table_key pattern is missing {optical_element}.")
+        assert optical_element in phot_table_keys, f"optical_element {optical_element} not found in phot_table_keys."
 
     def test_optical_elements_have_phot_table_key(self, phot_table_key, optical_elements):
         """
-        Confirm that the optical_element filter in wfi_img_photom.yaml matches optical_element
+        Confirm that each phot_table_key corresponds to an optical_element in wfi_img_photom
         """
         # NOTE: GRISM_0 is a special case that will only ever be used in the photom table,
         #   It is due to a special photom measurement only relevant for calibration purposes
         #   so it will never appear anywhere else, so it is excluded from the optical elements
         #   in general.
         assert phot_table_key in (*optical_elements, "GRISM_0"), f"phot_table_key {phot_table_key} not found in optical_elements."
+
+    def test_abvegaoffset_keys_have_optical_element_entry(self, abvegaoffset_keys, optical_element):
+        """
+        Confirm that each optical_element corresponds to an abvegaoffset data key in abvegaoffset.yaml
+        """
+        assert optical_element in abvegaoffset_keys, f"optical_element {optical_element} not found in abvegaoffset_keys."
+
+    def test_optical_elements_have_abvegaoffset_key(self, abvegaoffset_key, optical_elements):
+        """
+        Confirm that abvegaoffset data keys in abvegaoffset.yaml correspond to an optical_element
+        """
+        assert abvegaoffset_key in optical_elements, f"abvegaoffset_key {abvegaoffset_key} not found in optical_elements."
+
+    def test_apcorr_keys_have_optical_element_entry(self, apcorr_keys, optical_element):
+        """
+        Confirm that each optical_element corresponds to an apcorr data key in apcorr.yaml
+        """
+        assert optical_element in apcorr_keys, f"optical_element {optical_element} not found in apcorr_keys."
+
+    def test_optical_elements_have_apcorr_key(self, apcorr_key, optical_elements):
+        """
+        Confirm that apcorr data keys in apcorr.yaml correspond to an optical_element
+        """
+        assert apcorr_key in optical_elements, f"apcorr_key {apcorr_key} not found in optical_elements."
 
     def test_p_exptype_entries_have_exposure_type(self, p_exptype_pattern, exposure_type):
         """Confirm that the p_keyword version of exposure type match the enum version."""


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #709

<!-- describe the changes comprising this PR here -->

As noted in the closed issue it makes more sense for these schemas to explicitly define entries for each of the optical elements via a definition rather than using a `patternProperties` argument. This PR is based off #630 to incorporate those changes cleanly into this.

RDM PR: spacetelescope/roman_datamodels#577

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
