### PR TITLE
Allow null pointing fields for CGI dark/calibration data

### DIFF
--- a/changes/885.misc.rst
+++ b/changes/885.misc.rst
@@ -1,0 +1,1 @@
+Allow CGI pointing fields to accept null values for dark/calibration data.

--- a/latest/SSC/CGI/keywords/cgi_pointing.yaml
+++ b/latest/SSC/CGI/keywords/cgi_pointing.yaml
@@ -11,43 +11,55 @@ properties:
   RA:
     title: RA (J2000)
     description: Right Ascension (J2000), from 0 to 360, in degrees
-    type: number
+    anyOf:
+      - type: number
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [CGIExposure.ra_ref, CGIMosaic.ra_ref]
   DEC:
     title: Dec (J2000)
     description: Declination (J2000), from -90 to +90, in degrees
-    type: number
+    anyOf:
+      - type: number
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [CGIExposure.dec_ref, CGIMosaic.dec_ref]
   RAPM:
     title: RA proper motion
     description: RA proper motion (mas/yr)
-    type: number
+    anyOf:
+      - type: number
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [CGIExposure.rapm, CGIMosaic.rapm]
   DECPM:
     title: Dec proper motion
     description: Dec proper motion
-    type: number
+    anyOf:
+      - type: number
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [CGIExposure.decpm, CGIMosaic.decpm]
   TARGET:
     title: Target Name
     description: Name of the source pointed at by the telescope
-    type: string
-    maxLength: 256
+    anyOf:
+      - type: string
+        maxLength: 256
+      - type: "null"
     archive_catalog:
       datatype: nvarchar(256)
       destination: [CGIExposure.target_name, CGIMosaic.target_name]
   EQUINOX:
     title: Equinox
     description: The equinox of the coordinates J2000 (yr)
-    type: number
+    anyOf:
+      - type: number
+      - type: "null"
     archive_catalog:
       datatype: float
       destination: [CGIExposure.equinox, CGIMosaic.equinox]


### PR DESCRIPTION
Closes #883

CGI calibration data can have no target. Made all 6 pointing fields
nullable via anyOf to match the repo convention.

- RA, DEC, RAPM, DECPM: number | null
- TARGET: string | null (maxLength preserved)
- EQUINOX: number | null