### PR TITLE
Add reference files, cal_steps, and changed name of flagged_spatial_id

### DIFF
--- a/changes/815.feature.rst
+++ b/changes/815.feature.rst
@@ -1,0 +1,9 @@
+Various small schema updates::
+
+    - Add ``dark_decay`` to ``ref_file`` and ``l2_cal_step``.
+    - Add ``integralnonlinearity`` to ``ref_file``.
+    - Update ``inverse_linearity`` to ``inverselinearity`` in ``ref_file``.
+    - Change ``flagged_spatial_index`` to ``flagged_spatial_id`` in source catalog column
+      definitions and all tables that reference it.
+
+These changes also required schema version bumps throughout RAD to support the new changes.

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.3.0
 
 title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -10,7 +10,7 @@ datamodel_name: ForcedImageSourceCatalogModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -17,7 +17,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/forced_mosaic_source_catalog.yaml
+++ b/latest/forced_mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.4.0
 
 title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -26,7 +26,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.5.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.6.0
 
 title: Source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Source Catalog L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -18,7 +18,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -24,13 +24,13 @@ tags:
     title: Ramp schema
     description: |-
       Ramp schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.7.0
     title: Ramp fit output schema
     description: |-
       Ramp fit output schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.7.0
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
@@ -163,13 +163,13 @@ tags:
     description: |-
       Multiple Accumulation Table Reference File Schema
   # Misc
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.5.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.5.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.6.0
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.5.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.5.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.6.0
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
@@ -193,8 +193,8 @@ tags:
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.3.0
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
@@ -204,8 +204,8 @@ tags:
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
   # SSC data models
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.7.0
     title: MSOS Stack Level 3 Schema
     description: |-
       Level 3 schema for SSC's MSOS stack products

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.7.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.7.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.8.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.8.0
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.
@@ -19,8 +19,8 @@ tags:
     title: Level 1 Detector Guide Star Window Information schema
     description: |-
       Level 1 Detector Guide Star Window Information schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.7.0
     title: Ramp schema
     description: |-
       Ramp schema
@@ -34,8 +34,8 @@ tags:
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.7.0
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -173,13 +173,13 @@ tags:
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.7.0
     title: Mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.2.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.2.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step
@@ -198,8 +198,8 @@ tags:
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.3.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.3.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.4.0
     title: Forced mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
 
 title: Common metadata properties
 
@@ -28,7 +28,7 @@ allOf:
       program:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
       ref_file:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0
       rcs:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/rcs-1.1.0
       velocity_aberration:

--- a/latest/meta/l2_cal_step.yaml
+++ b/latest/meta/l2_cal_step.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.3.0
 
 title: Level 2 Calibration Status
 type: object

--- a/latest/meta/l2_cal_step.yaml
+++ b/latest/meta/l2_cal_step.yaml
@@ -39,6 +39,17 @@ properties:
     archive_catalog:
       datatype: nvarchar(15)
       destination: [ScienceRefData.s_dark]
+  dark_decay:
+    title: Dark Decay Subtraction Step
+    description: |
+      Step in romancal that performs subtracts signal
+      associated with the dark decay systematic, using the dark decay
+      reference file.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dark_decay]
   dq_init:
     title: Data Quality Initialization Step
     description: |
@@ -165,6 +176,7 @@ required:
   [
     assign_wcs,
     dark,
+    dark_decay,
     dq_init,
     flat_field,
     flux,

--- a/latest/meta/l2_catalog_common.yaml
+++ b/latest/meta/l2_catalog_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
 
 title: Common Level 2 Catalog Metadata
 
@@ -26,7 +26,7 @@ allOf:
       program:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
       ref_file:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0
       visit:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
       wcsinfo:

--- a/latest/meta/ref_file.yaml
+++ b/latest/meta/ref_file.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0
 
 title: Reference File Information
 type: object

--- a/latest/meta/ref_file.yaml
+++ b/latest/meta/ref_file.yaml
@@ -71,6 +71,16 @@ properties:
     archive_catalog:
       datatype: nvarchar(120)
       destination: [ScienceRefData.r_dark, GuideWindow.r_dark]
+  darkdecaysignal:
+    title: Dark Decay Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for dark decay signal in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [ScienceRefData.r_darkdecaysignal, GuideWindow.r_darkdecaysignal]
   distortion:
     title: Distortion Reference File Information
     description: |
@@ -119,7 +129,7 @@ properties:
     archive_catalog:
       datatype: nvarchar(120)
       destination: [ScienceRefData.r_gain, GuideWindow.r_gain]
-  inverse_linearity:
+  inverselinearity:
     title: Inverse Linearity Reference File Information
     description: |
       Name of the calibration reference file used in
@@ -129,7 +139,7 @@ properties:
     archive_catalog:
       datatype: nvarchar(120)
       destination:
-        [ScienceRefData.r_inverse_linearity, GuideWindow.r_inverse_linearity]
+        [ScienceRefData.r_inverselinearity, GuideWindow.r_inverselinearity]
   linearity:
     title: Linearity Reference File Information
     description: |
@@ -139,6 +149,19 @@ properties:
     archive_catalog:
       datatype: nvarchar(120)
       destination: [ScienceRefData.r_linearity, GuideWindow.r_linearity]
+  integralnonlinearity:
+    title: Integral Nonlinearity Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for integral nonlinearity in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          ScienceRefData.r_integralnonlinearity,
+          GuideWindow.r_integralnonlinearity,
+        ]
   photom:
     title: Photometry Reference File Information
     description: |
@@ -181,6 +204,7 @@ required:
     apcorr,
     crds,
     dark,
+    darkdecaysignal,
     distortion,
     epsf,
     mask,
@@ -188,7 +212,8 @@ required:
     gain,
     readnoise,
     linearity,
-    inverse_linearity,
+    inverselinearity,
+    integralnonlinearity,
     photom,
     area,
     saturation,

--- a/latest/mosaic_source_catalog.yaml
+++ b/latest/mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.7.0
 
 title: Source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -27,7 +27,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.7.0
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
       - type: object
         properties:
           image_list:

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
 
 title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -25,7 +25,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.1.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
       - type: object
         properties:
           cal_step:

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.7.0
 
 title: Ramp Schema
 
@@ -15,7 +15,7 @@ properties:
       - type: object
         properties:
           cal_step:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.3.0
         required: [cal_step]
   data:
     title: Science Data Including Border Reference Pixels (DN, electrons)

--- a/latest/ramp_fit_output.yaml
+++ b/latest/ramp_fit_output.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.7.0
 
 title: Ramp Fit Output Schema
 
@@ -10,7 +10,7 @@ datamodel_name: RampFitOutputModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
   slope:
     title: Slope for Specific Segment (electrons / s)
     description: |

--- a/latest/segmentation_map.yaml
+++ b/latest/segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.5.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.6.0
 
 title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Segmentation Map L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
   data:
     title: Segmentation map
     description: |

--- a/latest/tables/forced_catalog_table.yaml
+++ b/latest/tables/forced_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
 
 title: Forced source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_index$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^forced_dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^forced_warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^forced_fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^forced_is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^forced_roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^forced_sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/forced_catalog_table.yaml
+++ b/latest/tables/forced_catalog_table.yaml
@@ -16,10 +16,10 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
-                      pattern: ^flagged_spatial_index$
+                      pattern: ^flagged_spatial_id$
       - not:
           items:
             not:

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -16,10 +16,10 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
-                      pattern: ^flagged_spatial_index$
+                      pattern: ^flagged_spatial_id$
       - not:
           items:
             not:

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
 
 title: Multiband source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_index$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
 
 title: Prompt source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_index$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -16,10 +16,10 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_index"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
-                      pattern: ^flagged_spatial_index$
+                      pattern: ^flagged_spatial_id$
       - not:
           items:
             not:

--- a/latest/tables/source_catalog_columns.yaml
+++ b/latest/tables/source_catalog_columns.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0
 
 title: Source catalog column definitions
 

--- a/latest/tables/source_catalog_columns.yaml
+++ b/latest/tables/source_catalog_columns.yaml
@@ -6,7 +6,7 @@ id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.
 title: Source catalog column definitions
 
 definitions:
-  flagged_spatial_index:
+  flagged_spatial_id:
     description: Bit flag encoding the overlap flag, projection, skycell and pixel coordinates of the source
     unit: none
     properties:

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.7.0
 
 title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -20,7 +20,7 @@ properties:
           cal_logs:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-1.1.0
           cal_step:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.3.0
           outlier_detection:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/outlier_detection-1.1.0
           photometry:

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
       - type: object
         properties:
           background:

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.7.0
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: Science WFI Level 1
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
   data:
     title: Science Data (DN)
     description: |

--- a/src/rad/resources/manifests/datamodels-1.7.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.7.0.yaml
@@ -1,1 +1,211 @@
-../../../../latest/manifests/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.7.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.7.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.5.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.5.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.6.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp_fit_output-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.6.0
+    title: Ramp fit output schema
+    description: |-
+      Ramp fit output schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.6.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.6.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.6.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.4.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.3.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.3.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.6.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/detectorstatus-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/detectorstatus-1.1.0
+    title: Detector Status reference schema
+    description: |-
+      Reference file that is a summary for the current status of each WFI detector to support prompt processing.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/darkdecaysignal-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/darkdecaysignal-1.1.0
+    title: Dark Decay Signal Reference File Schema
+    description: |-
+      Dark decay reference file contains the residual signal properties for each WFI detector
+      that can be removed by an exponentially decreasing signal of DN with respect to time.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.4.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.5.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.4.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.3.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/integralnonlinearity-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/integralnonlinearity-1.1.0
+    title: Integral nonlinearity correction reference schema
+    description: |-
+      Integral nonlinearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.3.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.4.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.3.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.3.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.4.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.4.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.3.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.3.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.3.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.4.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.2.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.3.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.5.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.5.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.6.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.2.0
+    title: Multiband source catalog
+    description: |-
+      Photometry and astrometry computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.6.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0
+    title: Multiband segmentation map
+    description: |-
+      Segmentation map computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.2.0
+    title: Forced image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.3.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.3.0
+    title: Forced mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.6.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/manifests/datamodels-1.8.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/manifests/datamodels.yaml

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.2.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.2.0.yaml
@@ -1,1 +1,24 @@
-../../../../latest/forced_image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.2.0
+
+title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ForcedImageSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_image_source_catalog.yaml

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-1.3.0.yaml
@@ -1,1 +1,33 @@
-../../../../latest/forced_mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.3.0
+
+title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: ForcedMosaicSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-1.2.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-1.1.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/image_source_catalog-1.5.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.5.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.5.0
+
+title: Source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ImageSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/image_source_catalog-1.6.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.6.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/image_source_catalog.yaml

--- a/src/rad/resources/schemas/meta/common-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/common-1.2.0.yaml
@@ -1,1 +1,55 @@
-../../../../../latest/meta/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+
+title: Common metadata properties
+
+allOf:
+  # Meta Variables
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-1.1.0
+  - type: object
+    properties:
+      # Meta Objects
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-1.1.0
+      ephemeris:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-1.1.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
+      guide_star:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.2.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+      rcs:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/rcs-1.1.0
+      velocity_aberration:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-1.1.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-1.1.0
+    required:
+      [
+        coordinates,
+        ephemeris,
+        exposure,
+        guide_star,
+        instrument,
+        observation,
+        pointing,
+        program,
+        ref_file,
+        rcs,
+        velocity_aberration,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/common-1.3.0.yaml
+++ b/src/rad/resources/schemas/meta/common-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/common.yaml

--- a/src/rad/resources/schemas/meta/l2_cal_step-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_cal_step-1.2.0.yaml
@@ -1,1 +1,182 @@
-../../../../../latest/meta/l2_cal_step.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+
+title: Level 2 Calibration Status
+type: object
+properties:
+  assign_wcs:
+    title: Assign World Coordinate System (WCS) Step
+    description: |
+      Step in romancal that assigns a World Coordinate
+      System (WCS) object to a science image.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_assign_wcs]
+  flat_field:
+    title: Flat Field Correction Step
+    description: |
+      Step in romancal in which a science image is
+      flat-fielded, whereby each detector pixel is calibrated to give
+      the same signal for the same illumination based on the pixel
+      response.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flat_field]
+  dark:
+    title: Dark Current Subtraction Step
+    description: |
+      Step in romancal that performs a correction for the
+      dark current by subtracting the dark reference data from the
+      science data.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dark]
+  dq_init:
+    title: Data Quality Initialization Step
+    description: |
+      Step in romancal that initializes the data quality
+      array and masks known bad pixels.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_dq_init]
+  flux:
+    title: Flux Scale Application Step
+    description: |
+      Step in ROMANCAL which applies the scaling factors determined in the Photom calibrations step.
+      The data are converted from DN/s to MJy/sr.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_flux]
+  linearity:
+    title: Classical Linearity Correction Step
+    description: |
+      Step in romancal that linearizes the ramp data to
+      correct for deviations from a linear response.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_linearity]
+  photom:
+    title: Populate Photometric Keywords Step
+    description: |
+      Step in romancal that populates photometric
+      calibration information in the metadata of the science file.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_photom]
+  source_catalog:
+    title: Source Catalog Step
+    description: |
+      Step in romancal that detects point sources in an
+      image for use in astrometric alignment.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_source_catalog]
+  ramp_fit:
+    title: Ramp Fitting Step
+    description: |
+      Step in romancal that fits a slope to each pixel to
+      compute the count rate.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_ramp_fit]
+  refpix:
+    title: Reference Pixel Correction Step
+    description: |
+      Step in romancal that corrects science pixels for
+      additional signal from the readout electronics (e.g., 1/f noise)
+      using the reference pixels.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_refpix]
+  saturation:
+    title: Saturation Identification Step
+    description: |
+      Step in romancal that sets data quality flags for
+      pixels at or above the saturation threshold.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_saturation]
+  outlier_detection:
+    title: Outlier Detection Step
+    description: |
+      Step in ROMANCAL which detects and flags outliers in a science image.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_outlier_detection]
+  tweakreg:
+    title: Tweakreg step
+    description: |
+      Step in romancal that compares the positions of point
+      sources in the image with coordinates from an astrometric
+      catalog and, if necessary, corrects the World Coordinate System
+      (WCS) alignment.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_tweakreg]
+  skymatch:
+    title: Sky Matching for Combining Overlapping Images Step
+    description: |
+      Step in ROMANCAL that computes sky background values of each input image
+      and derives scalings to equalize overlapping regions.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_skymatch]
+  wfi18_transient:
+    title: WFI18 Transient Anomaly Correction Step
+    description: |
+      Step in romancal that fits and removes a transient anomaly in
+      the first read of a WFI18 exposure.
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/cal_step_flag-1.2.0
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination: [ScienceRefData.s_wfi18_transient]
+required:
+  [
+    assign_wcs,
+    dark,
+    dq_init,
+    flat_field,
+    flux,
+    linearity,
+    outlier_detection,
+    photom,
+    source_catalog,
+    ramp_fit,
+    refpix,
+    saturation,
+    skymatch,
+    tweakreg,
+    wfi18_transient,
+  ]
+additionalProperties: true

--- a/src/rad/resources/schemas/meta/l2_cal_step-1.3.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_cal_step-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l2_cal_step.yaml

--- a/src/rad/resources/schemas/meta/l2_catalog_common-1.1.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-1.1.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/meta/l2_catalog_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+
+title: Common Level 2 Catalog Metadata
+
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-1.1.0
+  - type: object
+    properties:
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-1.1.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
+      image:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/catalog_image-1.1.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
+      photometry:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-1.1.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-1.1.0
+    required:
+      [
+        coordinates,
+        exposure,
+        instrument,
+        observation,
+        photometry,
+        pointing,
+        program,
+        ref_file,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/l2_catalog_common-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l2_catalog_common.yaml

--- a/src/rad/resources/schemas/meta/ref_file-1.1.0.yaml
+++ b/src/rad/resources/schemas/meta/ref_file-1.1.0.yaml
@@ -1,1 +1,196 @@
-../../../../../latest/meta/ref_file.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0
+
+title: Reference File Information
+type: object
+properties:
+  crds:
+    title: Calibration Reference Data System (CRDS) Information
+    description: |
+      Calibration Reference Data System Parameters
+    type: object
+    properties:
+      version:
+        title: CRDS Software Version
+        description: |
+          Version of the Calibration Reference Data
+          System (CRDS) software package used to match calibration
+          reference files to science observations.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        maxLength: 120
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_version, GuideWindow.crds_version]
+      context:
+        title: CRDS Context
+        description: |
+          Name of the Calibration Reference Data System
+          (CRDS) context (.pmap) file used to match calibration
+          reference files to science observations.
+        type: string
+        sdf:
+          special_processing: VALUE_REQUIRED
+          source:
+            origin: TBD
+        maxLength: 120
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination: [WFIExposure.crds_context, GuideWindow.crds_context]
+    required: [version, context]
+  apcorr:
+    title: Aperture Correction Reference File Schema
+    description: |
+      Name of the calibration reference file used to apply
+      the aperture correction to the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_apcorr, GuideWindow.r_apcorr]
+  area:
+    title: Pixel Area Reference File Information
+    description: |
+      Name of the calibration reference file containing the
+      pixel-to-pixel estimates of the area of each detector pixel on
+      the sky.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_area, GuideWindow.r_area]
+  dark:
+    title: Dark Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for dark current signal in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_dark, GuideWindow.r_dark]
+  distortion:
+    title: Distortion Reference File Information
+    description: |
+      Name of the calibration reference file used to include
+      the geometric distortion model in the world coordinate system
+      (WCS) of the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_distortion, GuideWindow.r_distortion]
+  epsf:
+    title: ePSF Reference File Information
+    description: |
+      Name of the calibration reference file used to apply
+      the ePSF model to the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_epsf, GuideWindow.r_epsf]
+  mask:
+    title: Bad Pixel Mask Reference File Information
+    description: |
+      Name of the calibration reference file used to mark
+      bad pixels in the data quality array of the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_mask, GuideWindow.r_mask]
+  flat:
+    title: Flat Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for element-dependent, spatially-variable sensitivity in the
+      science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_flat, GuideWindow.r_flat]
+  gain:
+    title: Gain Reference Rile Information
+    description: |
+      Name of the calibration reference file used to convert
+      between data numbers (DN) and photo-electrons in the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_gain, GuideWindow.r_gain]
+  inverse_linearity:
+    title: Inverse Linearity Reference File Information
+    description: |
+      Name of the calibration reference file used in
+      simulations of Level 1 data products to imprint the effect of
+      classical non-linearity in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [ScienceRefData.r_inverse_linearity, GuideWindow.r_inverse_linearity]
+  linearity:
+    title: Linearity Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for classical linearity in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_linearity, GuideWindow.r_linearity]
+  photom:
+    title: Photometry Reference File Information
+    description: |
+      Name of the calibration reference file containing
+      photometric zeropoints and related information populated into
+      the science product metadata.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_photom, GuideWindow.r_photom]
+  readnoise:
+    title: Read Noise Reference File Information
+    description: |
+      Name of the calibration reference file that estimates
+      the pixel-to-pixel read noise in the science data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_readnoise, GuideWindow.r_readnoise]
+  refpix:
+    title: Reference Pixel Reference File Information
+    description: |
+      Name of the calibration reference file used to correct
+      for 1/f noise using the reference pixels.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_refpix, GuideWindow.r_refpix]
+  saturation:
+    title: Saturation Reference File Information
+    description: |
+      Information about the saturation reference file used with the science
+      data.
+    type: string
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination: [ScienceRefData.r_saturation, GuideWindow.r_saturation]
+required:
+  [
+    apcorr,
+    crds,
+    dark,
+    distortion,
+    epsf,
+    mask,
+    flat,
+    gain,
+    readnoise,
+    linearity,
+    inverse_linearity,
+    photom,
+    area,
+    saturation,
+    refpix,
+  ]

--- a/src/rad/resources/schemas/meta/ref_file-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/ref_file-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/ref_file.yaml

--- a/src/rad/resources/schemas/mosaic_source_catalog-1.6.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-1.6.0.yaml
@@ -1,1 +1,34 @@
-../../../../latest/mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.6.0
+
+title: Source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: MosaicSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-1.2.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-1.1.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/mosaic_source_catalog-1.7.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/msos_stack-1.6.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.6.0.yaml
@@ -1,1 +1,62 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.6.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - type: object
+        properties:
+          image_list:
+            type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  psf:
+    title: Point Spread Function
+    description: |
+      PSF array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage, psf]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage, psf]

--- a/src/rad/resources/schemas/msos_stack-1.7.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/multiband_source_catalog-1.2.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.2.0.yaml
@@ -1,1 +1,32 @@
-../../../../latest/multiband_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.2.0
+
+title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Multiband Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
+        required: [image_metas]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.1.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_source_catalog.yaml

--- a/src/rad/resources/schemas/ramp-1.6.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.6.0.yaml
@@ -1,1 +1,196 @@
-../../../../latest/ramp.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.6.0
+
+title: Ramp Schema
+
+datamodel_name: RampModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - type: object
+        properties:
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+        required: [cal_step]
+  data:
+    title: Science Data Including Border Reference Pixels (DN, electrons)
+    description: |
+      Science Data Including Border Reference Pixels in units of DN or
+      electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
+  pixeldq:
+    title: Two Dimensional Data Quality Flags Array for Each Pixel
+    description: |
+      Two dimensional data quality flags array applying to all resultants in a
+      given pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+  groupdq:
+    title: Three-dimensional Data Quality Array For Each Resultant in Each Pixel
+    description: |
+      Three-dimensional data quality array indicating quality of each individual
+      resultant for each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+  err:
+    title: Error Array Containing the Square Root of the Exposure-level Combined Variance (DN, electrons)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+  amp33:
+    title: Amp 33 Reference Pixel Data (DN)
+    description: |
+      Amplifier 33 Reference Pixel Data in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_left:
+    title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Left of the Detector, from the instrument's
+      perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_right:
+    title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Right of the Detector, from the
+      instrument's perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Top of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_bottom:
+    title: Border Reference Pixels on the Bottom of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Bottom of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  dq_border_ref_pix_left:
+    title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Left Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Data Quality Flag for Border Reference Pixels, on the Right Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Right Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Data Quality Flag for Border Reference Pixels, on Top.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Data Quality Flag for Border Reference Pixels, on Bottom.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    err,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+    reset_read,
+    reset_amp33,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    err,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/ramp-1.7.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp.yaml

--- a/src/rad/resources/schemas/ramp_fit_output-1.6.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.6.0.yaml
@@ -1,1 +1,130 @@
-../../../../latest/ramp_fit_output.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp_fit_output-1.6.0
+
+title: Ramp Fit Output Schema
+
+datamodel_name: RampFitOutputModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+  slope:
+    title: Slope for Specific Segment (electrons / s)
+    description: |
+      Slope of a specific segment for a ramp with uneven resultants, in units of
+      electrons per second. A segment is a set of contiguous resultants where
+      none of the resultants are saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  sigslope:
+    title: Uncertainty on Slope for Specific Segment (electrons / s)
+    description: |
+      Uncertainty on slope for specific segment for a ramp with uneven
+      resultants in units of electrons per second. A segment is a set of
+      contiguous resultants where none of the resultants are saturated or cosmic
+      ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron / s"
+  yint:
+    title: Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Y-intercept derived for a specific segment (electrons). A segment is a set
+      of contiguous resultants where none of the resultants are saturated or
+      cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  sigyint:
+    title: Uncertainty on Y-Intercept Derived for a Specific Segment (electrons)
+    description: |
+      Uncertainty on Y-intercept derived for a specific segment (electrons). A
+      segment is a set of contiguous resultants where none of the resultants are
+      saturated or cosmic ray-affected.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  pedestal:
+    title: Pedestal Array (electrons)
+    description: |
+      Signal at zero exposure time for each pixel in electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  weights:
+    title: Weights for Segment Specific Fit
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  crmag:
+    title: Approximate Cosmic Ray Magnitudes (AB magnitude)
+    description: |
+      The magnitude of each segment that was flagged as having a cosmic ray hit.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron"
+  var_poisson:
+    title: Poisson Variance Associated with a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Poisson variance associated with a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+  var_rnoise:
+    title: Read Noise Variance Associated for a Segment Specific Slope (electrons^2 / sec^2)
+    description: |
+      Read noise-associated variance for a segment-specific slope, in units of
+      electrons^2 / sec^2.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    exact_datatype: true
+    unit: "electron2 / s2"
+required:
+  [
+    meta,
+    slope,
+    sigslope,
+    yint,
+    sigyint,
+    pedestal,
+    weights,
+    crmag,
+    var_poisson,
+    var_rnoise,
+  ]
+propertyOrder:
+  [
+    meta,
+    slope,
+    sigslope,
+    yint,
+    sigyint,
+    pedestal,
+    weights,
+    crmag,
+    var_poisson,
+    var_rnoise,
+  ]
+flowStyle: block

--- a/src/rad/resources/schemas/ramp_fit_output-1.7.0.yaml
+++ b/src/rad/resources/schemas/ramp_fit_output-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp_fit_output.yaml

--- a/src/rad/resources/schemas/segmentation_map-1.5.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.5.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.5.0
+
+title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: SegmentationMapModel
+
+archive_meta: Science WFI Level 4 Segmentation Map L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.1.0
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/segmentation_map-1.6.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.6.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/segmentation_map.yaml

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.1.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.1.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/forced_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.1.0
+
+title: Forced source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_index$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^forced_dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^forced_warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/forced_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.1.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.1.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/multiband_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.1.0
+
+title: Multiband source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_index$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/multiband_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.1.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.1.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/prompt_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.1.0
+
+title: Prompt source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/flagged_spatial_index"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_index$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/prompt_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.1.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.1.0.yaml
@@ -1,1 +1,664 @@
-../../../../../latest/tables/source_catalog_columns.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.1.0
+
+title: Source catalog column definitions
+
+definitions:
+  flagged_spatial_index:
+    description: Bit flag encoding the overlap flag, projection, skycell and pixel coordinates of the source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int64]
+  bbox_xmax:
+    description: Column index of the right edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_xmin:
+    description: Column index of the left edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymax:
+    description: Row index of the top edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymin:
+    description: Row index of the bottom edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  image_flags:
+    description: Image quality bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  label:
+    description: Label of the source segment in the segmentation image
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_area:
+    description: Area of the source segment
+    unit: arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec:
+    description: Best estimate of the declination (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid:
+    description: Declination of the source centroid (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_err:
+    description: Uncertainty in dec_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_centroid_win:
+    description: Declination (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_win_err:
+    description: Uncertainty in dec_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_psf_~band~:
+    description: Declination (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_psf_~band~_err:
+    description: Uncertainty in dec_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_gof_~band~:
+    description: PSF goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra:
+    description: Best estimate of the right ascension (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid:
+    description: Right ascension (ICRS) of the source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_err:
+    description: Uncertainty in ra_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_centroid_win:
+    description: Right ascension (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_win_err:
+    description: Uncertainty in ra_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_psf_~band~:
+    description: Right ascension (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_psf_~band~_err:
+    description: Uncertainty in ra_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid:
+    description: Column coordinate of the source centroid from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_err:
+    description: Uncertainty x_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win:
+    description: Column coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win_err:
+    description: Uncertainty on x_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~:
+    description: Column coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~_err:
+    description: Uncertainty in x_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid:
+    description: Row coordinate of the source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_err:
+    description: Uncertainty on y_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win:
+    description: Row coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win_err:
+    description: Uncertainty on y_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~:
+    description: Row coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~_err:
+    description: Uncertainty on y_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux:
+    description: Local background estimated within a circular annulus
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux_err:
+    description: Uncertainty in aper_bkg_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux:
+    description: Local background estimate for PSF-matched aperture photometry
+    unit: nJy/arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux_err:
+    description: Uncertainty in aper_bkg_flux_err
+    unit: nJy/arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux:
+    description: Flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux_err:
+    description: Uncertainty in flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux:
+    description: PSF-matched flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux_err:
+    description: Uncertainty in PSF-matched flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag:
+    description: AB magnitude within the elliptical Kron aperture
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag_err:
+    description: Uncertainty in kron_abmag
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux:
+    description: Flux within the elliptical Kron aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux_err:
+    description: Uncertainty in kron_<band>_flux_err
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_abmag:
+    description: PSF-matched flux within the elliptical Kron aperture
+    unit: abmag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_abmag_err:
+    description: Uncertainty in kron_<band>m<band>_abmag_err
+    unit: abmag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux:
+    description: Total PSF flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux_err:
+    description: Uncertainty in psf_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_flags_~band~:
+    description: PSF fitting bit flags (0 = good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_~band~_flux:
+    description: Isophotal flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~_flux_err:
+    description: Uncertainty in segment_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux:
+    description: Isophotal flux after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux_err:
+    description: Isophotal flux error after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  warning_flags:
+    description: Warning bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  cxx:
+    description: Coefficient for the x**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cxy:
+    description: Coefficient for the x*y term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cyy:
+    description: Coefficient for the y**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ellipticity:
+    description: Source ellipticity as 1 - (semimajor / semiminor)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  fluxfrac_radius_50_~band~:
+    description: Radius of a circle centered on the source centroid that encloses 50% of the Kron flux
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  is_extended_~band~:
+    description: Flag indicating that the source appears to be more extended than a point source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [bool8]
+  fwhm:
+    description: Circularized full width at half maximum (FWHM) calculated from the semimajor and semiminor axes as 2*sqrt(ln(2) * (semimajor**2 + semiminor**2))
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_radius:
+    description: First-moment radius measured in the detection image.
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_pix:
+    description: Angle measured counter-clockwise from the positive X axis to the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_sky:
+    description: Position angle from North of the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  roundness1_~band~:
+    description: Photutils DAOFinder roundness1 statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semimajor:
+    description: Length of the source semimajor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semiminor:
+    description: Length of the source semiminor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  sharpness_~band~:
+    description: Photutils DAOFinder sharpness statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_distance:
+    description: Distance to the nearest neighbor in this skycell
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_label:
+    description: Segment label of the nearest neighbor in this skycell
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  photoz:
+    description: Recommended point estimate of photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_gof:
+    description: Photo-z goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high68:
+    description: 68% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high90:
+    description: 90% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high99:
+    description: 99% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low68:
+    description: 68% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low90:
+    description: 90% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low99:
+    description: 99% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_sed:
+    description: Best-fit spectral-energy distribution for this photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/source_catalog_columns.yaml

--- a/src/rad/resources/schemas/wfi_image-1.6.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.6.0.yaml
@@ -1,1 +1,265 @@
-../../../../latest/wfi_image.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.6.0
+
+title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: ImageModel
+archive_meta: Science WFI Level 2
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+      - type: object
+        properties:
+          background:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/sky_background-1.1.0
+          cal_logs:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.2.0
+          outlier_detection:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/outlier_detection-1.1.0
+          photometry:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-1.1.0
+          source_catalog:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/source_catalog-1.1.0
+          statistics:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/statistics-1.1.0
+          wcs:
+            title: WCS object
+            anyOf:
+              - tag: tag:stsci.edu:gwcs/wcs-*
+              - type: "null"
+
+        required: [photometry, wcs]
+  data:
+    title: Science Data (DN/s) or (MJy/sr)
+    description: |
+      Calibrated science rate image in units of data numbers
+      per second (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  dq:
+    title: Data Quality
+    description: |
+      Bitwise sum of data quality flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Error (DN / s) or (MJy / sr)
+    description: |
+      Total error array in units of data numbers per second
+      (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  var_poisson:
+    title: Poisson Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to Poisson
+      noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_rnoise:
+    title: Read Noise Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to detector
+      read noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_flat:
+    title: Flat Field Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to the flat
+      field in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  chisq:
+    title: Chi-squared of Ramp Fit
+    description: |
+      Chi-squared statistic of the ramp fit (unitless).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+  dumo:
+    title: Difference Uniform Minus Optimal (DN / s) or (MJy / sr)
+    description: |
+      Ramp fit with uniform weights minus ramp fit with optimal weights
+      in units of data numbers per second (DN/s) or megaJanskys per
+      steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DN).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_left:
+    title: Left-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the left-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, :4] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_right:
+    title: Right-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the right-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, 4092:] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border reference pixels on the top of the detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the bottom-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :4, :] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  dq_border_ref_pix_left:
+    title: Left-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the left-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, :4] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Right-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the right-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, 4092:] in a
+      zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Border Reference Pixel Data Quality on the Top of the Detector (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the top-edge of the detector in
+      the science frame orientation. In the L1 uncal file data array,
+      these are pixels (z, y, x) = [:, 4092:, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the bottom-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :4, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+propertyOrder:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    var_rnoise,
+    var_flat,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/wfi_image-1.7.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_image.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-1.6.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.6.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.6.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: Science WFI Level 1
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.2.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+  reference_read:
+    title: Reference Read (DN)
+    description: |
+      Reference read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reference read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reference_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reference Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reference read. This array is only present if a reference
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reference_read, reference_amp33]
+flowStyle: block
+required: [meta, data, amp33]

--- a/src/rad/resources/schemas/wfi_science_raw-1.7.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,7 +19,7 @@ METADATA_FORCE_XFAILS = (
 
 VARCHAR_XFAILS = (
     # <resource uri>
-    "asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.1.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0",
 )
 
 REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.2.0",)


### PR DESCRIPTION
This PR adds a missing cal_step entry for dark_decay and adds missing ref_file entries for the dark_decay and integralnonlinearity reference files.  It also changes the name of the inverse_nonlinearity reference file to inversenonlinearity so that stpipe / crds can automatically fill it out.  Finally, it renames flagged_spatial_index to flagged_spatial_id in the source_catalog_columns table in order to accommodate a CSB name change request.

I think the greatest impact on the archive folks will be the new dark_decay and integralnonlinearity columns, as well as the inversenonlinearity name change.  flagged_spatial_id is present in the catalog fields and likely has no archive implications.

I've not updated any roman_datamodels components; I don't think these are needed here.

## Tasks

- [X] Update or add relevant `rad` tests.
- [X] Update relevant docstrings and / or `docs/` page.
- [X] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [X] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [X] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
