### PR TITLE
Fix units and description of local background aperture columns

### DIFF
--- a/changes/834.bugfix.rst
+++ b/changes/834.bugfix.rst
@@ -1,2 +1,1 @@
 Fix units and description of local background aperture columns.
-

--- a/changes/834.bugfix.rst
+++ b/changes/834.bugfix.rst
@@ -1,0 +1,2 @@
+Fix units and description of local background aperture columns.
+

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
 
 title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -17,7 +17,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/forced_mosaic_source_catalog.yaml
+++ b/latest/forced_mosaic_source_catalog.yaml
@@ -26,7 +26,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
 
 title: Source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -18,7 +18,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -163,8 +163,8 @@ tags:
     description: |-
       Multiple Accumulation Table Reference File Schema
   # Misc
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
@@ -178,8 +178,8 @@ tags:
     title: Mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.3.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step
@@ -193,8 +193,8 @@ tags:
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.3.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.3.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step

--- a/latest/mosaic_source_catalog.yaml
+++ b/latest/mosaic_source_catalog.yaml
@@ -27,7 +27,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
 
 title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -25,7 +25,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/tables/forced_catalog_table.yaml
+++ b/latest/tables/forced_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
 
 title: Forced source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^forced_dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^forced_warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^forced_fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^forced_is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^forced_roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^forced_sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
 
 title: Multiband source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
 
 title: Prompt source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/source_catalog_columns.yaml
+++ b/latest/tables/source_catalog_columns.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0
 
 title: Source catalog column definitions
 
@@ -295,8 +295,8 @@ definitions:
           datatype:
             enum: [float32]
   aper_bkg_~band~_flux_err:
-    description: Uncertainty in aper_bkg_flux
-    unit: nJy
+    description: Uncertainty in local background estimated in a circular annulus
+    unit: nJy arcsec-2
     properties:
       data:
         properties:
@@ -304,15 +304,15 @@ definitions:
             enum: [float32]
   aper_bkg_~band~m~band~_flux:
     description: Local background estimate for PSF-matched aperture photometry
-    unit: nJy/arcsec^2
+    unit: nJy arcsec-2
     properties:
       data:
         properties:
           datatype:
             enum: [float32]
   aper_bkg_~band~m~band~_flux_err:
-    description: Uncertainty in aper_bkg_flux_err
-    unit: nJy/arcsec^2
+    description: Uncertainty in local background estimate for PSF-matched aperture photometry
+    unit: nJy arcsec-2
     properties:
       data:
         properties:

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.3.0.yaml
@@ -1,1 +1,24 @@
-../../../../latest/forced_image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.3.0
+
+title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ForcedImageSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_image_source_catalog.yaml

--- a/src/rad/resources/schemas/image_source_catalog-1.6.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.6.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.6.0
+
+title: Source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ImageSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/image_source_catalog-1.7.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/image_source_catalog.yaml

--- a/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.3.0.yaml
@@ -1,1 +1,32 @@
-../../../../latest/multiband_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.3.0
+
+title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Multiband Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
+        required: [image_metas]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_source_catalog.yaml

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.2.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/forced_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.2.0
+
+title: Forced source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^forced_dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^forced_warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/forced_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.2.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/multiband_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.2.0
+
+title: Multiband source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/multiband_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.2.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/prompt_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.2.0
+
+title: Prompt source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/prompt_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.2.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.2.0.yaml
@@ -1,1 +1,664 @@
-../../../../../latest/tables/source_catalog_columns.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.2.0
+
+title: Source catalog column definitions
+
+definitions:
+  flagged_spatial_id:
+    description: Bit flag encoding the overlap flag, projection, skycell and pixel coordinates of the source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int64]
+  bbox_xmax:
+    description: Column index of the right edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_xmin:
+    description: Column index of the left edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymax:
+    description: Row index of the top edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymin:
+    description: Row index of the bottom edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  image_flags:
+    description: Image quality bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  label:
+    description: Label of the source segment in the segmentation image
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_area:
+    description: Area of the source segment
+    unit: arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec:
+    description: Best estimate of the declination (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid:
+    description: Declination of the source centroid (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_err:
+    description: Uncertainty in dec_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_centroid_win:
+    description: Declination (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_win_err:
+    description: Uncertainty in dec_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_psf_~band~:
+    description: Declination (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_psf_~band~_err:
+    description: Uncertainty in dec_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_gof_~band~:
+    description: PSF goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra:
+    description: Best estimate of the right ascension (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid:
+    description: Right ascension (ICRS) of the source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_err:
+    description: Uncertainty in ra_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_centroid_win:
+    description: Right ascension (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_win_err:
+    description: Uncertainty in ra_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_psf_~band~:
+    description: Right ascension (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_psf_~band~_err:
+    description: Uncertainty in ra_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid:
+    description: Column coordinate of the source centroid from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_err:
+    description: Uncertainty x_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win:
+    description: Column coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win_err:
+    description: Uncertainty on x_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~:
+    description: Column coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~_err:
+    description: Uncertainty in x_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid:
+    description: Row coordinate of the source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_err:
+    description: Uncertainty on y_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win:
+    description: Row coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win_err:
+    description: Uncertainty on y_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~:
+    description: Row coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~_err:
+    description: Uncertainty on y_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux:
+    description: Local background estimated within a circular annulus
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux_err:
+    description: Uncertainty in aper_bkg_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux:
+    description: Local background estimate for PSF-matched aperture photometry
+    unit: nJy/arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux_err:
+    description: Uncertainty in aper_bkg_flux_err
+    unit: nJy/arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux:
+    description: Flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux_err:
+    description: Uncertainty in flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux:
+    description: PSF-matched flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux_err:
+    description: Uncertainty in PSF-matched flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag:
+    description: AB magnitude within the elliptical Kron aperture
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag_err:
+    description: Uncertainty in kron_abmag
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux:
+    description: Flux within the elliptical Kron aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux_err:
+    description: Uncertainty in kron_<band>_flux_err
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_abmag:
+    description: PSF-matched flux within the elliptical Kron aperture
+    unit: abmag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_abmag_err:
+    description: Uncertainty in kron_<band>m<band>_abmag_err
+    unit: abmag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux:
+    description: Total PSF flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux_err:
+    description: Uncertainty in psf_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_flags_~band~:
+    description: PSF fitting bit flags (0 = good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_~band~_flux:
+    description: Isophotal flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~_flux_err:
+    description: Uncertainty in segment_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux:
+    description: Isophotal flux after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux_err:
+    description: Isophotal flux error after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  warning_flags:
+    description: Warning bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  cxx:
+    description: Coefficient for the x**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cxy:
+    description: Coefficient for the x*y term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cyy:
+    description: Coefficient for the y**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ellipticity:
+    description: Source ellipticity as 1 - (semimajor / semiminor)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  fluxfrac_radius_50_~band~:
+    description: Radius of a circle centered on the source centroid that encloses 50% of the Kron flux
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  is_extended_~band~:
+    description: Flag indicating that the source appears to be more extended than a point source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [bool8]
+  fwhm:
+    description: Circularized full width at half maximum (FWHM) calculated from the semimajor and semiminor axes as 2*sqrt(ln(2) * (semimajor**2 + semiminor**2))
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_radius:
+    description: First-moment radius measured in the detection image.
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_pix:
+    description: Angle measured counter-clockwise from the positive X axis to the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_sky:
+    description: Position angle from North of the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  roundness1_~band~:
+    description: Photutils DAOFinder roundness1 statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semimajor:
+    description: Length of the source semimajor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semiminor:
+    description: Length of the source semiminor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  sharpness_~band~:
+    description: Photutils DAOFinder sharpness statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_distance:
+    description: Distance to the nearest neighbor in this skycell
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_label:
+    description: Segment label of the nearest neighbor in this skycell
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  photoz:
+    description: Recommended point estimate of photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_gof:
+    description: Photo-z goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high68:
+    description: 68% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high90:
+    description: 90% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high99:
+    description: 99% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low68:
+    description: 68% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low90:
+    description: 90% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low99:
+    description: 99% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_sed:
+    description: Best-fit spectral-energy distribution for this photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/source_catalog_columns.yaml


### PR DESCRIPTION
The units for `aper_bkg_~band~_flux_err` should be `nJy arcsec-2` instead of `nJy`.

aper_bkg_~band~_flux_err | nJy | Uncertainty in aper_bkg_flux
-- | -- | --

Also, the description of `aper_bkg_~band~m~band~_flux_err` is wrong (it's not an uncertainty in an uncertainty):

aper_bkg_~band~m~band~_flux_err | nJy/arcsec^2 | Uncertainty in aper_bkg_flux_err
-- | -- | --

I also normalized the units to be `nJy arcsec-2` everywhere.  In some places they were also listed as `nJy/arcsec^2`.






<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-nnnn](https://jira.stsci.edu/browse/RAD-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
