### PR TITLE
remove private asdf api usage

### DIFF
--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from deepdiff import DeepDiff
 
 _RAD_URLS = (
+    "https://github.com/spacetelescope/rad",
     "https://github.com/spacetelescope/rad.git",
     "git@github.com:spacetelescope/rad.git",
 )

--- a/src/rad/_parser/_super_schema.py
+++ b/src/rad/_parser/_super_schema.py
@@ -3,21 +3,15 @@ from __future__ import annotations
 import copy
 from collections import abc
 from typing import TYPE_CHECKING
+from urllib.parse import urldefrag
 
 import asdf
 import asdf.schema
 import asdf.treeutil
-from astropy.utils import minversion
+from asdf.generic_io import resolve_uri
 
 if TYPE_CHECKING:
     from typing import Any
-
-if not minversion("asdf", "5.0.0"):
-    from functools import partial
-
-    _safe_resolve = partial(asdf.schema._safe_resolve, None)
-else:
-    _safe_resolve = asdf.schema._safe_resolve
 
 
 __all__ = ["super_schema"]
@@ -45,7 +39,7 @@ def _get_schema_from_uri(schema_uri: str) -> dict[str, Any]:
             json_id = schema_uri
 
         if isinstance(node, dict) and "$ref" in node:
-            suburl_base, suburl_fragment = _safe_resolve(json_id, node["$ref"])
+            suburl_base, suburl_fragment = urldefrag(resolve_uri(json_id, node["$ref"]))
 
             if suburl_base == schema_uri or suburl_base == schema.get("id"):
                 # This is a local ref, which we'll resolve in both cases.


### PR DESCRIPTION
Removes private asdf API usage introduced in https://github.com/spacetelescope/rad/pull/721

Replacing `asdf.schema._safe_resolve` with public API `urldefrag(resolve_uri(...))`.

I also added another acceptable remote to the archive.py script which was needed to allow me to test these changes locally.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
