### PR TITLE
RAD-256 Significantly speed up unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,32 +81,32 @@ addopts = [
   "--strict-markers", # fail on unknown markers
   "-ra",              # Show summary of all failures/errors
 ]
-testpaths = ["tests", "src/rad/resources/schemas"]
+testpaths = ["tests", "latest"]
 filterwarnings = ["error"]
 asdf_schema_tests_enabled = "true"
 # All the SSC schemas with a $ref have to be xfailed due to asdf-format/pytest-asdf-plugin#9
 asdf_schema_xfail_tests = [
-  "src/rad/resources/schemas/SSC/CGI/cgi_ancillary-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/CGI/cgi_level_1-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/CGI/cgi_level_2a-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/CGI/cgi_level_2b-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/CGI/cgi_level_3-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/CGI/cgi_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_combined_1d_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_decontam_2d_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_individual_1d_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_location_table_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_dqa_2d_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/GDPS/wfi_spec_catalog_dqa_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_event_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_light_curve_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_reference_frame_level_3-1.0.0.yaml",
-  "src/rad/resources/schemas/SSC/MSOS/wfi_microlensing_variability_catalog_level_4-1.0.0.yaml",
+  "latest/SSC/CGI/cgi_ancillary.yaml",
+  "latest/SSC/CGI/cgi_level_1.yaml",
+  "latest/SSC/CGI/cgi_level_2a.yaml",
+  "latest/SSC/CGI/cgi_level_2b.yaml",
+  "latest/SSC/CGI/cgi_level_3.yaml",
+  "latest/SSC/CGI/cgi_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_catalog_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_combined_1d_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_decontam_2d_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_individual_1d_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_location_table_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_dqa_2d_level_4.yaml",
+  "latest/SSC/GDPS/wfi_spec_catalog_dqa_level_4.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_event_catalog_level_4.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_light_curve_catalog_level_4.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_object_periodic_catalog_level_4.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_object_fiducial_catalog_level_4.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_reference_frame_level_3.yaml",
+  "latest/SSC/MSOS/wfi_microlensing_variability_catalog_level_4.yaml",
 ]
-asdf_schema_root = "src/rad/resources/schemas"
+asdf_schema_root = "latest"
 
 [tool.ruff]
 line-length = 130


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-256](https://jira.stsci.edu/browse/RAD-256)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #820

<!-- describe the changes comprising this PR here -->

Issue #820 observed that adding new schemas significantly slowed down the tests. Basic test profiling on my local machine indicated that the biggest source of these slowdowns came from the`pytest-asdf-plugin` tests that run directly on each schema. Since the `pytest-asdf-plugin` was pointed at the `src/rad/resources` and not `latest` that caused it to run over every single schema in RAD even the ones we have perminantly fixed meaning that testing of them in this way is irrelavant. Note that these tests took around ~60sec on my local machine in total compaired with the `tests` which took ~20sec.

This PR configures the `pytest-asdf-plugin` to point at the `latest` schemas rather than all of them reducing the average test suite run on my machine from ~83sec to ~30sec. This should not grow much when we bump schemas unlike before.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
