### PR TITLE
Add dust map column to source catalog table.

### DIFF
--- a/changes/870.feature.rst
+++ b/changes/870.feature.rst
@@ -1,0 +1,1 @@
+Added new dust_map column to source catalog table.

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.5.0
 
 title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -17,7 +17,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.4.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/forced_mosaic_source_catalog.yaml
+++ b/latest/forced_mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.5.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.6.0
 
 title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -26,7 +26,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.4.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.8.0
 
 title: Source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -18,7 +18,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.4.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.9.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.9.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.10.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.10.0
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.
@@ -163,8 +163,8 @@ tags:
     description: |-
       Multiple Accumulation Table Reference File Schema
   # Misc
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.7.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.8.0
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
@@ -173,13 +173,13 @@ tags:
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.8.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.8.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.9.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.9.0
     title: Mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.4.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.5.0
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step
@@ -193,13 +193,13 @@ tags:
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.4.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.5.0
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.5.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.5.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.6.0
     title: Forced mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step

--- a/latest/mosaic_source_catalog.yaml
+++ b/latest/mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.8.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.9.0
 
 title: Source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -27,7 +27,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.4.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.5.0
 
 title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -31,7 +31,7 @@ properties:
       Photometry and astrometry computed in the Source Catalog Step.
     allOf:
       - tag: tag:astropy.org:astropy/table/table-1.*
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.4.0
 
 required: [meta, source_catalog]
 flowStyle: block

--- a/latest/tables/forced_catalog_table.yaml
+++ b/latest/tables/forced_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.4.0
 
 title: Forced source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^forced_dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^forced_segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^forced_warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^forced_fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^forced_is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^forced_roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^forced_sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.4.0
 
 title: Multiband source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -436,3 +436,11 @@ properties:
                 - properties:
                     name:
                       pattern: ^nn_label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dust_ebv"
+                - properties:
+                    name:
+                      pattern: ^dust_ebv$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.4.0
 
 title: Prompt source catalog table schema
 
 definitions:
-  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions"
 
 type: object
 properties:
@@ -16,7 +16,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/flagged_spatial_id"
                 - properties:
                     name:
                       pattern: ^flagged_spatial_id$
@@ -24,7 +24,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmax"
                 - properties:
                     name:
                       pattern: ^bbox_xmax$
@@ -32,7 +32,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_xmin"
                 - properties:
                     name:
                       pattern: ^bbox_xmin$
@@ -40,7 +40,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymax"
                 - properties:
                     name:
                       pattern: ^bbox_ymax$
@@ -48,7 +48,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/bbox_ymin"
                 - properties:
                     name:
                       pattern: ^bbox_ymin$
@@ -56,7 +56,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/image_flags"
                 - properties:
                     name:
                       pattern: ^image_flags$
@@ -64,7 +64,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/label"
                 - properties:
                     name:
                       pattern: ^label$
@@ -72,7 +72,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_area"
                 - properties:
                     name:
                       pattern: ^segment_area$
@@ -80,7 +80,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec"
                 - properties:
                     name:
                       pattern: ^dec$
@@ -88,7 +88,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid"
                 - properties:
                     name:
                       pattern: ^dec_centroid$
@@ -96,7 +96,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_err$
@@ -104,7 +104,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win$
@@ -112,7 +112,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dec_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^dec_centroid_win_err$
@@ -120,7 +120,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra"
                 - properties:
                     name:
                       pattern: ^ra$
@@ -128,7 +128,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid"
                 - properties:
                     name:
                       pattern: ^ra_centroid$
@@ -136,7 +136,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_err$
@@ -144,7 +144,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win$
@@ -152,7 +152,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ra_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^ra_centroid_win_err$
@@ -160,7 +160,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid"
                 - properties:
                     name:
                       pattern: ^x_centroid$
@@ -168,7 +168,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_err$
@@ -176,7 +176,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win"
                 - properties:
                     name:
                       pattern: ^x_centroid_win$
@@ -184,7 +184,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/x_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^x_centroid_win_err$
@@ -192,7 +192,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid"
                 - properties:
                     name:
                       pattern: ^y_centroid$
@@ -200,7 +200,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_err$
@@ -208,7 +208,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win"
                 - properties:
                     name:
                       pattern: ^y_centroid_win$
@@ -216,7 +216,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/y_centroid_win_err"
                 - properties:
                     name:
                       pattern: ^y_centroid_win_err$
@@ -224,7 +224,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux$
@@ -232,7 +232,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper_bkg_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper_bkg_flux_err$
@@ -240,7 +240,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux$
@@ -248,7 +248,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/aper~radius~_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^aper[0-9]{2}_flux_err$
@@ -256,7 +256,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag"
                 - properties:
                     name:
                       pattern: ^kron_abmag$
@@ -264,7 +264,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_abmag_err"
                 - properties:
                     name:
                       pattern: ^kron_abmag_err$
@@ -272,7 +272,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux"
                 - properties:
                     name:
                       pattern: ^kron_flux$
@@ -280,7 +280,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^kron_flux_err$
@@ -288,7 +288,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux"
                 - properties:
                     name:
                       pattern: ^segment_flux$
@@ -296,7 +296,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/segment_~band~_flux_err"
                 - properties:
                     name:
                       pattern: ^segment_flux_err$
@@ -304,7 +304,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/warning_flags"
                 - properties:
                     name:
                       pattern: ^warning_flags$
@@ -312,7 +312,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxx"
                 - properties:
                     name:
                       pattern: ^cxx$
@@ -320,7 +320,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cxy"
                 - properties:
                     name:
                       pattern: ^cxy$
@@ -328,7 +328,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/cyy"
                 - properties:
                     name:
                       pattern: ^cyy$
@@ -336,7 +336,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/ellipticity"
                 - properties:
                     name:
                       pattern: ^ellipticity$
@@ -344,7 +344,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fluxfrac_radius_50_~band~"
                 - properties:
                     name:
                       pattern: ^fluxfrac_radius_50$
@@ -352,7 +352,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/is_extended_~band~"
                 - properties:
                     name:
                       pattern: ^is_extended$
@@ -360,7 +360,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/fwhm"
                 - properties:
                     name:
                       pattern: ^fwhm$
@@ -368,7 +368,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/kron_radius"
                 - properties:
                     name:
                       pattern: ^kron_radius$
@@ -376,7 +376,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_pix"
                 - properties:
                     name:
                       pattern: ^orientation_pix$
@@ -384,7 +384,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/orientation_sky"
                 - properties:
                     name:
                       pattern: ^orientation_sky$
@@ -392,7 +392,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/roundness1_~band~"
                 - properties:
                     name:
                       pattern: ^roundness1$
@@ -400,7 +400,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semimajor"
                 - properties:
                     name:
                       pattern: ^semimajor$
@@ -408,7 +408,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/semiminor"
                 - properties:
                     name:
                       pattern: ^semiminor$
@@ -416,7 +416,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/sharpness_~band~"
                 - properties:
                     name:
                       pattern: ^sharpness$
@@ -424,7 +424,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_distance"
                 - properties:
                     name:
                       pattern: ^nn_distance$
@@ -432,7 +432,7 @@ properties:
           items:
             not:
               allOf:
-                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/nn_label"
                 - properties:
                     name:
                       pattern: ^nn_label$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -436,3 +436,11 @@ properties:
                 - properties:
                     name:
                       pattern: ^nn_label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0#/definitions/dust_ebv"
+                - properties:
+                    name:
+                      pattern: ^dust_ebv$

--- a/latest/tables/source_catalog_columns.yaml
+++ b/latest/tables/source_catalog_columns.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
-id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.4.0
 
 title: Source catalog column definitions
 
@@ -590,6 +590,14 @@ definitions:
         properties:
           datatype:
             enum: [int32]
+  dust_ebv:
+    description: Estimated dust extinction in B-V, taken by default from the map of Schlegel, Finkbeiner, and Davis (1998)
+    unit: mag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
   photoz:
     description: Recommended point estimate of photometric redshift
     unit: none

--- a/src/rad/resources/manifests/datamodels-1.10.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.10.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/manifests/datamodels.yaml

--- a/src/rad/resources/manifests/datamodels-1.9.0.yaml
+++ b/src/rad/resources/manifests/datamodels-1.9.0.yaml
@@ -1,1 +1,211 @@
-../../../../latest/manifests/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.9.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.9.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-1.6.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-1.6.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-1.8.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-1.8.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-1.8.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.7.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-1.5.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-1.4.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-1.4.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-1.7.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/detectorstatus-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/detectorstatus-1.2.0
+    title: Detector Status reference schema
+    description: |-
+      Reference file that is a summary for the current status of each WFI detector to support prompt processing.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/darkdecaysignal-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/darkdecaysignal-1.2.0
+    title: Dark Decay Signal Reference File Schema
+    description: |-
+      Dark decay reference file contains the residual signal properties for each WFI detector
+      that can be removed by an exponentially decreasing signal of DN with respect to time.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-1.5.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-1.6.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-1.6.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/etc-1.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/etc-1.0.0
+    title: Exposure Time Calculator Reference File Schema
+    description: |-
+      Exposure Time Calculator Reference File Schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-1.5.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-1.4.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/integralnonlinearity-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/integralnonlinearity-1.2.0
+    title: Integral nonlinearity correction reference schema
+    description: |-
+      Integral nonlinearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-1.4.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-1.5.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-1.4.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-1.4.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-1.5.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-1.5.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-1.4.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-1.4.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-1.4.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-1.5.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-1.2.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-1.4.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-1.7.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.8.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
+    title: Multiband source catalog
+    description: |-
+      Photometry and astrometry computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-1.7.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.7.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-1.2.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.2.0
+    title: Multiband segmentation map
+    description: |-
+      Segmentation map computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.4.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
+    title: Forced image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.5.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.5.0
+    title: Forced mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-1.8.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-1.8.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.4.0.yaml
@@ -1,1 +1,24 @@
-../../../../latest/forced_image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-1.4.0
+
+title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ForcedImageSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_image_source_catalog-1.5.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-1.5.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_image_source_catalog.yaml

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-1.5.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-1.5.0.yaml
@@ -1,1 +1,33 @@
-../../../../latest/forced_mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-1.5.0
+
+title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: ForcedMosaicSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-1.2.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-1.2.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-1.6.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-1.6.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/image_source_catalog-1.7.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.7.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-1.7.0
+
+title: Source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ImageSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-1.3.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/image_source_catalog-1.8.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-1.8.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/image_source_catalog.yaml

--- a/src/rad/resources/schemas/mosaic_source_catalog-1.8.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-1.8.0.yaml
@@ -1,1 +1,34 @@
-../../../../latest/mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-1.8.0
+
+title: Source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: MosaicSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-1.1.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-1.2.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-1.2.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/mosaic_source_catalog-1.9.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-1.9.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.4.0.yaml
@@ -1,1 +1,38 @@
-../../../../latest/multiband_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.4.0
+
+title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Multiband Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0
+          psf_match_reference_filter:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-1.1.0
+            title: PSF-matched photometric filter
+            description: |
+              Reference band used to compute PSF-matched photometry.
+        required: [image_metas, psf_match_reference_filter]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/multiband_source_catalog-1.5.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-1.5.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_source_catalog.yaml

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.3.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/forced_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-1.3.0
+
+title: Forced source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^forced_dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^forced_segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^forced_warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^forced_sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/forced_catalog_table-1.4.0.yaml
+++ b/src/rad/resources/schemas/tables/forced_catalog_table-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/forced_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.3.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/multiband_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-1.3.0
+
+title: Multiband source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_(f062|f087|f106|f129|f158|f184|f213|f146)_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness_(f062|f087|f106|f129|f158|f184|f213|f146)$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/multiband_catalog_table-1.4.0.yaml
+++ b/src/rad/resources/schemas/tables/multiband_catalog_table-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/multiband_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.3.0.yaml
@@ -1,1 +1,438 @@
-../../../../../latest/tables/prompt_catalog_table.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-1.3.0
+
+title: Prompt source catalog table schema
+
+definitions:
+  $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions"
+
+type: object
+properties:
+  columns:
+    allOf:
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/flagged_spatial_id"
+                - properties:
+                    name:
+                      pattern: ^flagged_spatial_id$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmax"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_xmin"
+                - properties:
+                    name:
+                      pattern: ^bbox_xmin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymax"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymax$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/bbox_ymin"
+                - properties:
+                    name:
+                      pattern: ^bbox_ymin$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/image_flags"
+                - properties:
+                    name:
+                      pattern: ^image_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/label"
+                - properties:
+                    name:
+                      pattern: ^label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_area"
+                - properties:
+                    name:
+                      pattern: ^segment_area$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec"
+                - properties:
+                    name:
+                      pattern: ^dec$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/dec_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^dec_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra"
+                - properties:
+                    name:
+                      pattern: ^ra$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ra_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^ra_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid"
+                - properties:
+                    name:
+                      pattern: ^x_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/x_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^x_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid"
+                - properties:
+                    name:
+                      pattern: ^y_centroid$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/y_centroid_win_err"
+                - properties:
+                    name:
+                      pattern: ^y_centroid_win_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper_bkg_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper_bkg_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/aper~radius~_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^aper[0-9]{2}_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_abmag_err"
+                - properties:
+                    name:
+                      pattern: ^kron_abmag_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^kron_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^kron_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux"
+                - properties:
+                    name:
+                      pattern: ^segment_flux$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/segment_~band~_flux_err"
+                - properties:
+                    name:
+                      pattern: ^segment_flux_err$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/warning_flags"
+                - properties:
+                    name:
+                      pattern: ^warning_flags$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxx"
+                - properties:
+                    name:
+                      pattern: ^cxx$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cxy"
+                - properties:
+                    name:
+                      pattern: ^cxy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/cyy"
+                - properties:
+                    name:
+                      pattern: ^cyy$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/ellipticity"
+                - properties:
+                    name:
+                      pattern: ^ellipticity$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fluxfrac_radius_50_~band~"
+                - properties:
+                    name:
+                      pattern: ^fluxfrac_radius_50$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/is_extended_~band~"
+                - properties:
+                    name:
+                      pattern: ^is_extended$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/fwhm"
+                - properties:
+                    name:
+                      pattern: ^fwhm$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/kron_radius"
+                - properties:
+                    name:
+                      pattern: ^kron_radius$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_pix"
+                - properties:
+                    name:
+                      pattern: ^orientation_pix$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/orientation_sky"
+                - properties:
+                    name:
+                      pattern: ^orientation_sky$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/roundness1_~band~"
+                - properties:
+                    name:
+                      pattern: ^roundness1$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semimajor"
+                - properties:
+                    name:
+                      pattern: ^semimajor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/semiminor"
+                - properties:
+                    name:
+                      pattern: ^semiminor$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/sharpness_~band~"
+                - properties:
+                    name:
+                      pattern: ^sharpness$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_distance"
+                - properties:
+                    name:
+                      pattern: ^nn_distance$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0#/definitions/nn_label"
+                - properties:
+                    name:
+                      pattern: ^nn_label$

--- a/src/rad/resources/schemas/tables/prompt_catalog_table-1.4.0.yaml
+++ b/src/rad/resources/schemas/tables/prompt_catalog_table-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/prompt_catalog_table.yaml

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.3.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.3.0.yaml
@@ -1,1 +1,664 @@
-../../../../../latest/tables/source_catalog_columns.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-1.1.0
+id: asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-1.3.0
+
+title: Source catalog column definitions
+
+definitions:
+  flagged_spatial_id:
+    description: Bit flag encoding the overlap flag, projection, skycell and pixel coordinates of the source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int64]
+  bbox_xmax:
+    description: Column index of the right edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_xmin:
+    description: Column index of the left edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymax:
+    description: Row index of the top edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  bbox_ymin:
+    description: Row index of the bottom edge of the source bounding box (0 indexed)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  image_flags:
+    description: Image quality bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  label:
+    description: Label of the source segment in the segmentation image
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_area:
+    description: Area of the source segment
+    unit: arcsec^2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec:
+    description: Best estimate of the declination (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid:
+    description: Declination of the source centroid (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_err:
+    description: Uncertainty in dec_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_centroid_win:
+    description: Declination (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_centroid_win_err:
+    description: Uncertainty in dec_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  dec_psf_~band~:
+    description: Declination (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  dec_psf_~band~_err:
+    description: Uncertainty in dec_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_gof_~band~:
+    description: PSF goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra:
+    description: Best estimate of the right ascension (ICRS)
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid:
+    description: Right ascension (ICRS) of the source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_err:
+    description: Uncertainty in ra_centroid
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_centroid_win:
+    description: Right ascension (ICRS) of the windowed source centroid
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_centroid_win_err:
+    description: Uncertainty in ra_centroid_win
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ra_psf_~band~:
+    description: Right ascension (ICRS) of the PSF-fitted position
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float64]
+  ra_psf_~band~_err:
+    description: Uncertainty in ra_psf
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid:
+    description: Column coordinate of the source centroid from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_err:
+    description: Uncertainty x_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win:
+    description: Column coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_centroid_win_err:
+    description: Uncertainty on x_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~:
+    description: Column coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  x_psf_~band~_err:
+    description: Uncertainty in x_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid:
+    description: Row coordinate of the source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_err:
+    description: Uncertainty on y_centroid
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win:
+    description: Row coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_centroid_win_err:
+    description: Uncertainty on y_centroid_win
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~:
+    description: Row coordinate of the source from PSF fitting (0 indexed)
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  y_psf_~band~_err:
+    description: Uncertainty on y_psf
+    unit: pix
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux:
+    description: Local background estimated within a circular annulus
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~_flux_err:
+    description: Uncertainty in local background estimated in a circular annulus
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux:
+    description: Local background estimate for PSF-matched aperture photometry
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper_bkg_~band~m~band~_flux_err:
+    description: Uncertainty in local background estimate for PSF-matched aperture photometry
+    unit: nJy arcsec-2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux:
+    description: Flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~_flux_err:
+    description: Uncertainty in flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux:
+    description: PSF-matched flux within circular aperture (radius in tenths of arcsec)
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  aper~radius~_~band~m~band~_flux_err:
+    description: Uncertainty in PSF-matched flux within circular aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag:
+    description: AB magnitude within the elliptical Kron aperture
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_abmag_err:
+    description: Uncertainty in kron_abmag
+    unit: mag(AB)
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux:
+    description: Flux within the elliptical Kron aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~_flux_err:
+    description: Uncertainty in kron_<band>_flux_err
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_flux:
+    description: PSF-matched flux within the elliptical Kron aperture
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_~band~m~band~_flux_err:
+    description: Uncertainty in kron_<band>m<band>_abmag_err
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux:
+    description: Total PSF flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_~band~_flux_err:
+    description: Uncertainty in psf_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  psf_flags_~band~:
+    description: PSF fitting bit flags (0 = good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  segment_~band~_flux:
+    description: Isophotal flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~_flux_err:
+    description: Uncertainty in segment_flux
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux:
+    description: Isophotal flux after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  segment_~band~m~band~_flux_err:
+    description: Isophotal flux error after PSF matching to a reference band
+    unit: nJy
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  warning_flags:
+    description: Warning bit flags (0=good)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  cxx:
+    description: Coefficient for the x**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cxy:
+    description: Coefficient for the x*y term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  cyy:
+    description: Coefficient for the y**2 term in the generalized quadratic ellipse equation
+    unit: 1/arcsec2
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  ellipticity:
+    description: Source ellipticity as 1 - (semimajor / semiminor)
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  fluxfrac_radius_50_~band~:
+    description: Radius of a circle centered on the source centroid that encloses 50% of the Kron flux
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  is_extended_~band~:
+    description: Flag indicating that the source appears to be more extended than a point source
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [bool8]
+  fwhm:
+    description: Circularized full width at half maximum (FWHM) calculated from the semimajor and semiminor axes as 2*sqrt(ln(2) * (semimajor**2 + semiminor**2))
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  kron_radius:
+    description: First-moment radius measured in the detection image.
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_pix:
+    description: Angle measured counter-clockwise from the positive X axis to the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  orientation_sky:
+    description: Position angle from North of the source major axis computed from image moments
+    unit: deg
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  roundness1_~band~:
+    description: Photutils DAOFinder roundness1 statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semimajor:
+    description: Length of the source semimajor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  semiminor:
+    description: Length of the source semiminor axis computed from image moments
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  sharpness_~band~:
+    description: Photutils DAOFinder sharpness statistic
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_distance:
+    description: Distance to the nearest neighbor in this skycell
+    unit: arcsec
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  nn_label:
+    description: Segment label of the nearest neighbor in this skycell
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]
+  photoz:
+    description: Recommended point estimate of photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_gof:
+    description: Photo-z goodness of fit metric
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high68:
+    description: 68% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high90:
+    description: 90% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_high99:
+    description: 99% confidence upper bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low68:
+    description: 68% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low90:
+    description: 90% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_low99:
+    description: 99% confidence lower bound on photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
+  photoz_sed:
+    description: Best-fit spectral-energy distribution for this photometric redshift
+    unit: none
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [int32]

--- a/src/rad/resources/schemas/tables/source_catalog_columns-1.4.0.yaml
+++ b/src/rad/resources/schemas/tables/source_catalog_columns-1.4.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/tables/source_catalog_columns.yaml


### PR DESCRIPTION
### DO NOT MERGE
#### PR #876 needs to be merged first, then this PR needs to be updated to the same version used in that PR.
---

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-272](https://jira.stsci.edu/browse/RAD-272)

<!-- describe the changes comprising this PR here -->

This PR adds a new column to the source catalog table containing information about the estimated dust extinction in B-V, taken by default from the map of Schlegel, Finkbeiner, and Davis (1998).

## Regression tests
- ~https://github.com/spacetelescope/RegressionTests/actions/runs/25376111589/job/74411539791 (05/05/2026; all passing)~.
- https://github.com/spacetelescope/RegressionTests/actions/runs/25581320355 (05/08/2026; all tests passing).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
