### PR TITLE
RAD-272: Add dust map column to source catalog table.

### DIFF
--- a/changes/877.feature.rst
+++ b/changes/877.feature.rst
@@ -1,0 +1,1 @@
+Added new dust_map column to source catalog table.

--- a/latest/tables/multiband_catalog_table.yaml
+++ b/latest/tables/multiband_catalog_table.yaml
@@ -436,3 +436,11 @@ properties:
                 - properties:
                     name:
                       pattern: ^nn_label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-2.0.0#/definitions/dust_ebv"
+                - properties:
+                    name:
+                      pattern: ^dust_ebv$

--- a/latest/tables/prompt_catalog_table.yaml
+++ b/latest/tables/prompt_catalog_table.yaml
@@ -436,3 +436,11 @@ properties:
                 - properties:
                     name:
                       pattern: ^nn_label$
+      - not:
+          items:
+            not:
+              allOf:
+                - $ref: "asdf://stsci.edu/datamodels/roman/schemas/tables/source_catalog_columns-2.0.0#/definitions/dust_ebv"
+                - properties:
+                    name:
+                      pattern: ^dust_ebv$

--- a/latest/tables/source_catalog_columns.yaml
+++ b/latest/tables/source_catalog_columns.yaml
@@ -590,6 +590,14 @@ definitions:
         properties:
           datatype:
             enum: [int32]
+  dust_ebv:
+    description: Estimated dust extinction in B-V, taken by default from the map of Schlegel, Finkbeiner, and Davis (1998)
+    unit: mag
+    properties:
+      data:
+        properties:
+          datatype:
+            enum: [float32]
   photoz:
     description: Recommended point estimate of photometric redshift
     unit: none


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RAD-1234: <Fix a bug> -->

Resolves [RAD-272](https://jira.stsci.edu/browse/RAD-272)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #871

<!-- describe the changes comprising this PR here -->

#### This PR incorporates v2.0.0 changes and thus supplants #870 

This PR adds a new column to the source catalog table containing information about the estimated dust extinction in B-V, taken by default from the map of Schlegel, Finkbeiner, and Davis (1998).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
