### PR TITLE
restrict NOT_CONFIGURED to reference files

### DIFF
--- a/changes/848.feature.rst
+++ b/changes/848.feature.rst
@@ -1,1 +1,0 @@
-Added NOT_CONFIGURED to the wfi_detector enum schema.

--- a/changes/862.feature.rst
+++ b/changes/862.feature.rst
@@ -1,0 +1,1 @@
+Allow ``NOT_CONFIGURED`` value for ``meta.instrument.detector`` in reference files.

--- a/latest/enums/wfi_detector.yaml
+++ b/latest/enums/wfi_detector.yaml
@@ -26,4 +26,3 @@ enum:
   - WFI16
   - WFI17
   - WFI18
-  - NOT_CONFIGURED

--- a/latest/reference_files/ref_common.yaml
+++ b/latest/reference_files/ref_common.yaml
@@ -51,8 +51,11 @@ properties:
         type: string
         enum: [WFI]
       detector:
-        allOf:
+        oneOf:
           - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_detector-1.2.0
+          - type: string
+            enum:
+              - NOT_CONFIGURED
         title: Detector
         description: |
           The numbered WFI detector in the focal plane (e.g., WFI01 for SCA 01).

--- a/latest/reference_files/ref_common.yaml
+++ b/latest/reference_files/ref_common.yaml
@@ -51,7 +51,7 @@ properties:
         type: string
         enum: [WFI]
       detector:
-        oneOf:
+        anyOf:
           - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_detector-1.2.0
           - type: string
             enum:

--- a/tests/test_moc_metadata.py
+++ b/tests/test_moc_metadata.py
@@ -64,7 +64,7 @@ TRUTH = {
     },
     "meta.instrument.detector": {
         "type": "string",
-        "enum": set([f"WFI{i:02}" for i in range(1, 19)] + ["NOT_CONFIGURED"]),
+        "enum": set([f"WFI{i:02}" for i in range(1, 19)]),
     },
     "meta.instrument.optical_element": {
         "type": "string",


### PR DESCRIPTION
Follow-up to https://github.com/spacetelescope/rad/pull/848

Restrict `NOT_CONFIGURED` as an allowable detector option to only reference files. This allows the schema validation to correctly fail if a L2 files is produced with `meta.instrument.detector` of `NOT_CONFIGURED`.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
