### PR TITLE
Fix issue when file is deleted in archive script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ _version.py
 
 # uv
 uv.lock
+
+# archive script default write directory
+archive_dump/

--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -58,7 +58,7 @@ def _repo_branch(repo: Repo, hexsha: str) -> Generator[None, None, None]:
 
     if file_diffs:
         for file_diff in file_diffs:
-            if file_diff.a_path.startswith("latest/"):
+            if file_diff.a_path.startswith("latest/") or file_diff.a_path.startswith("src/rad/resources/"):
                 changed_latest.append(file_diff.a_path)
 
         # Only want to change the latest files during this context the other changes should be preserved
@@ -71,6 +71,7 @@ def _repo_branch(repo: Repo, hexsha: str) -> Generator[None, None, None]:
 
     # Checkout checkout the latest files from hexshaw in the primary repo.
     repo.git.checkout(hexsha, "--", "latest")
+    repo.git.checkout(hexsha, "--", "src/rad/resources")
 
     # Apply the stashed changes back to the working directory
     if file_diffs:
@@ -128,8 +129,8 @@ def _diff_repo(
         verbose=True,
     )["archive_schemas"]
 
+    print("Generating archive files for the main branch...")
     with _repo_branch(repo, hexsha):
-        print("Generating archive files for the current staged state...")
         main_schemas = dump(
             base_dir, super_schema=False, archive_json=False, archive_txt=False, archive_yaml=False, verbose=True
         )["archive_schemas"]


### PR DESCRIPTION
In PR #789 a latest file AND its symlink were removed, which exposed a bug in the archive comparison script. This is an oversight as for the SOC schemas never result in a file missing form the `src/rad/resources` directory as we are versioning those schemas. However, the SSC schemas are not versioned so when a file/symlink was removed from `src/rad/resources` ASDF fails to fully resolve the old state of RAD.

This PR fixes this by also targeting the changes to `src/rad/resources`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
