### PR TITLE
Bugfix for missing static tags

### DIFF
--- a/changes/845.bugfix.rst
+++ b/changes/845.bugfix.rst
@@ -1,0 +1,2 @@
+Add a collection of tags which were removed from the ``datamodels-*`` manifests
+but where not added to the ``static-*`` manifests.

--- a/latest/manifests/static.yaml
+++ b/latest/manifests/static.yaml
@@ -189,6 +189,31 @@ tags:
     title: Ramp fit output schema
     description: |-
       Ramp fit output schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l3_cal_step-1.1.0
+    title: Level 3 Calibration Step status information
+    description: |-
+      Level 3 Calibration Step status information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/resample-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/resample-1.0.0
+    title: Resample information
+    description: |-
+      Resample information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/individual_image_meta-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/individual_image_meta-1.0.0
+    title: Combined level 2 metadata
+    description: |-
+      Combined level 2 metadata
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_associations-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_associations-1.0.0
+    title: Mosaic associations metadata keywords
+    description: |-
+      Mosaic associations metadata keywords
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_wcsinfo-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_wcsinfo-1.0.0
+    title: Mosaic WCS parameters
+    description: |-
+      Mosaic WCS parameters
 
   # Tagged Scalars
   - tag_uri: asdf://stsci.edu/datamodels/roman/tags/calibration_software_name-1.0.0


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

In PR spacetelescope/roman_datamodels#639 I discovered a few tags that had been removed from the `datamodels-*` manifest, but which had not been added to the `static-*` manifest. This PR fixes that issue.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
