### PR TITLE
RAD-251: Fix Required Keys in l3_resample

### DIFF
--- a/changes/849.bugfix.rst
+++ b/changes/849.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the required keys list in the l3_resample schema.

--- a/latest/meta/l3_resample.yaml
+++ b/latest/meta/l3_resample.yaml
@@ -71,4 +71,4 @@ properties:
       time ("exptime") and inverse variance map ("ivm") weighting.
     type: string
 required:
-  [good_bits, members, pixel_scale_ratio, pixfrac, pointings, weight_type]
+  [good_bits, members, pixel_scale_ratio, pixfrac, pixmap_stepsize, pointings, weight_type]

--- a/latest/meta/l3_resample.yaml
+++ b/latest/meta/l3_resample.yaml
@@ -71,4 +71,12 @@ properties:
       time ("exptime") and inverse variance map ("ivm") weighting.
     type: string
 required:
-  [good_bits, members, pixel_scale_ratio, pixfrac, pixmap_stepsize, pointings, weight_type]
+  [
+    good_bits,
+    members,
+    pixel_scale_ratio,
+    pixfrac,
+    pixmap_stepsize,
+    pointings,
+    weight_type,
+  ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-251](https://jira.stsci.edu/browse/RAD-251)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes spacetelescope/romancal#2268 

<!-- describe the changes comprising this PR here -->

This PR fixes the required keys list in the l3_resample schema.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
