### PR TITLE
[SCSB-223] align dependencies with explicit imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,14 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Astronomy",
   "Programming Language :: Python :: 3",
 ]
-dependencies = ["asdf >=4.1.0", "asdf-astropy >=0.8.0"]
+dependencies = [
+  "asdf>=4.1.0",
+  "asdf-astropy>=0.8.0",
+  "asdf-standard>=1.1.0",
+  "deepdiff>=8.1",
+  "pyyaml>=6.0",
+  "semantic-version>=2.10.0",
+]
 license-files = ["LICENSE"]
 dynamic = ["version"]
 
@@ -18,15 +25,14 @@ content-type = "text/markdown"
 
 [project.optional-dependencies]
 test = [
-  "pytest>=7.0.0",
-  "pytest-doctestplus>=1.2.1",
-  "pytest-asdf-plugin>=0.1.0",
   "crds>=12.0.4",
   "GitPython>=3.1.44",
-  "semantic-version>=2.10.0",
-  "textual>=3.1",
-  "deepdiff>=8.1",
+  "pytest-asdf-plugin>=0.1.0",
+  "pytest-doctestplus>=1.2.1",
+  "pytest>=7.0.0",
+
 ]
+script = ["GitPython>=3.1.44", "astropy>=6.0.0", "textual>=3.1"]
 docs = [
   "sphinx",
   "sphinx-asdf>=0.1.3",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [SCSB-223](https://jira.stsci.edu/browse/SCSB-223)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

used [`valimdep`](https://github.com/zacharyburnett/valimdep) to find unimported dependencies and undepended imports:
- added `pyyaml` to main deps
- ~removed `asdf-astropy` from main deps~
- added `asdf-standard` to main deps
- moved `deepdiff` from test extra to main deps
- moved `semantic-version` from test extra to main deps
- moved `textual` from test extra to new `script` extra
- added `astropy` to new `script` extra
- sorted imports alphabetically

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
