### PR TITLE
Replaced MSOS object catalog with Periodic and Fiducial variants

### DIFF
--- a/changes/797.misc.rst
+++ b/changes/797.misc.rst
@@ -1,0 +1,1 @@
+Introduced SSC MSOS periodic and fiducial object catalogs

--- a/latest/SSC/MSOS/keywords/msos_common.yaml
+++ b/latest/SSC/MSOS/keywords/msos_common.yaml
@@ -8,15 +8,6 @@ extName: SSC
 
 type: object
 properties:
-  instrume:
-    title: Instrument
-    description: Instrument used
-    type: string
-    maxLength: 8
-    archive_catalog:
-      datatype: nvarchar(8)
-      destination:
-        [WFIMSOSReferenceFrame.instrument_name, WFIMSOSCatalog.instrument_name]
   # The following fields are NOT required, but they would be nice to have as explicitly specified values to fill in for our cross-mission search. If not relevant or not provided these will just be null values at MAST.
   detector: # SOC Proposed
     title: Detector
@@ -58,4 +49,4 @@ properties:
       destination:
         [WFIMSOSReferenceFrame.optical_element, WFIMSOSCatalog.optical_element]
 
-required: [instrume, detector, aperture, calver, optical_element]
+required: [detector, aperture, calver, optical_element]

--- a/latest/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4.yaml
+++ b/latest/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4-1.0.0
+
+# https://outerspace.stsci.edu/spaces/RSEC/pages/245072239/Level+4+Microlensing+Data+Products#Level4MicrolensingDataProducts-Level4-MicrolensingObjectCatalogDataProduct-Fiducial
+
+title: GBTDS Level 4 Microlensing Object Fiducial Catalog
+archive_meta: Science WFI Level 4 MSOS Object Fiducial Catalog
+type: object
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_basic-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_common-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_observation-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_program-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_settings-1.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/keywords/msos_weekly-1.0.0

--- a/latest/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4.yaml
+++ b/latest/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/wfi_microlensing_object_catalog_level_4-1.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4-1.0.0
 
-# https://outerspace.stsci.edu/display/RSEC/Level+4+Microlensing+Data+Products#Level4MicrolensingDataProducts-Level4-MicrolensingObjectCatalogDataProduct
+# https://outerspace.stsci.edu/spaces/RSEC/pages/245072239/Level+4+Microlensing+Data+Products#Level4MicrolensingDataProducts-Level4-MicrolensingObjectCatalogDataProduct-Periodic
 
-title: GBTDS Level 4 Microlensing Object Catalog
-archive_meta: Science WFI Level 4 MSOS Object Catalog
+title: GBTDS Level 4 Microlensing Object Periodic Catalog
+archive_meta: Science WFI Level 4 MSOS Object Periodic Catalog
 type: object
 allOf:
   - $ref: asdf://stsci.edu/datamodels/roman/schemas/SSC/ssc_basic-1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ asdf_schema_xfail_tests = [
   "src/rad/resources/schemas/SSC/GDPS/wfi_spec_location_table_level_4-1.0.0.yaml",
   "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_event_catalog_level_4-1.0.0.yaml",
   "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_light_curve_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4-1.0.0.yaml",
+  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4-1.0.0.yaml",
   "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_reference_frame_level_3-1.0.0.yaml",
   "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_variability_catalog_level_4-1.0.0.yaml",
 ]

--- a/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_catalog_level_4-1.0.0.yaml
+++ b/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_catalog_level_4-1.0.0.yaml
@@ -1,1 +1,0 @@
-../../../../../../latest/SSC/MSOS/wfi_microlensing_object_catalog_level_4.yaml

--- a/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4-1.0.0.yaml
+++ b/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4-1.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../../../latest/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4.yaml

--- a/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4-1.0.0.yaml
+++ b/src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4-1.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../../../latest/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4.yaml


### PR DESCRIPTION
MSOS object catalogs come in periodic and fiducial variants and may have slightly different metadata in the future.  These already have unique file types in the [SSC transfer interface](https://github.com/spacetelescope/roman-soc-ssc-common/blob/main/schemas/data_availability.json#L48).  This PR creates dedicated top level metadata definitions for each type, along with proposed new SOC archive file type names.

This PR also removes instrume keyword from msos_common.yaml as the instrument keyword is being moved to ssc_basic.yaml in https://github.com/spacetelescope/rad/pull/770.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
