### PR TITLE
RAD-260: Add psf_match_reference_filter to multiband catalog

### DIFF
--- a/changes/843.feature.rst
+++ b/changes/843.feature.rst
@@ -1,0 +1,1 @@
+This PR adds psf_match_reference_filter to multiband catalog and segment schemas.

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -183,8 +183,8 @@ tags:
     title: Mosaic segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-1.1.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.2.0
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step

--- a/latest/multiband_segmentation_map.yaml
+++ b/latest/multiband_segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.2.0
 
 title: Segmentation map generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -18,7 +18,12 @@ properties:
             type: array
             items:
               $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
-        required: [image_metas]
+          psf_match_reference_filter:
+            title: PSF-matched photometric filter
+            description: |
+              Reference band used to compute PSF-matched photometry.
+            type: string
+        required: [image_metas, psf_match_reference_filter]
   data:
     title: Segmentation map
     description: |

--- a/latest/multiband_segmentation_map.yaml
+++ b/latest/multiband_segmentation_map.yaml
@@ -23,6 +23,7 @@ properties:
             description: |
               Reference band used to compute PSF-matched photometry.
             type: string
+            enum: [F062, F087, F106, F129, F146, F158, F184, F213]
         required: [image_metas, psf_match_reference_filter]
   data:
     title: Segmentation map

--- a/latest/multiband_segmentation_map.yaml
+++ b/latest/multiband_segmentation_map.yaml
@@ -20,7 +20,7 @@ properties:
               $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
           psf_match_reference_filter:
             allOf:
-                - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-1.1.0
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-1.1.0
             title: PSF-matched photometric filter
             description: |
               Reference band used to compute PSF-matched photometry.

--- a/latest/multiband_segmentation_map.yaml
+++ b/latest/multiband_segmentation_map.yaml
@@ -19,11 +19,11 @@ properties:
             items:
               $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
           psf_match_reference_filter:
+            allOf:
+                - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-1.1.0
             title: PSF-matched photometric filter
             description: |
               Reference band used to compute PSF-matched photometry.
-            type: string
-            enum: [F062, F087, F106, F129, F146, F158, F184, F213]
         required: [image_metas, psf_match_reference_filter]
   data:
     title: Segmentation map

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -18,7 +18,12 @@ properties:
             type: array
             items:
               $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
-        required: [image_metas]
+          psf_match_reference_filter:
+            title: PSF-matched photometric filter
+            description: |
+              Reference band used to compute PSF-matched photometry.
+            type: string
+        required: [image_metas, psf_match_reference_filter]
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -19,11 +19,11 @@ properties:
             items:
               $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
           psf_match_reference_filter:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-1.1.0
             title: PSF-matched photometric filter
             description: |
               Reference band used to compute PSF-matched photometry.
-            type: string
-            enum: [F062, F087, F106, F129, F146, F158, F184, F213]
         required: [image_metas, psf_match_reference_filter]
   source_catalog:
     title: Source Catalog

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -23,6 +23,7 @@ properties:
             description: |
               Reference band used to compute PSF-matched photometry.
             type: string
+            enum: [F062, F087, F106, F129, F146, F158, F184, F213]
         required: [image_metas, psf_match_reference_filter]
   source_catalog:
     title: Source Catalog

--- a/src/rad/resources/schemas/multiband_segmentation_map-1.1.0.yaml
+++ b/src/rad/resources/schemas/multiband_segmentation_map-1.1.0.yaml
@@ -1,1 +1,33 @@
-../../../../latest/multiband_segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0
+
+title: Segmentation map generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSegmentationMapModel
+
+archive_meta: Science WFI Level 4 Multiband Segmentation Map L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
+        required: [image_metas]
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/multiband_segmentation_map-1.2.0.yaml
+++ b/src/rad/resources/schemas/multiband_segmentation_map-1.2.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_segmentation_map.yaml


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-260: <Fix a bug> -->

Resolves [RAD-260](https://jira.stsci.edu/browse/RAD-260)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #833 

<!-- describe the changes comprising this PR here -->

This PR adds psf_match_reference_filter to multiband catalog and segment schemas.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
