### PR TITLE
RAD-267: Create new Exposure Time Calculator reference file schema

### DIFF
--- a/changes/857.feature.rst
+++ b/changes/857.feature.rst
@@ -1,0 +1,1 @@
+Added support for Exposure Time Calculator reference files.

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -82,6 +82,11 @@ tags:
     title: ePSF reference schema
     description: |-
       ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/etc-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/etc-1.0.0
+    title: Exposure Time Calculator Reference File Schema
+    description: |-
+      Exposure Time Calculator Reference File Schema
   - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.4.0
     schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.4.0
     title: Flat reference schema

--- a/latest/reference_files/etc.yaml
+++ b/latest/reference_files/etc.yaml
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.4.0
       - type: object
         properties:
           reftype:

--- a/latest/reference_files/etc.yaml
+++ b/latest/reference_files/etc.yaml
@@ -1,0 +1,24 @@
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/reference_files/etc-1.0.0
+
+title: Exposure Time Calculator Reference File Schema
+
+datamodel_name: EtcRefModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.3.0
+      - type: object
+        properties:
+          reftype:
+            type: string
+            enum: [ETC]
+  form:
+    type: object
+required: [meta, form]
+flowStyle: block
+propertyOrder: [meta, form]

--- a/src/rad/resources/schemas/reference_files/etc-1.0.0.yaml
+++ b/src/rad/resources/schemas/reference_files/etc-1.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/reference_files/etc.yaml


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-267](https://jira.stsci.edu/browse/RAD-267)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #836 

<!-- describe the changes comprising this PR here -->

This PR adds support for Exposure Time Calculator reference files.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
