### PR TITLE
replace setup uv with setup python

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -27,16 +27,14 @@ jobs:
         run: |
           git remote add upstream https://github.com/spacetelescope/rad.git
 
-      - name: Install uv and setup Python
-        uses: astral-sh/setup-uv@v7
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          enable-cache: true
           python-version: "3.13"
-          activate-environment: true
 
       - name: Install RAD
         run: |
-          uv pip install -e ".[test]"
+          pip install -e ".[test]"
 
       - name: Generate archive information
         run: |


### PR DESCRIPTION
Replace `astral-sh/setup-uv@v7` in the archive workflow with a pinned version of setup-python. This is motivated by the latest release of `setup-uv` not being compatible with dependabot meaning we would be stuck on an old version without any notice of an upgrade. See https://github.com/astral-sh/setup-uv/issues/830 for more details.

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
