### PR TITLE
Automatically generate the doc pages for schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/generated/
+docs/_schemas/
 
 # PyBuilder
 .pybuilder/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,7 @@ New Features
       - Add ``integralnonlinearity`` to ``ref_file``.
       - Update ``inverse_linearity`` to ``inverselinearity`` in ``ref_file``.
       - Change ``flagged_spatial_index`` to ``flagged_spatial_id`` in source
-  catalog column
-        definitions and all tables that reference it.
+        catalog column definitions and all tables that reference it.
 
   These changes also required schema version bumps throughout RAD to support
   the new changes. (`#815 <https://github.com/spacetelescope/rad/issues/815>`_)
@@ -168,7 +167,7 @@ New Features
   <https://github.com/spacetelescope/rad/issues/721>`_)
 - Update L4 (catalog) metadata to better match input/image file metadata.
   (`#724 <https://github.com/spacetelescope/rad/issues/724>`_)
-- Added "null" as a possible value for `acq_centroid_quality` in the L1
+- Added "null" as a possible value for ``acq_centroid_quality`` in the L1
   Detector Guide Window schema. (`#737
   <https://github.com/spacetelescope/rad/issues/737>`_)
 
@@ -192,12 +191,12 @@ Misc
   <https://github.com/spacetelescope/rad/issues/718>`_)
 - SSC ROMAN-3912 Update G2DP keywords in ``/latest/SSC`` directory (`#722
   <https://github.com/spacetelescope/rad/issues/722>`_)
-- Made the `product_type` keyword required. (`#733
+- Made the ``product_type`` keyword required. (`#733
   <https://github.com/spacetelescope/rad/issues/733>`_)
-- Removed the enum list for `pedigree` in `ref_common`. (`#734
+- Removed the enum list for ``pedigree`` in ``ref_common``. (`#734
   <https://github.com/spacetelescope/rad/issues/734>`_)
-- Renamed the reset read variables to reference read in `wfi_science_raw` and
-  removed them from `wfi_image`. (`#735
+- Renamed the reset read variables to reference read in ``wfi_science_raw`` and
+  removed them from ``wfi_image``. (`#735
   <https://github.com/spacetelescope/rad/issues/735>`_)
 
 
@@ -259,17 +258,19 @@ New Features
   RAD resources.
   Features include:
   - Listing the latest versions of all the RAD resources.
-    - includes indications of which resources are "frozen" (not changeable
-  without
-      a new version) at the time of script execution.
+
+    - Includes indications of which resources are "frozen"
+      (not changeable without a new version) at the time of script execution.
+
   - Creating (and integrating) a new RAD resource.
     - Includes bumping the manifest version if necessary
   - Bumping existing RAD resource versions.
     - Includes solving the cascade of version bumps that maybe required.
   - Editing existing RAD resources.
+
     - Includes bumping the resource (and the cascade of other resources) if the
-      edits necessitate a version bump. (`#593
-  <https://github.com/spacetelescope/rad/issues/593>`_)
+      edits necessitate a version bump. (`#593 <https://github.com/spacetelescope/rad/issues/593>`_)
+
 - Refactor the ``cal_step`` schemas to use a common schema for the step flags.
   (`#598 <https://github.com/spacetelescope/rad/issues/598>`_)
 - Move ``wfi_mosaic.cal_logs`` to ``wfi_mosaic.meta.cal_logs`` for consistency
@@ -427,7 +428,7 @@ New Features
 Misc
 ----
 
-- Changed the db type of `vparity`. (`#508
+- Changed the db type of ``vparity``. (`#508
   <https://github.com/spacetelescope/rad/issues/508>`_)
 - Remove upper pin for asdf. (`#510
   <https://github.com/spacetelescope/rad/issues/510>`_)
@@ -504,7 +505,7 @@ Misc
   <https://github.com/spacetelescope/rad/issues/506>`_)
 - Updated the ePSF schema. (`#507
   <https://github.com/spacetelescope/rad/issues/507>`_)
-- pin `asdf<4.0` (`#509 <https://github.com/spacetelescope/rad/issues/509>`_)
+- pin ``asdf<4.0`` (`#509 <https://github.com/spacetelescope/rad/issues/509>`_)
 
 
 Deprecations and Removals

--- a/changes/839.feature.rst
+++ b/changes/839.feature.rst
@@ -1,0 +1,1 @@
+Update the sphinx docs so they generate their own schema documentation.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -40,6 +40,7 @@ clean:
 	-rm -rf $(BUILDDIR)
 	-rm -rf api
 	-rm -rf generated
+	-rm -rf _schemas
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/ccsp.rst
+++ b/docs/ccsp.rst
@@ -4,7 +4,7 @@ CCSP Schemas
 ============
 
 "Community Contributed Science Product" (CCSP) schemas are located in the
-`resources/schemas/CCSP` directory of this package.
+``resources/schemas/CCSP`` directory of this package.
 
 .. _ccsp-creating:
 

--- a/docs/ccsp.rst
+++ b/docs/ccsp.rst
@@ -32,10 +32,7 @@ products. As a result, CCSP teams should entirely ignore the  :ref:`external-met
 
 Instead CCSP schemas must contain a reference to either:
 
-.. asdf-autoschemas::
-
-   CCSP/ccsp_minimal-1.0.0
-   CCSP/ccsp_custom_product-1.0.0
+.. include:: _schemas/CCSP.rst
 
 Which schema to use will depend on the details of the product, as described
 below. In both cases, these schemas will require the addition of a new

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 # Ensure documentation examples are deterministically random.
 import numpy
+import yaml
 from importlib_metadata import distribution
 
 try:
@@ -144,6 +145,95 @@ sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname("__file__")), "s
 extensions += ["sphinx_asdf"]  # noqa: F405
 
 
+LATEST = Path("../latest")
+SCHEMAS = Path("./_schemas")
+
+SCHEMAS.mkdir(exist_ok=True)
+
+schemas = {}
+archive_schemas = {}
+# We only work with the latest schemas
+for file_path in LATEST.glob("**/*.yaml"):
+    path = file_path.relative_to(LATEST)
+
+    # Currently we do not document the SSC schemas
+    if path.parts[0] == "SSC":
+        continue
+
+    # No need to document the rad_schema
+    if path.stem == "rad_schema":
+        continue
+
+    # This is used to find the version number of the schema
+    #    We need to do this because of the way sphinx-asdf
+    #    generates links between schemas, this requires us
+    #    to have the version number included in the page
+    #    url, which is easiest to accomplish by pointing
+    #    spinx-asdf at src/rad/references instead of latest
+    schema_dict = yaml.safe_load(file_path.read_bytes())
+    version = schema_dict["id"].split("-")[-1]
+    entry = f"{path.stem}-{version}"
+
+    # The archive_meta keyword distinguishes the level of the
+    #    schemas going into the archive which makes it an easy
+    #    way to separate all the different data model types
+    filename = None
+    if "archive_meta" in schema_dict:
+        meta = "_".join(schema_dict["archive_meta"].split(" ")[:4])
+        filename = f"{meta}.rst"
+
+    # Now we generate the prefix for the asdf-autoschemas argument
+    prefix = str(path.parent)
+    if prefix == ".":
+        prefix = ""
+
+    # If we don't have a filename lets build it from the prefix
+    if filename is None:
+        # empty prefix means top-level data model that is not
+        #     archived. We dump these in the remaining file
+        if prefix == "":
+            filename = "datamodels.rst"
+        else:
+            # Otherwise turn the prefix into something nice for a file name
+            filename = f"{prefix.replace('/', '_')}.rst"
+
+    # Now if we aren't a manifest in `src/rad/resources` we need
+    #    to point in the schemas directory
+    if prefix != "manifests":
+        prefix = f"schemas/{prefix}"
+
+    # Create a key that will store this schema
+    key = (prefix, filename)
+
+    # Add a empty list if the key is not found
+    if key not in schemas:
+        schemas[key] = []
+
+    # Add the key to the list in the schemas
+    schemas[key].append(entry)
+
+for (prefix, filename), schema_list in schemas.items():
+    # First line is the directive followed by the prefix
+    #    argument on the next line followed by and empty
+    #    line to create the sphinx directive.
+    lines = [".. asdf-autoschemas::"]
+    lines.append(f"   :standard_prefix: {prefix}")
+    lines.append("")
+
+    # Make the list alphabetical
+    schema_list.sort()
+    for schema in schema_list:
+        # Standard indent of RST is supposed to be three spaces
+        lines.append(f"   {schema}")
+
+    # Add blank line at the end to close the directive properly
+    lines.append("")
+
+    # Write the doc file.
+    with (SCHEMAS / filename).open(mode="w") as file:
+        file.write("\n".join(lines))
+
+
 def setup(app):
     app.add_css_file("custom.css")
 
@@ -151,6 +241,8 @@ def setup(app):
 # -- sphinx_asdf configuration ---------------------------------------------
 
 # Top-level directory containing ASDF schemas (relative to current directory)
+# NOTE: This has to be this and not latest because of how sphinx-asdf will generate
+# links between schemas.
 asdf_schema_path = "../src/rad/resources"
 # This is the prefix common to all schema IDs in this repository
 asdf_schema_standard_prefix = "schemas"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,92 +146,134 @@ extensions += ["sphinx_asdf"]  # noqa: F405
 
 
 LATEST = Path("../latest")
+LEGACY = Path("../src/rad/resources")
 SCHEMAS = Path("./_schemas")
 
 SCHEMAS.mkdir(exist_ok=True)
 
-schemas = {}
-archive_schemas = {}
-# We only work with the latest schemas
-for file_path in LATEST.glob("**/*.yaml"):
-    path = file_path.relative_to(LATEST)
 
-    # Currently we do not document the SSC schemas
-    if path.parts[0] == "SSC":
-        continue
+def pull_schemas(schema_path: Path) -> dict[tuple[str, str], str]:
+    schemas = {}
+    # Search files
+    for file_path in schema_path.glob("**/*.yaml"):
+        path = file_path.relative_to(schema_path)
 
-    # No need to document the rad_schema
-    if path.stem == "rad_schema":
-        continue
+        # Currently we do not document the SSC schemas
+        if "SSC" in str(path):
+            continue
 
-    # This is used to find the version number of the schema
-    #    We need to do this because of the way sphinx-asdf
-    #    generates links between schemas, this requires us
-    #    to have the version number included in the page
-    #    url, which is easiest to accomplish by pointing
-    #    spinx-asdf at src/rad/references instead of latest
-    schema_dict = yaml.safe_load(file_path.read_bytes())
-    version = schema_dict["id"].split("-")[-1]
-    entry = f"{path.stem}-{version}"
+        # No need to document the rad_schema
+        if "rad_schema" in str(path):
+            continue
 
-    # The archive_meta keyword distinguishes the level of the
-    #    schemas going into the archive which makes it an easy
-    #    way to separate all the different data model types
-    filename = None
-    if "archive_meta" in schema_dict:
-        meta = "_".join(schema_dict["archive_meta"].split(" ")[:4])
-        filename = f"{meta}.rst"
+        # No need to document automatically fps
+        if "fps" in str(path):
+            continue
 
-    # Now we generate the prefix for the asdf-autoschemas argument
-    prefix = str(path.parent)
-    if prefix == ".":
-        prefix = ""
+        # No need to document automatically tvac
+        if "tvac" in str(path):
+            continue
 
-    # If we don't have a filename lets build it from the prefix
-    if filename is None:
-        # empty prefix means top-level data model that is not
-        #     archived. We dump these in the remaining file
-        if prefix == "":
-            filename = "datamodels.rst"
-        else:
-            # Otherwise turn the prefix into something nice for a file name
-            filename = f"{prefix.replace('/', '_')}.rst"
+        # This is used to find the version number of the schema
+        #    We need to do this because of the way sphinx-asdf
+        #    generates links between schemas, this requires us
+        #    to have the version number included in the page
+        #    url, which is easiest to accomplish by pointing
+        #    spinx-asdf at src/rad/references instead of latest
+        schema_dict = yaml.safe_load(file_path.read_bytes())
 
-    # Now if we aren't a manifest in `src/rad/resources` we need
-    #    to point in the schemas directory
-    if prefix != "manifests":
-        prefix = f"schemas/{prefix}"
+        entry = str(path.stem)
+        if "-" not in entry:
+            version = schema_dict["id"].split("-")[-1]
+            entry = f"{entry}-{version}"
 
-    # Create a key that will store this schema
-    key = (prefix, filename)
+        # The archive_meta keyword distinguishes the level of the
+        #    schemas going into the archive which makes it an easy
+        #    way to separate all the different data model types
+        filename = None
+        if "archive_meta" in schema_dict:
+            meta = "_".join(schema_dict["archive_meta"].split(" ")[:4])
+            filename = f"{meta}.rst"
 
-    # Add a empty list if the key is not found
-    if key not in schemas:
-        schemas[key] = []
+        # Now we generate the prefix for the asdf-autoschemas argument
+        prefix = str(path.parent)
+        if prefix == ".":
+            prefix = "schemas"
 
-    # Add the key to the list in the schemas
-    schemas[key].append(entry)
+        # If we don't have a filename lets build it from the prefix
+        if filename is None:
+            # empty prefix means top-level data model that is not
+            #     archived. We dump these in the remaining file
+            if prefix == "schemas":
+                filename = "datamodels.rst"
+            else:
+                # Otherwise turn the prefix into something nice for a file name
+                filename = f"{prefix.replace('/', '_')}.rst"
 
-for (prefix, filename), schema_list in schemas.items():
-    # First line is the directive followed by the prefix
-    #    argument on the next line followed by and empty
-    #    line to create the sphinx directive.
-    lines = [".. asdf-autoschemas::"]
-    lines.append(f"   :standard_prefix: {prefix}")
-    lines.append("")
+        # Now if we aren't a manifest in `src/rad/resources` we need
+        #    to point in the schemas directory
+        if prefix != "manifests" and not prefix.startswith("schemas"):
+            prefix = f"schemas/{prefix}"
 
-    # Make the list alphabetical
-    schema_list.sort()
-    for schema in schema_list:
-        # Standard indent of RST is supposed to be three spaces
-        lines.append(f"   {schema}")
+        # Create a key that will store this schema
+        key = (prefix, filename)
 
-    # Add blank line at the end to close the directive properly
-    lines.append("")
+        # Add a empty list if the key is not found
+        if key not in schemas:
+            schemas[key] = []
 
-    # Write the doc file.
-    with (SCHEMAS / filename).open(mode="w") as file:
-        file.write("\n".join(lines))
+        # Add the key to the list in the schemas
+        schemas[key].append(entry)
+
+    return schemas
+
+
+def write_schemas(schemas: dict[tuple[str, str], str], path: Path):
+    for (prefix, filename), schema_list in schemas.items():
+        # First line is the directive followed by the prefix
+        #    argument on the next line followed by an empty
+        #    line to create the sphinx directive.
+        lines = [".. asdf-autoschemas::"]
+        lines.append(f"   :standard_prefix: {prefix}")
+        lines.append("")
+
+        # Make the list alphabetical
+        schema_list.sort()
+        for schema in schema_list:
+            # Standard indent of RST is supposed to be three spaces
+            lines.append(f"   {schema}")
+
+        # Add blank line at the end to close the directive properly
+        lines.append("")
+
+        # Write the doc file.
+        with (path / filename).open(mode="w") as file:
+            file.write("\n".join(lines))
+
+
+latest_schemas = pull_schemas(LATEST)
+all_schemas = pull_schemas(LEGACY)
+
+latest_paths = []
+for (prefix, _), value in latest_schemas.items():
+    for suffix in value:
+        latest_paths.append(f"{prefix}/{suffix}")
+
+_manifest_key = ("manifests", "legacy_manifests.rst")
+_schema_key = ("schemas", "legacy_schemas.rst")
+legacy_schemas = {
+    _manifest_key: [],
+    _schema_key: [],
+}
+for (prefix, _), value in all_schemas.items():
+    for suffix in value:
+        if (schema := f"{prefix}/{suffix}") not in latest_paths:
+            if schema.startswith(_manifest_key[0]):
+                legacy_schemas[_manifest_key].append(suffix)
+            else:
+                legacy_schemas[_schema_key].append(schema.removeprefix("schemas/"))
+
+write_schemas({**latest_schemas, **legacy_schemas}, SCHEMAS)
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,3 +200,7 @@ asdf_schema_reference_mappings = [
     ("http://stsci.edu/schemas/asdf/", "https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/"),
     ("tag:stsci.edu:gwcs/wcs-*", "https://asdf-wcs-schemas.readthedocs.io/en/latest/generated/gwcs/wcs-1.0.0.html"),
 ]
+
+# Enable nitpicky mode - which ensures that all references in the docs resolve.
+nitpicky = True
+nitpick_ignore = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Developer Resources
   versioning.rst
   contributing.rst
   changes.rst
+  legacy.rst
 
 Index
 =====

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -1,0 +1,17 @@
+.. _legacy_schemas:
+
+Archive of Legacy Resources
+===========================
+
+The following is a listing of all the previous versions of schemas used by RAD.
+
+Manifests
+---------
+
+.. include:: _schemas/legacy_manifests.rst
+
+
+Legacy Schemas
+--------------
+
+.. include:: _schemas/legacy_schemas.rst

--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -5,8 +5,4 @@ Manifests
 
 The ``tag`` manifests:
 
-.. asdf-autoschemas::
-    :standard_prefix: manifests
-
-    datamodels-1.5.0
-    static-1.1.0
+.. include:: _schemas/manifests.rst

--- a/docs/reference_files.rst
+++ b/docs/reference_files.rst
@@ -5,28 +5,4 @@ Reference File Schemas
 
 Schemas used in Nancy Grace Roman Space Telescope Reference Files:
 
-.. asdf-autoschemas::
-    :standard_prefix: schemas/reference_files
-
-    abvegaoffset-1.2.0
-    apcorr-1.2.0
-    dark-1.4.0
-    distortion-1.3.0
-    epsf-1.3.0
-    flat-1.3.0
-    gain-1.2.0
-    inverselinearity-1.2.0
-    ipc-1.3.0
-    linearity-1.2.0
-    mask-1.2.0
-    matable-1.2.0
-    pixelarea-1.3.0
-    readnoise-1.3.0
-    ref_common-1.2.0
-    ref_exposure_type-1.3.0
-    ref_optical_element-1.3.0
-    refpix-1.2.0
-    saturation-1.2.0
-    skycells-1.1.0
-    superbias-1.2.0
-    wfi_img_photom-1.3.0
+.. include:: _schemas/reference_files.rst

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -9,104 +9,52 @@ The following ASDF schemas define the structures used in Nancy Grace Roman Space
 See :ref:`roman_datamodels:creating-datamodels` for more details about how these schemas are used.
 See :ref:`asdf-standard:asdf-schemas` for more information about ASDF schemas.
 
+Data Model Schemas
+------------------
+
 Level 1 (uncalibrated) schema
------------------------------
+*****************************
 
-.. asdf-autoschemas::
-
-  wfi_science_raw-1.4.0
+.. include:: _schemas/Science_WFI_Level_1.rst
 
 Level 2 (calibrated exposure) schema
-------------------------------------
+************************************
 
-.. asdf-autoschemas::
-
-   wfi_image-1.4.0
-   wfi_wcs-1.3.0
+.. include:: _schemas/Science_WFI_Level_2.rst
 
 Level 3 (resampled mosaic) schema
----------------------------------
+*********************************
 
-.. asdf-autoschemas::
-
-  wfi_mosaic-1.4.0
+.. include:: _schemas/Science_WFI_Level_3.rst
 
 Level 4 (ancillary) schemas
----------------------------
+***************************
 
-.. asdf-autoschemas::
+.. include:: _schemas/Science_WFI_Level_4.rst
 
-  image_source_catalog-1.4.0
-  forced_image_source_catalog-1.1.0
-  segmentation_map-1.4.0
-  mosaic_source_catalog-1.4.0
-  forced_mosaic_source_catalog-1.1.0
-  mosaic_segmentation_map-1.4.0
-  multiband_source_catalog-1.1.0
-  multiband_segmentation_map-1.0.0
+Guide Window
+************
+
+.. include:: _schemas/Guide_Window_Level_1.rst
+
+
+Other Data Models
+*****************
+
+.. include:: _schemas/datamodels.rst
 
 
 Meta
 ----
 
-.. asdf-autoschemas::
-
-  meta/basic-1.0.0
-  meta/cal_logs-1.0.0
-  meta/calibration_software_name-1.0.0
-  meta/calibration_software_version-1.0.0
-  meta/catalog_image-1.0.0
-  meta/common-1.0.0
-  meta/coordinates-1.0.0
-  meta/ephemeris-1.0.0
-  meta/exposure-1.0.0
-  meta/file_date-1.0.0
-  meta/filename-1.0.0
-  meta/guidestar-1.0.0
-  meta/individual_image_meta-1.0.0
-  meta/l2_cal_step-1.0.0
-  meta/l2_catalog_common-1.0.0
-  meta/l3_cal_step-1.0.0
-  meta/l3_catalog_common-1.0.0
-  meta/l3_common-1.0.0
-  meta/l3_resample-1.0.0
-  meta/l3_wcsinfo-1.0.0
-  meta/model_type-1.0.0
-  meta/observation-1.0.0
-  meta/origin-1.0.0
-  meta/outlier_detection-1.0.0
-  meta/photometry-1.0.0
-  meta/pointing-1.0.0
-  meta/prd_version-1.0.0
-  meta/product_type-1.0.0
-  meta/program-1.0.0
-  meta/rcs-1.0.0
-  meta/ref_file-1.0.0
-  meta/sdf_software_version-1.0.0
-  meta/sky_background-1.0.0
-  meta/source_catalog-1.0.0
-  meta/telescope-1.0.0
-  meta/velocity_aberration-1.0.0
-  meta/visit-1.0.0
-  meta/wcsinfo-1.0.0
-  meta/wfi_mode-1.0.0
+.. include:: _schemas/meta.rst
 
 Enums
 -----
-.. asdf-autoschemas::
 
-  enums/cal_step_flag-1.0.0
-  enums/exposure_type-1.0.0
-  enums/guidewindow_modes-1.0.0
-  enums/wfi_detector-1.0.0
-  enums/wfi_optical_element-1.0.0
+.. include:: _schemas/enums.rst
 
 Tables
 ------
 
-.. asdf-autoschemas::
-
-  tables/forced_catalog_table-1.0.0
-  tables/multiband_catalog_table-1.0.0
-  tables/prompt_catalog_table-1.0.0
-  tables/source_catalog_columns-1.0.0
+.. include:: _schemas/tables.rst

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -3,8 +3,10 @@
 Science Products Schemas
 ========================
 
+.. TODO: update the roman_datamodels link once I fix the docs there.
+
 The following ASDF schemas define the structures used in Nancy Grace Roman Space Telescope files.
-See :ref:doc:`roman_datamodels:roman_datamodels/datamodels/general_structure` for more details about how these schemas are used.
+See :ref:`roman_datamodels:creating-datamodels` for more details about how these schemas are used.
 See :ref:`asdf-standard:asdf-schemas` for more information about ASDF schemas.
 
 Level 1 (uncalibrated) schema

--- a/docs/ssc.rst
+++ b/docs/ssc.rst
@@ -2,6 +2,6 @@
 
 SSC Schemas
 ===========
-SSC schemas are located in the `resources/schemas/SSC` directory of the package.
+SSC schemas are located in the ``resources/schemas/SSC`` directory of the package.
 These schemas are not true ASDF schemas so they are not registered with ASDF by default.
 For more information on these schemas contact the Archive and/or SSC teams.


### PR DESCRIPTION
Closes #743

<!-- describe the changes comprising this PR here -->

This PR has sphinx automatically make the lists of schemas to include into the documentation, which then trigger the sphinx-asdf plugin to generate documentation pages for them.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
