### PR TITLE
RCAL-1327: Add description and units to catalog.

### DIFF
--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -178,8 +178,8 @@ tags:
     title: Mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.3.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
 
 title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -25,7 +25,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -437,102 +437,129 @@ properties:
                     name:
                       pattern: ^nn_label$
       # Optional photoz columns - validated if present but not required
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz"
-                - properties:
-                    name:
-                      pattern: ^photoz$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_gof$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_gof"
-                - properties:
-                    name:
-                      pattern: ^photoz_gof$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_high68$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high68"
-                - properties:
-                    name:
-                      pattern: ^photoz_high68$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_high90$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high90"
-                - properties:
-                    name:
-                      pattern: ^photoz_high90$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_high99$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high99"
-                - properties:
-                    name:
-                      pattern: ^photoz_high99$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_low68$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low68"
-                - properties:
-                    name:
-                      pattern: ^photoz_low68$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_low90$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low90"
-                - properties:
-                    name:
-                      pattern: ^photoz_low90$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_low99$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low99"
-                - properties:
-                    name:
-                      pattern: ^photoz_low99$
-      - items:
-          anyOf:
-            - not:
-                properties:
-                  name:
-                    pattern: ^photoz_sed$
-            - allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_sed"
-                - properties:
-                    name:
-                      pattern: ^photoz_sed$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz"
+                    - properties:
+                        name:
+                          pattern: ^photoz$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_gof$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_gof"
+                    - properties:
+                        name:
+                          pattern: ^photoz_gof$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_high68$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high68"
+                    - properties:
+                        name:
+                          pattern: ^photoz_high68$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_high90$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high90"
+                    - properties:
+                        name:
+                          pattern: ^photoz_high90$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_high99$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high99"
+                    - properties:
+                        name:
+                          pattern: ^photoz_high99$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_low68$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low68"
+                    - properties:
+                        name:
+                          pattern: ^photoz_low68$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_low90$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low90"
+                    - properties:
+                        name:
+                          pattern: ^photoz_low90$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_low99$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low99"
+                    - properties:
+                        name:
+                          pattern: ^photoz_low99$
+      - not:
+          items:
+            not:
+              anyOf:
+                - not:
+                    required: [name]
+                    properties:
+                      name:
+                        pattern: ^photoz_sed$
+                - allOf:
+                    - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_sed"
+                    - properties:
+                        name:
+                          pattern: ^photoz_sed$

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
 
 title: Multiband source catalog table schema
 
@@ -436,3 +436,103 @@ properties:
                 - properties:
                     name:
                       pattern: ^nn_label$
+      # Optional photoz columns - validated if present but not required
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz"
+                - properties:
+                    name:
+                      pattern: ^photoz$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_gof$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_gof"
+                - properties:
+                    name:
+                      pattern: ^photoz_gof$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_high68$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high68"
+                - properties:
+                    name:
+                      pattern: ^photoz_high68$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_high90$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high90"
+                - properties:
+                    name:
+                      pattern: ^photoz_high90$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_high99$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_high99"
+                - properties:
+                    name:
+                      pattern: ^photoz_high99$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_low68$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low68"
+                - properties:
+                    name:
+                      pattern: ^photoz_low68$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_low90$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low90"
+                - properties:
+                    name:
+                      pattern: ^photoz_low90$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_low99$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_low99"
+                - properties:
+                    name:
+                      pattern: ^photoz_low99$
+      - items:
+          anyOf:
+            - not:
+                properties:
+                  name:
+                    pattern: ^photoz_sed$
+            - allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/photoz_sed"
+                - properties:
+                    name:
+                      pattern: ^photoz_sed$

--- a/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
@@ -1,1 +1,32 @@
-../../../../latest/multiband_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+
+title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Multiband Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
+        required: [image_metas]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_source_catalog.yaml

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/multiband_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+
+title: Multiband source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/multiband_catalog_table.yaml


### PR DESCRIPTION
Resolves [RCAL-1327](https://jira.stsci.edu/browse/RCAL-1327)

<!-- describe the changes comprising this PR here -->

This PR adds optional photometric redshift (roman-photoz) columns to the multiband source catalog table. The column definitions already exist in source_catalog_columns-1.2.0; this PR wires them into the multiband catalog table as optional fields — they are validated against the schema if present, but not required.

## Changes

- `multiband_catalog_table` 1.2.0 → 1.3.0: added 9 optional photoz columns using an `items: anyOf` pattern that validates them if present but does not require them;

- `multiband_source_catalog` 1.3.0 → 1.4.0: updated to reference `multiband_catalog_table-1.3.0`;

- `datamodels-1.9.0` manifest: updated to reference `multiband_source_catalog-1.4.0`;

- frozen the previous `multiband_catalog_table-1.2.0` and `multiband_source_catalog-1.3.0` as static files per the versioning policy.

## Note
This PR depends on [RDM PR #633](https://github.com/spacetelescope/roman_datamodels/pull/633), which need to go first. Once that PR is in, the failing unit tests reported here will pass because RDM will handle optional columns.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
