### PR TITLE
Revert "RAD-231: Make product_type required"

### DIFF
--- a/changes/733.misc.rst
+++ b/changes/733.misc.rst
@@ -1,1 +1,0 @@
-Made the `product_type` keyword required.

--- a/latest/meta/basic.yaml
+++ b/latest/meta/basic.yaml
@@ -37,7 +37,6 @@ required:
     model_type,
     origin,
     prd_version,
-    product_type,
     sdf_software_version,
     telescope,
   ]


### PR DESCRIPTION
Reverts spacetelescope/rad#733

A bug in the regtest environment resolution https://github.com/spacetelescope/RegressionTests/issues/281 combined with some syntax issue with the requirements override meant a few RAD PRs had regtest runs that did not use the associated PR.

This revert is to test if this is the only one we need to revert to get tests working again. I'm also regenerating files for the L4 metadata updates that may fix the errors.

Regtest run (with hopefully this PR): https://github.com/spacetelescope/RegressionTests/actions/runs/18511154628