### PR TITLE
RCAL-1311 Add stepsize and order to l3_resample schema

### DIFF
--- a/changes/806.misc.rst
+++ b/changes/806.misc.rst
@@ -1,0 +1,1 @@
+Add stepsize and order to l3_resample schema

--- a/latest/meta/l3_resample.yaml
+++ b/latest/meta/l3_resample.yaml
@@ -19,6 +19,13 @@ properties:
       would only allow pixels with DQ bits equal to 0 in the
       calibrated rate images to be included in the final product.
     type: string
+  order:
+    title: Interpolation order
+    description: >
+      Order of the 2D spline to interpolate the sparse pixel mapping
+      if stepsize>1.  Supported values are: 1 (bilinear) or 3 (bicubic).
+      This parameter is ignored when stepsize <= 1.
+    type: integer
   pixel_scale_ratio:
     title: Pixel Scale Ratio
     description: >
@@ -35,6 +42,18 @@ properties:
     title: Number of Input Images
     description: >
       The number of input images combined with resample into an output product.
+    type: integer
+  stepsize:
+    title: Grid stepsize
+    description: >
+      If ``stepsize>1``, perform the full WCS calculation on a sparser
+      grid and use interpolation to fill in the rest of the pixels.  This
+      option speeds up pixel map computation by reducing the number of WCS
+      calls, though at the cost of reduced pixel map accuracy.  The loss
+      of accuracy is typically negligible if the underlying distortion
+      correction is smooth, but if the distortion is non-smooth,
+      ``stepsize>1`` is not recommended.  Large ``stepsize`` values are
+      automatically reduced to no more than 1/10 of image size.
     type: integer
   members:
     title: Resample Input Filenames

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -33,7 +33,7 @@ class TestLastestResources:
         Check that the file name of the schema matches the schema ID WITHOUT the version number suffix.
         """
         # Check that the file name does not contain a version number
-        assert len(str(latest_path).split("/rad/latest/")[-1].split("-")) == 1
+        assert len(str(latest_path).split("/latest/")[-1].split("-")) == 1
 
         # Check that the file name is consistent with the schema ID
         uri = yaml.safe_load(latest_path.read_bytes())["id"]


### PR DESCRIPTION
WIP [RCAL-1311](https://jira.stsci.edu/browse/RCAL-1311)

This PR adds two new items:
- stepsize
- order

These are new input parameters to the outlier detection and resample steps.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
