### PR TITLE
fix path in test

### DIFF
--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -30,7 +30,7 @@ class TestLastestResources:
         Check that the file name of the schema matches the schema ID WITHOUT the version number suffix.
         """
         # Check that the file name does not contain a version number
-        assert len(str(latest_path).split("/rad/resources/")[-1].split("-")) == 1
+        assert len(str(latest_path).split("/rad/latest/")[-1].split("-")) == 1
 
         # Check that the file name is consistent with the schema ID
         uri = yaml.safe_load(latest_path.read_bytes())["id"]


### PR DESCRIPTION
Closes #714

See issue for description of bug. The test was splitting on "rad/resources" instead of "rad/latest" which this PR fixes.

Confirmed to fix test when run with the rad clone at a path that includes a "-" in the parent path contents.

No changelog or regtests as this is only a unit test change.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
