### PR TITLE
RCAL_1351 Add quaternion and H/V guide star meta

### DIFF
--- a/changes/837.feature.rst
+++ b/changes/837.feature.rst
@@ -1,0 +1,1 @@
+Add quaternion and H/V guide star meta

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -10,7 +10,7 @@ datamodel_name: ForcedImageSourceCatalogModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Source Catalog L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -39,8 +39,8 @@ tags:
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.4.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.4.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.5.0
     title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
     description: |-
       Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
@@ -163,8 +163,8 @@ tags:
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.6.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.6.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.7.0
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -19,18 +19,18 @@ tags:
     title: Level 1 Detector Guide Star Window Information schema
     description: |-
       Level 1 Detector Guide Star Window Information schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.7.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.7.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.8.0
     title: Ramp schema
     description: |-
       Ramp schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.7.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.7.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.8.0
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.7.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.7.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.8.0
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information
@@ -199,8 +199,8 @@ tags:
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
   # SSC data models
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.7.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.7.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.8.0
     title: MSOS Stack Level 3 Schema
     description: |-
       Level 3 schema for SSC's MSOS stack products

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -24,7 +24,7 @@ allOf:
       observation:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
       pointing:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.2.0
       program:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
       ref_file:

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.4.0
 
 title: Common metadata properties
 
@@ -18,7 +18,7 @@ allOf:
       exposure:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
       guide_star:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.2.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.3.0
       instrument:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
       observation:

--- a/latest/meta/guidestar.yaml
+++ b/latest/meta/guidestar.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.3.0
 
 title: Guide Star and Guide Window Information
 
@@ -122,6 +122,16 @@ properties:
       major axis moves toward the +X axis. When no guidestar was
       observed with this detector, a default value will be used.
     type: number
+  hv_position:
+    title: Commanded guide star position in FGS H/V pixel frame (pixels)
+    description: |
+      A 2-tuple giving the (H, V) commanded position of the guide star
+      in the H/V pixel frame (in pixels). Found in the PDB dms_guid_star view.
+    type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      type: number
 required:
   [
     guide_window_id,

--- a/latest/meta/l2_catalog_common.yaml
+++ b/latest/meta/l2_catalog_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
 
 title: Common Level 2 Catalog Metadata
 
@@ -22,7 +22,7 @@ allOf:
       photometry:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-1.1.0
       pointing:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.2.0
       program:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
       ref_file:

--- a/latest/meta/pointing.yaml
+++ b/latest/meta/pointing.yaml
@@ -52,11 +52,11 @@ properties:
       The quaternion of the observatory orientation at the mid-point of the
       exposure. Determined by querying the engineering database for the
       mnemonics SCF_AC_SDR_QBJ_[1-4].
-      type: array
-      minItems: 4
-      maxItems: 4
-      items:
-        type: number
+    type: array
+    minItems: 4
+    maxItems: 4
+    items:
+      type: number
   ra_v1:
     title: Right Ascension of the Telescope V1 Axis (deg)
     description: |

--- a/latest/meta/pointing.yaml
+++ b/latest/meta/pointing.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.2.0
 
 title: Spacecraft Pointing Information
 type: object
@@ -46,6 +46,17 @@ properties:
           WFIExposure.pointing_engineering_source,
           GuideWindow.pointing_engineering_source,
         ]
+  quaternion:
+    title: Observatory orientation quaternion
+    description: |
+      The quaternion of the observatory orientation at the mid-point of the
+      exposure. Determined by querying the engineering database for the
+      mnemonics SCF_AC_SDR_QBJ_[1-4].
+      type: array
+      minItems: 4
+      maxItems: 4
+      items:
+        type: number
   ra_v1:
     title: Right Ascension of the Telescope V1 Axis (deg)
     description: |

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.7.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.8.0
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.4.0
       - type: object
         properties:
           image_list:

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.7.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.8.0
 
 title: Ramp Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.4.0
       - type: object
         properties:
           cal_step:

--- a/latest/segmentation_map.yaml
+++ b/latest/segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.6.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.7.0
 
 title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Segmentation Map L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
   data:
     title: Segmentation map
     description: |

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.7.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.8.0
 
 title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.4.0
       - type: object
         properties:
           background:

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.7.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.8.0
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: Science WFI Level 1
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.4.0
   data:
     title: Science Data (DN)
     description: |

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.4.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.5.0
 
 title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -25,7 +25,7 @@ properties:
           observation:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
           pointing:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.2.0
           program:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
           velocity_aberration:

--- a/src/rad/resources/schemas/meta/common-1.3.0.yaml
+++ b/src/rad/resources/schemas/meta/common-1.3.0.yaml
@@ -1,1 +1,55 @@
-../../../../../latest/meta/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+
+title: Common metadata properties
+
+allOf:
+  # Meta Variables
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-1.1.0
+  - type: object
+    properties:
+      # Meta Objects
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-1.1.0
+      ephemeris:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-1.1.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
+      guide_star:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.2.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0
+      rcs:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/rcs-1.1.0
+      velocity_aberration:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-1.1.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-1.1.0
+    required:
+      [
+        coordinates,
+        ephemeris,
+        exposure,
+        guide_star,
+        instrument,
+        observation,
+        pointing,
+        program,
+        ref_file,
+        rcs,
+        velocity_aberration,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/common-1.4.0.yaml
+++ b/src/rad/resources/schemas/meta/common-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/common.yaml

--- a/src/rad/resources/schemas/meta/guidestar-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/guidestar-1.2.0.yaml
@@ -1,1 +1,135 @@
-../../../../../latest/meta/guidestar.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-1.2.0
+
+title: Guide Star and Guide Window Information
+
+type: object
+properties:
+  guide_window_id:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guide_window_id-1.1.0
+  guide_mode:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/guidewindow_modes-1.1.0
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(18)
+      destination: [WFIExposure.guide_mode, GuideWindow.guide_mode]
+  window_xstart:
+    title: Guide Window X Start Position (pixels)
+    description: |
+      Minimum X position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_xstart]
+  window_ystart:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Minimum Y position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_ystart]
+  window_xstop:
+    title: Guide Window X Stop Position (pixels)
+    description: |
+      Maximum X position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_xstop]
+  window_ystop:
+    title: Guide Window Y Start Position (pixels)
+    description: |
+      Maximum Y position in pixels in the science coordinate
+      frame of all tracking guide windows in this exposure.
+    type: integer
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Science Data Formatting
+    archive_catalog:
+      datatype: int
+      destination: [WFIExposure.window_ystop]
+  guide_star_id:
+    title: Guide Star Identifier
+    description: |
+      Identification of the guide star from the Guide Star Catalog (GSC).
+      This is based on planned information from the Roman Planning and
+      Scheduling Subsystem.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_guide_star.star_id
+    maxLength: 20
+    archive_catalog:
+      datatype: nvarchar(20)
+      destination: [WFIExposure.guide_star_id, GuideWindow.guide_star_id]
+  epoch:
+    title: Guide Star Coordinates Epoch
+    description: |
+      Epoch of the celestial coordinates of the guide star
+      from the Guide Star Catalog (GSC).
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.epoch, GuideWindow.epoch]
+  jitter_major:
+    title: Major Axis Jitter (milliarcseconds)
+    description: Estimate of the guidestar jitter kernel width (in
+      milliarcseconds) along the major axis of the jitter kernel.
+      When no guidestar was observed with this detector, a default
+      value will be used.
+    type: number
+  jitter_minor:
+    title: Minor Axis Jitter (milliarcseconds)
+    description: Estimate of the guidestar jitter kernel width (in
+      milliarcseconds) along the minor axis of the jitter kernel.
+      When no guidestar was observed with this detector, a default
+      value will be used.
+    type: number
+  jitter_position_angle:
+    title: Jitter Position Angle (deg)
+    description: Position angle (in degrees) of the jitter kernel in the
+      science coordinate system. The position angle is the angle of the
+      major axis relative to the +Y axis, with PA increasing as the
+      major axis moves toward the +X axis. When no guidestar was
+      observed with this detector, a default value will be used.
+    type: number
+required:
+  [
+    guide_window_id,
+    guide_mode,
+    window_xstart,
+    window_ystart,
+    window_xstop,
+    window_ystop,
+    guide_star_id,
+    epoch,
+  ]

--- a/src/rad/resources/schemas/meta/guidestar-1.3.0.yaml
+++ b/src/rad/resources/schemas/meta/guidestar-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/guidestar.yaml

--- a/src/rad/resources/schemas/meta/l2_catalog_common-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-1.2.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/meta/l2_catalog_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+
+title: Common Level 2 Catalog Metadata
+
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-1.1.0
+  - type: object
+    properties:
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-1.1.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
+      image:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/catalog_image-1.1.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
+      photometry:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-1.1.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-1.2.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-1.1.0
+    required:
+      [
+        coordinates,
+        exposure,
+        instrument,
+        observation,
+        photometry,
+        pointing,
+        program,
+        ref_file,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/l2_catalog_common-1.3.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-1.3.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l2_catalog_common.yaml

--- a/src/rad/resources/schemas/meta/pointing-1.1.0.yaml
+++ b/src/rad/resources/schemas/meta/pointing-1.1.0.yaml
@@ -1,1 +1,156 @@
-../../../../../latest/meta/pointing.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+
+title: Spacecraft Pointing Information
+type: object
+properties:
+  pa_aperture:
+    title: Aperture Position Angle (deg)
+    description: |
+      Position angle in degrees of the aperture ideal Y axis
+      relative to the V3 axis of the spacecraft. This information
+      comes from the Science Instrument Aperture File (SIAF) in the
+      Science Operations Center (SOC) Project Reference Database
+      (PRD).
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.pa_aperture, GuideWindow.pa_aperture]
+  pointing_engineering_source:
+    title: Pointing Engineering Source
+    description: |
+      The source type of the pointing information in the
+      metadata may be set to either "PLANNED" or "CALCULATED". If the
+      value is "PLANNED", then pointing mnemonics were not found in
+      the engineering database, and the pointing data were taken from
+      the observation planning information. If the value is
+      "CALCULATED", then the pointing data were determined using the
+      information in the engineering database.
+    type: string
+    enum: [CALCULATED, PLANNED]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination:
+        [
+          WFIExposure.pointing_engineering_source,
+          GuideWindow.pointing_engineering_source,
+        ]
+  ra_v1:
+    title: Right Ascension of the Telescope V1 Axis (deg)
+    description: |
+      The right ascension coordinate of the V1 axis in units
+      of degrees. This may be considered the right ascension
+      coordinate of the telescope boresight. The telescope V
+      coordinate system is defined with its origin at the vertex of
+      the primary mirror. The V1 axis is orthogonal to the primary
+      mirror, parallel to the telescope boresight, and increasing
+      positively through the telescope aperture. See
+      Roman-STScI-000143 "Description of the Roman SIAF and Coordinate
+      Frames" for more information.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.ra_v1, GuideWindow.ra_v1]
+  dec_v1:
+    title: Declination of the Telescope V1 Axis (deg)
+    description: |
+      The declination coordinate of the V1 axis in units of
+      degrees. This may be considered the declination coordinate of
+      the telescope boresight. The telescope V coordinate system is
+      defined with its origin at the vertex of the primary mirror. The
+      +V1 axis is orthogonal to the primary mirror, parallel to the
+      telescope boresight, and increasing positively through the
+      telescope aperture. See Roman-STScI-000143 "Description of the
+      Roman SIAF and Coordinate Frames" for more information.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.dec_v1, GuideWindow.dec_v1]
+  pa_v3:
+    title: Position Angle of the Telescope V3 Axis (deg)
+    description: |
+      The position angle of the V3 axis (in units of
+      degrees) is defined as the projection of the V3 axis on the sky
+      measured from North to East. The telescope V coordinate system
+      is defined with its origin at the vertex of the primary mirror.
+      The +V3 axis is defined to be orthogonal to the sunshield. See
+      Roman-STScI-000143 "Description of the Roman SIAF and Coordinate
+      Frames" for more information.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.pa_v3, GuideWindow.pa_v3]
+  target_aperture:
+    title: Aperture Name Used for Pointing
+    description: |
+      Name of the aperture used to align the instrument to a
+      position on the sky.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 100
+    archive_catalog:
+      datatype: nvarchar(100)
+      destination: [WFIExposure.target_aperture, GuideWindow.target_aperture]
+  target_ra:
+    title: Right Ascension of the Target Aperture (deg)
+    description: |
+      Right ascension in units of degrees at the location of
+      the target aperture.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.target_ra, GuideWindow.target_ra]
+  target_dec:
+    title: Declination of the Target Aperture
+    description: |
+      Declination in units of degrees at the location of the
+      target aperture.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.target_dec, GuideWindow.target_dec]
+required:
+  [
+    pa_aperture,
+    pointing_engineering_source,
+    ra_v1,
+    dec_v1,
+    pa_v3,
+    target_aperture,
+    target_ra,
+    target_dec,
+  ]

--- a/src/rad/resources/schemas/meta/pointing-1.2.0.yaml
+++ b/src/rad/resources/schemas/meta/pointing-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/pointing.yaml

--- a/src/rad/resources/schemas/msos_stack-1.7.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.7.0.yaml
@@ -1,1 +1,62 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.7.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - type: object
+        properties:
+          image_list:
+            type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  psf:
+    title: Point Spread Function
+    description: |
+      PSF array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage, psf]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage, psf]

--- a/src/rad/resources/schemas/msos_stack-1.8.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/ramp-1.7.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.7.0.yaml
@@ -1,1 +1,187 @@
-../../../../latest/ramp.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.7.0
+
+title: Ramp Schema
+
+datamodel_name: RampModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - type: object
+        properties:
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.3.0
+        required: [cal_step]
+  data:
+    title: Science Data Including Border Reference Pixels (DN, electrons)
+    description: |
+      Science Data Including Border Reference Pixels in units of DN or
+      electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
+  pixeldq:
+    title: Two Dimensional Data Quality Flags Array for Each Pixel
+    description: |
+      Two dimensional data quality flags array applying to all resultants in a
+      given pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+  groupdq:
+    title: Three-dimensional Data Quality Array For Each Resultant in Each Pixel
+    description: |
+      Three-dimensional data quality array indicating quality of each individual
+      resultant for each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+  amp33:
+    title: Amp 33 Reference Pixel Data (DN)
+    description: |
+      Amplifier 33 Reference Pixel Data in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_left:
+    title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Left of the Detector, from the instrument's
+      perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_right:
+    title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Right of the Detector, from the
+      instrument's perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Top of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_bottom:
+    title: Border Reference Pixels on the Bottom of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Bottom of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  dq_border_ref_pix_left:
+    title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Left Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Data Quality Flag for Border Reference Pixels, on the Right Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Right Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Data Quality Flag for Border Reference Pixels, on Top.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Data Quality Flag for Border Reference Pixels, on Bottom.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+    reset_read,
+    reset_amp33,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/ramp-1.8.0.yaml
+++ b/src/rad/resources/schemas/ramp-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp.yaml

--- a/src/rad/resources/schemas/segmentation_map-1.6.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.6.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.6.0
+
+title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: SegmentationMapModel
+
+archive_meta: Science WFI Level 4 Segmentation Map L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.2.0
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/segmentation_map-1.7.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-1.7.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/segmentation_map.yaml

--- a/src/rad/resources/schemas/wfi_image-1.7.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.7.0.yaml
@@ -1,1 +1,265 @@
-../../../../latest/wfi_image.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.7.0
+
+title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: ImageModel
+archive_meta: Science WFI Level 2
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+      - type: object
+        properties:
+          background:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/sky_background-1.1.0
+          cal_logs:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-1.3.0
+          outlier_detection:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/outlier_detection-1.1.0
+          photometry:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-1.1.0
+          source_catalog:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/source_catalog-1.1.0
+          statistics:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/statistics-1.1.0
+          wcs:
+            title: WCS object
+            anyOf:
+              - tag: tag:stsci.edu:gwcs/wcs-*
+              - type: "null"
+
+        required: [photometry, wcs]
+  data:
+    title: Science Data (DN/s) or (MJy/sr)
+    description: |
+      Calibrated science rate image in units of data numbers
+      per second (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  dq:
+    title: Data Quality
+    description: |
+      Bitwise sum of data quality flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Error (DN / s) or (MJy / sr)
+    description: |
+      Total error array in units of data numbers per second
+      (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  var_poisson:
+    title: Poisson Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to Poisson
+      noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_rnoise:
+    title: Read Noise Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to detector
+      read noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_flat:
+    title: Flat Field Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to the flat
+      field in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  chisq:
+    title: Chi-squared of Ramp Fit
+    description: |
+      Chi-squared statistic of the ramp fit (unitless).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+  dumo:
+    title: Difference Uniform Minus Optimal (DN / s) or (MJy / sr)
+    description: |
+      Ramp fit with uniform weights minus ramp fit with optimal weights
+      in units of data numbers per second (DN/s) or megaJanskys per
+      steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DN).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_left:
+    title: Left-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the left-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, :4] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_right:
+    title: Right-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the right-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, 4092:] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border reference pixels on the top of the detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the bottom-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :4, :] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  dq_border_ref_pix_left:
+    title: Left-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the left-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, :4] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Right-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the right-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, 4092:] in a
+      zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Border Reference Pixel Data Quality on the Top of the Detector (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the top-edge of the detector in
+      the science frame orientation. In the L1 uncal file data array,
+      these are pixels (z, y, x) = [:, 4092:, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the bottom-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :4, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+propertyOrder:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    var_rnoise,
+    var_flat,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/wfi_image-1.8.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_image.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-1.7.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.7.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.7.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: Science WFI Level 1
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-1.3.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+  reference_read:
+    title: Reference Read (DN)
+    description: |
+      Reference read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reference read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reference_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reference Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reference read. This array is only present if a reference
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reference_read, reference_amp33]
+flowStyle: block
+required: [meta, data, amp33]

--- a/src/rad/resources/schemas/wfi_science_raw-1.8.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/src/rad/resources/schemas/wfi_wcs-1.4.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.4.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_wcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.4.0
+
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-1.1.0
+      - type: object
+        properties:
+          coordinates:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-1.1.0
+          ephemeris:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-1.1.0
+          exposure:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-1.1.0
+          instrument:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-1.1.0
+          observation:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-1.1.0
+          pointing:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-1.1.0
+          program:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-1.1.0
+          velocity_aberration:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-1.1.0
+          visit:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-1.1.0
+          wcsinfo:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-1.1.0
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
+        required:
+          [
+            coordinates,
+            ephemeris,
+            exposure,
+            instrument,
+            observation,
+            pointing,
+            program,
+            velocity_aberration,
+            visit,
+            wcsinfo,
+          ]
+  wcs_l2:
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta]

--- a/src/rad/resources/schemas/wfi_wcs-1.5.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-1.5.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_wcs.yaml


### PR DESCRIPTION
Resolves [RAD-259](https://jira.stsci.edu/browse/RAD-259)
Triggered by [RCAL-1351](https://jira.stsci.edu/browse/RCAL-1351)

This PR adds the following meta:
- pointing.quaternion: The observatory orientation quaternion
- guide_star.hv_position: The H/V position of the guide star

These values are populated when `set_telescope_pointing` is executed during L1 construction and are meant primarily as documentation during the orientation-determination process.

Need to be required? Developer opinion is no but up to maintainers.
Need to be archived? Developer opinion is no but up to maintainers.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] Update or add relevant `rad` tests.
- [x] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [x] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
