### PR TITLE
Add test that `archive_meta` is unique

### DIFF
--- a/changes/810.bugfix.rst
+++ b/changes/810.bugfix.rst
@@ -1,1 +1,0 @@
-Give multiband_segmentation_map a unique ``archive_meta`` value.

--- a/changes/810.bugfix.rst
+++ b/changes/810.bugfix.rst
@@ -1,0 +1,1 @@
+Give multiband_segmentation_map a unique ``archive_meta`` value.

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -38,6 +38,35 @@ class TestLastestResources:
         """
         assert latest_paths
 
+    def test_archive_meta_uniqueness(self, latest_paths):
+        """
+        Check that archve_meta is either:
+            - undefined
+            - None
+            - unique
+
+        across all latest schemas.
+        """
+        archive_metas = {}
+        for path, schema in latest_paths.items():
+            # It's ok for schemas to not contain this
+            if "archive_meta" not in schema:
+                continue
+            archive_meta = schema["archive_meta"].strip()
+
+            # Multiple schemas can contain "None" so don't bother checking those
+            if archive_meta == "None":
+                continue
+
+            # Track the possible duplicates
+            if archive_meta not in archive_metas:
+                archive_metas[archive_meta] = []
+            archive_metas[archive_meta].append(path)
+
+        # Check for duplicates
+        for archive_meta, paths in archive_metas.items():
+            assert len(paths) == 1, f"{paths} contain the same archive_meta: {archive_meta}"
+
     def test_latest_filename(self, latest_path, latest_uri):
         """
         Check that the file name of the schema matches the schema ID WITHOUT the version number suffix.

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -40,23 +40,15 @@ class TestLastestResources:
 
     def test_archive_meta_uniqueness(self, latest_paths):
         """
-        Check that archve_meta is either:
-            - undefined
-            - None
-            - unique
-
-        across all latest schemas.
+        Check that archve_meta is either undefined or unique.
         """
         archive_metas = {}
         for path, schema in latest_paths.items():
             # It's ok for schemas to not contain this
             if "archive_meta" not in schema:
                 continue
-            archive_meta = schema["archive_meta"].strip()
 
-            # Multiple schemas can contain "None" so don't bother checking those
-            if archive_meta == "None":
-                continue
+            archive_meta = schema["archive_meta"].strip()
 
             # Track the possible duplicates
             if archive_meta not in archive_metas:


### PR DESCRIPTION
Closes: #809

Add a test that `archive_meta` is unique across all latest schemas.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
