### PR TITLE
Remove subcategory enums from program and l3_common

### DIFF
--- a/changes/893.bugfix.rst
+++ b/changes/893.bugfix.rst
@@ -1,0 +1,1 @@
+Remove unnecessary subcategory enum from program and l3_common schemas.

--- a/latest/forced_image_source_catalog.yaml
+++ b/latest/forced_image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.1.0
 
 title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -10,7 +10,7 @@ datamodel_name: ForcedImageSourceCatalogModel
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.1.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/forced_mosaic_source_catalog.yaml
+++ b/latest/forced_mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.1.0
 
 title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
       - properties:
           association:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0

--- a/latest/image_source_catalog.yaml
+++ b/latest/image_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.1.0
 
 title: Source catalog generated from a Level 2 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Source Catalog L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.1.0
   source_catalog:
     title: Source Catalog
     description: |

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.0.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.0.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.1.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.1.0
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -19,18 +19,18 @@ tags:
     title: Level 1 Detector Guide Star Window Information schema
     description: |-
       Level 1 Detector Guide Star Window Information schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.1.0
     title: Ramp schema
     description: |-
       Ramp schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.1.0
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.1.0
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information
@@ -39,8 +39,8 @@ tags:
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.1.0
     title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
     description: |-
       Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
@@ -163,13 +163,13 @@ tags:
     description: |-
       Multiple Accumulation Table Reference File Schema
   # Misc
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.1.0
     title: Image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.1.0
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
@@ -193,8 +193,8 @@ tags:
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.1.0
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
@@ -204,8 +204,8 @@ tags:
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
   # SSC data models
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.1.0
     title: MSOS Stack Level 3 Schema
     description: |-
       Level 3 schema for SSC's MSOS stack products

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -34,8 +34,8 @@ tags:
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.1.0
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information
@@ -173,23 +173,23 @@ tags:
     title: Segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.1.0
     title: Mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.1.0
     title: Multiband source catalog
     description: |-
       Photometry and astrometry computed by the Multiband Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.1.0
     title: Mosaic segmentation map
     description: |-
       Segmentation map computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.1.0
     title: Multiband segmentation map
     description: |-
       Segmentation map computed by the Multiband Catalog Step
@@ -198,8 +198,8 @@ tags:
     title: Forced image source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-2.1.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.1.0
     title: Forced mosaic source catalog
     description: |-
       Photometry and astrometry computed by the Source Catalog Step

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.1.0
 
 title: Common metadata properties
 
@@ -26,7 +26,7 @@ allOf:
       pointing:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
       program:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0
       ref_file:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0
       rcs:

--- a/latest/meta/l2_catalog_common.yaml
+++ b/latest/meta/l2_catalog_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.1.0
 
 title: Common Level 2 Catalog Metadata
 
@@ -24,7 +24,7 @@ allOf:
       pointing:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
       program:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0
       ref_file:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0
       visit:

--- a/latest/meta/l3_catalog_common.yaml
+++ b/latest/meta/l3_catalog_common.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
 
 title: Common Level 3 Catalog Metadata
 
 allOf:
-  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0
   - properties:
       image:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/catalog_image-2.0.0

--- a/latest/meta/l3_common.yaml
+++ b/latest/meta/l3_common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0
 
 title: Common Level 3 Metadata
 
@@ -424,20 +424,6 @@ properties:
           the meta.program.category values.
         anyOf:
           - type: string
-            enum:
-              [
-                "CAL",
-                "CGI",
-                "CR",
-                "DR",
-                "GBTD",
-                "HLTD",
-                "HLWA",
-                "OR",
-                "WFI",
-                "WFSC",
-                "None",
-              ]
           - type: "null"
         archive_catalog:
           datatype: nvarchar(15)

--- a/latest/meta/program.yaml
+++ b/latest/meta/program.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0
 
 title: Program Information
 type: object
@@ -80,20 +80,6 @@ properties:
       and Control (WFSC). All subcategories belong to only a subset of
       the meta.program.category values.
     type: string
-    enum:
-      [
-        "CAL",
-        "CGI",
-        "CR",
-        "DR",
-        "GBTD",
-        "HLTD",
-        "HLWA",
-        "OR",
-        "WFI",
-        "WFSC",
-        "None",
-      ]
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/mosaic_segmentation_map.yaml
+++ b/latest/mosaic_segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.1.0
 
 title: Segmentation map generated from a Level 3 file by the Source Catalog Step.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
       - properties:
           association:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0

--- a/latest/mosaic_source_catalog.yaml
+++ b/latest/mosaic_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.1.0
 
 title: Source catalog generated from a Level 3 file by the Source Catalog Step.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
       - properties:
           association:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.1.0
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.1.0
       - type: object
         properties:
           image_list:

--- a/latest/multiband_segmentation_map.yaml
+++ b/latest/multiband_segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.1.0
 
 title: Segmentation map generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -12,12 +12,12 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
       - properties:
           image_metas:
             type: array
             items:
-              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0
           psf_match_reference_filter:
             allOf:
               - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-2.0.0

--- a/latest/multiband_source_catalog.yaml
+++ b/latest/multiband_source_catalog.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.1.0
 
 title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
 
@@ -12,12 +12,12 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0
       - properties:
           image_metas:
             type: array
             items:
-              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0
           psf_match_reference_filter:
             allOf:
               - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-2.0.0

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.1.0
 
 title: Ramp Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.1.0
       - type: object
         properties:
           cal_step:

--- a/latest/segmentation_map.yaml
+++ b/latest/segmentation_map.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.1.0
 
 title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
 
@@ -11,7 +11,7 @@ archive_meta: Science WFI Level 4 Segmentation Map L2 Product
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.1.0
   data:
     title: Segmentation map
     description: |

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.1.0
 
 title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.1.0
       - type: object
         properties:
           background:

--- a/latest/wfi_mosaic.yaml
+++ b/latest/wfi_mosaic.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.1.0
 
 title: The schema for WFI Level 3 mosaics.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0
       - required:
           [
             cal_logs,

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.1.0
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: Science WFI Level 1
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.1.0
   data:
     title: Science Data (DN)
     description: |

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.1.0
 
 title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -27,7 +27,7 @@ properties:
           pointing:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
           program:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0
           velocity_aberration:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-2.0.0
           visit:

--- a/src/rad/resources/manifests/datamodels-2.0.0.yaml
+++ b/src/rad/resources/manifests/datamodels-2.0.0.yaml
@@ -1,1 +1,211 @@
-../../../../latest/manifests/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.0.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.0.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-2.0.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-2.0.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-2.0.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-2.0.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-2.0.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/detectorstatus-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/detectorstatus-2.0.0
+    title: Detector Status reference schema
+    description: |-
+      Reference file that is a summary for the current status of each WFI detector to support prompt processing.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/darkdecaysignal-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/darkdecaysignal-2.0.0
+    title: Dark Decay Signal Reference File Schema
+    description: |-
+      Dark decay reference file contains the residual signal properties for each WFI detector
+      that can be removed by an exponentially decreasing signal of DN with respect to time.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-2.0.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-2.0.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/etc-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/etc-2.0.0
+    title: Exposure Time Calculator Reference File Schema
+    description: |-
+      Exposure Time Calculator Reference File Schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-2.0.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-2.0.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/integralnonlinearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/integralnonlinearity-2.0.0
+    title: Integral nonlinearity correction reference schema
+    description: |-
+      Integral nonlinearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-2.0.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-2.0.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-2.0.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-2.0.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-2.0.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-2.0.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-2.0.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-2.0.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-2.0.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-2.0.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-2.0.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-2.0.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.0.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.0.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.0.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0
+    title: Multiband source catalog
+    description: |-
+      Photometry and astrometry computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.0.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.0.0
+    title: Multiband segmentation map
+    description: |-
+      Segmentation map computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.0.0
+    title: Forced image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.0.0
+    title: Forced mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/manifests/datamodels-2.1.0.yaml
+++ b/src/rad/resources/manifests/datamodels-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/manifests/datamodels.yaml

--- a/src/rad/resources/schemas/forced_image_source_catalog-2.0.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-2.0.0.yaml
@@ -1,1 +1,24 @@
-../../../../latest/forced_image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.0.0
+
+title: Forced source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ForcedImageSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-2.0.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_image_source_catalog-2.1.0.yaml
+++ b/src/rad/resources/schemas/forced_image_source_catalog-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_image_source_catalog.yaml

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-2.0.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-2.0.0.yaml
@@ -1,1 +1,33 @@
-../../../../latest/forced_mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.0.0
+
+title: Forced source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: ForcedMosaicSourceCatalogModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-2.0.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-2.0.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/forced_catalog_table-2.0.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/forced_mosaic_source_catalog-2.1.0.yaml
+++ b/src/rad/resources/schemas/forced_mosaic_source_catalog-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/forced_mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/image_source_catalog-2.0.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-2.0.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/image_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.0.0
+
+title: Source catalog generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: ImageSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-2.0.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/image_source_catalog-2.1.0.yaml
+++ b/src/rad/resources/schemas/image_source_catalog-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/image_source_catalog.yaml

--- a/src/rad/resources/schemas/meta/common-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/common-2.0.0.yaml
@@ -1,1 +1,55 @@
-../../../../../latest/meta/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+
+title: Common metadata properties
+
+allOf:
+  # Meta Variables
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-2.0.0
+  - type: object
+    properties:
+      # Meta Objects
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
+      ephemeris:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
+      guide_star:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-2.0.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-2.0.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-2.0.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0
+      rcs:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/rcs-2.0.0
+      velocity_aberration:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-2.0.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-2.0.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-2.0.0
+    required:
+      [
+        coordinates,
+        ephemeris,
+        exposure,
+        guide_star,
+        instrument,
+        observation,
+        pointing,
+        program,
+        ref_file,
+        rcs,
+        velocity_aberration,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/common-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/common-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/common.yaml

--- a/src/rad/resources/schemas/meta/l2_catalog_common-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-2.0.0.yaml
@@ -1,1 +1,46 @@
-../../../../../latest/meta/l2_catalog_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+
+title: Common Level 2 Catalog Metadata
+
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-2.0.0
+  - type: object
+    properties:
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
+      image:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/catalog_image-2.0.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-2.0.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-2.0.0
+      photometry:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-2.0.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-2.0.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-2.0.0
+    required:
+      [
+        coordinates,
+        exposure,
+        instrument,
+        observation,
+        photometry,
+        pointing,
+        program,
+        ref_file,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/l2_catalog_common-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/l2_catalog_common-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l2_catalog_common.yaml

--- a/src/rad/resources/schemas/meta/l3_catalog_common-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/l3_catalog_common-2.0.0.yaml
@@ -1,1 +1,24 @@
-../../../../../latest/meta/l3_catalog_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+
+title: Common Level 3 Catalog Metadata
+
+allOf:
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+  - properties:
+      image:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/catalog_image-2.0.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_wcsinfo-2.0.0
+  - required:
+      [
+        coordinates,
+        coadd_info,
+        image,
+        instrument,
+        observation,
+        program,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/l3_catalog_common-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/l3_catalog_common-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l3_catalog_common.yaml

--- a/src/rad/resources/schemas/meta/l3_common-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/l3_common-2.0.0.yaml
@@ -1,1 +1,500 @@
-../../../../../latest/meta/l3_common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+
+title: Common Level 3 Metadata
+
+type: object
+properties:
+  calibration_software_name:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/calibration_software_name-2.0.0
+  calibration_software_version:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/calibration_software_version-2.0.0
+  data_release_id:
+    title: Data Release Identifier
+    description: >
+      A label for the data release (if applicable). This keyword
+      is optional and only populated for data release products.
+    type: string
+    maxLength: 120
+    archive_catalog:
+      datatype: nvarchar(120)
+      destination:
+        [
+          WFIMosaic.data_release_id,
+          SegmentationMap.data_release_id,
+          SourceCatalog.data_release_id,
+        ]
+  filename:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/filename-2.0.0
+  file_date:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/file_date-2.0.0
+  model_type:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/model_type-2.0.0
+  origin:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/origin-2.0.0
+  product_type:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/product_type-2.0.0
+  telescope:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/telescope-2.0.0
+
+  cal_logs:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-2.0.0
+
+  coordinates:
+    title: Celestial Coordinate Reference Frame
+    properties:
+      reference_frame:
+        title: Name of the Celestial Coordinate Reference Frame
+        description: >
+          Name of the celestial coordinate reference frame used
+          for the World Coordinate System (WCS).
+        type: string
+        archive_catalog:
+          datatype: nvarchar(10)
+          destination:
+            [
+              WFIMosaic.reference_frame,
+              SegmentationMap.reference_frame,
+              SourceCatalog.reference_frame,
+            ]
+        enum: [ICRS]
+    required: [reference_frame]
+
+  coadd_info:
+    title: Co-Addition Information
+    properties:
+      time_first:
+        title: Start Time of the First Exposure
+        description: >
+          The Universal Coordinated Time (UTC) start time of
+          the first exposure ordered in time used to create the
+          co-added product. The time is serialized on disk as an
+          International Organization for Standardization (ISO)
+          8601-compliant ISOT string. If opened in Python with the
+          asdf-astropy package installed, it may be read as an
+          astropy.time.Time object with all of the associated methods
+          and transforms available. See the documentation for
+          astropy.time.Time objects for more information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination:
+            [
+              WFIMosaic.time_first,
+              SegmentationMap.time_first,
+              SourceCatalog.time_first,
+            ]
+      time_last:
+        title: End Time of the Last Exposure
+        description: >
+          The Universal Coordinated Time (UTC) end time of
+          the last exposure ordered in time used to create the
+          co-added product. The time is serialized on disk as an
+          International Organization for Standardization (ISO)
+          8601-compliant ISOT string. If opened in Python with the
+          asdf-astropy package installed, it may be read as an
+          astropy.time.Time object with all of the associated methods
+          and transforms available. See the documentation for
+          astropy.time.Time objects for more information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination:
+            [
+              WFIMosaic.time_last,
+              SegmentationMap.time_last,
+              SourceCatalog.time_last,
+            ]
+      time_mean:
+        title: Mean Time of the Co-Added Data Product
+        description: >
+          The Universal Coordinated Time (UTC) mean start
+          time of the exposures used to create the co-added product.
+          The time is serialized on disk as an International
+          Organization for Standardization (ISO) 8601-compliant ISOT
+          string. If opened in Python with the asdf-astropy package
+          installed, it may be read as an astropy.time.Time object
+          with all of the associated methods and transforms available.
+          See the documentation for astropy.time.Time objects for more
+          information.
+        tag: tag:stsci.edu:asdf/time/time-1.*
+        archive_catalog:
+          datatype: datetime2
+          destination:
+            [
+              WFIMosaic.time_mean,
+              SegmentationMap.time_mean,
+              SourceCatalog.time_mean,
+            ]
+      max_exposure_time:
+        title: Maximum Exposure Time (s)
+        description: >
+          Maximum exposure time of all pixels in the
+          co-added product in units of seconds. The exposure times of
+          each input pixel are drizzled onto the output frame, and
+          then the maximum is computed from all output pixels with
+          exposure time > 0 seconds.
+        type: number
+        archive_catalog:
+          datatype: float
+          destination:
+            [
+              WFIMosaic.max_exposure_time,
+              SegmentationMap.max_exposure_time,
+              SourceCatalog.max_exposure_time,
+            ]
+      exposure_time:
+        title: Exposure Time (s)
+        description: >
+          A representative exposure time for the co-added
+          product in units of seconds. For Roman SOC products, the
+          exposure times of each input pixel are drizzled on the
+          output frame, and then the mean exposure time is computed
+          from all output pixels with exposure time > 0 seconds.
+          Please check the keyword meta.origin for contextual
+          information.
+        type: number
+        archive_catalog:
+          datatype: float
+          destination:
+            [
+              WFIMosaic.exposure_time,
+              SegmentationMap.exposure_time,
+              SourceCatalog.exposure_time,
+            ]
+    required: [time_first, time_last, time_mean, exposure_time]
+
+  individual_image_meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/individual_image_meta-2.0.0
+
+  instrument:
+    title: Wide Field Instrument (WFI) Configuration Information
+    properties:
+      name:
+        title: Instrument Name
+        description: >
+          Name of the instrument used to acquire the science data.
+        type: string
+        enum: [WFI]
+        archive_catalog:
+          datatype: nvarchar(5)
+          destination:
+            [
+              WFIMosaic.instrument_name,
+              SegmentationMap.instrument_name,
+              SourceCatalog.instrument_name,
+            ]
+      optical_element:
+        title: Wide Field Instrument (WFI) Optical Element
+        description: >
+          Name of the optical element used to take the science
+          data. If data using multiple optical elements are combined, the
+          value of optical_element will be None.
+        anyOf:
+          - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-2.0.0
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(20)
+          destination:
+            [
+              WFIMosaic.optical_element,
+              SegmentationMap.optical_element,
+              SourceCatalog.optical_element,
+            ]
+    required: [name, optical_element]
+
+  observation:
+    title: Observation Identifiers
+    properties:
+      execution_plan:
+        title: Execution Plan Number
+        description: >
+          Identifier for the execution plan. An execution plan
+          is a version of the complete set of activities for a survey. A
+          survey may include portions of multiple execution plans. A new
+          execution plan is required whenever there is a change in the
+          program. The allowed range of execution plan numbers is 01 to 99
+          inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [
+              WFIMosaic.execution_plan,
+              SegmentationMap.execution_plan,
+              SourceCatalog.execution_plan,
+            ]
+      exposure:
+        title: Exposure Number
+        description: |
+          An exposure is a single multi-accumulation (MA) table
+          sequence of the detector array at a single dither point in the
+          dither pattern. The allowed range of exposure numbers is 0001 to
+          9999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [
+              WFIMosaic.exposure,
+              SegmentationMap.exposure,
+              SourceCatalog.exposure,
+            ]
+      exposure_grouping:
+        title: Exposure Grouping
+        description: >
+          Conceptual type of exposure grouping used to create this coadd (e.g., by visit, or full)
+        anyOf:
+          - type: string
+            maxLength: 120
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(120)
+          destination:
+            [
+              WFIMosaic.exposure_grouping,
+              SegmentationMap.exposure_grouping,
+              SourceCatalog.exposure_grouping,
+            ]
+      observation:
+        title: Observation Number
+        description: |
+          Identifier for the observation. An observation is a
+          single traversal of a mosaic pattern, using a single, constant
+          instrument configuration (i.e., with no element wheel moves).
+          The allowed range of observation numbers is 001 to 999
+          inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [
+              WFIMosaic.observation,
+              SegmentationMap.observation,
+              SourceCatalog.observation,
+            ]
+      pass:
+        title: Pass Number
+        description: >
+          Identifier for the pass. A pass is the collection of
+          activities generated from each iteration of a pass plan in the
+          Astronomer's Proposal Tool (APT). Multiple passes may be
+          generated from the same Pass Plan to allow repetition or execute
+          at different orientations (via special requirements). The
+          allowed range of pass numbers is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [WFIMosaic.pass, SegmentationMap.pass, SourceCatalog.pass]
+      program:
+        title: Program Number
+        description: >
+          Identifier for the observing program. A program is an
+          approved specification for a science, calibration, or
+          engineering investigation to be pursued using Roman Space
+          Telescope mission resources. The allowed range of program
+          numbers is 00001 to 18445 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: int
+          destination:
+            [WFIMosaic.program, SegmentationMap.program, SourceCatalog.program]
+      segment:
+        title: Segment Number
+        description: >
+          Identifier for the segment. A segment is the sequence
+          of activities produced by each iteration of an Astronomer's
+          Proposal Tool (APT) segment plan in a pass. A segment may
+          include multiple traversals of mosaic pattern(s), with element
+          wheel moves occurring between observations. The allowed range of
+          segment numbers is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [WFIMosaic.segment, SegmentationMap.segment, SourceCatalog.segment]
+      visit:
+        title: Visit Number
+        description: >
+          A visit is the smallest scheduling unit for Roman,
+          which is a sequence of exposures executed without interruption,
+          including dither patterns. A visit corresponds to one tile of
+          the selected mosaic pattern. The allowed range of visit numbers
+          is 001 to 999 inclusive.
+        anyOf:
+          - type: integer
+          - type: "null"
+        archive_catalog:
+          datatype: smallint
+          destination:
+            [WFIMosaic.visit, SegmentationMap.visit, SourceCatalog.visit]
+    required:
+      [
+        execution_plan,
+        exposure,
+        exposure_grouping,
+        observation,
+        pass,
+        program,
+        segment,
+        visit,
+      ]
+
+  program:
+    title: Program Information
+    properties:
+      title:
+        title: Proposal Title
+        description: The submitted proposal title of the program.
+        anyOf:
+          - type: string
+            maxLength: 200
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(200)
+          destination:
+            [
+              WFIMosaic.program_title,
+              SegmentationMap.program_title,
+              SourceCatalog.program_title,
+            ]
+      investigator_name:
+        title: Principle Investigator Name
+        description: The name of the principle investigator (PI) of the program.
+        anyOf:
+          - type: string
+            maxLength: 100
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(100)
+          destination:
+            [
+              WFIMosaic.investigator_name,
+              SegmentationMap.investigator_name,
+              SourceCatalog.investigator_name,
+            ]
+      category:
+        title: Program Category
+        description: >
+          The submitted proposal category of the program. The
+          categories include calibration (CAL), core community survey
+          (CCS), coronagraph technology demonstration (CGI), observatory
+          commissioning (COM), engineering (ENG), general astrophysics
+          survey (GAS), general investigator (GI), and observing conducted
+          at the direction of the National Aeronautics and Space
+          Administration (NASA).
+        anyOf:
+          - type: string
+            maxLength: 6
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(6)
+          destination:
+            [
+              WFIMosaic.program_category,
+              SegmentationMap.program_category,
+              SourceCatalog.program_category,
+            ]
+      subcategory:
+        title: Program Subcategory
+        description: >
+          The submitted proposal subcategory of the program. The
+          subcategories include calibration (CAL), coronagraph technology
+          demonstration (CGI), community research programs (CR),
+          discretionary research programs (DR), Galactic Bulge Time Domain
+          Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
+          High-Latitude Wide-Area Survey (HLWA), observational research
+          program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
+          and Control (WFSC). All subcategories belong to only a subset of
+          the meta.program.category values.
+        anyOf:
+          - type: string
+            enum:
+              [
+                "CAL",
+                "CGI",
+                "CR",
+                "DR",
+                "GBTD",
+                "HLTD",
+                "HLWA",
+                "OR",
+                "WFI",
+                "WFSC",
+                "None",
+              ]
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(15)
+          destination:
+            [
+              WFIMosaic.program_subcategory,
+              SegmentationMap.program_subcategory,
+              SourceCatalog.program_subcategory,
+            ]
+      science_category:
+        title: Science Category
+        description: >
+          The science category assigned during the Time Allocation Committee (TAC) review process.
+        anyOf:
+          - type: string
+            maxLength: 50
+          - type: "null"
+        archive_catalog:
+          datatype: nvarchar(50)
+          destination:
+            [
+              WFIMosaic.science_category,
+              SegmentationMap.science_category,
+              SourceCatalog.science_category,
+            ]
+    required:
+      [title, investigator_name, category, subcategory, science_category]
+
+  statistics:
+    title: Basic Statistical Information
+    properties:
+      image_median:
+        title: Median Image Value (MJy/sr)
+        description: >
+          Median image value in units of megaJanskys per steradian (MJy/sr).
+        type: number
+      image_rms:
+        title: Image Mean Absolute Deviation (MJy/sr)
+        description: >
+          Mean absolute deviation of the image values in
+          units of megaJanskys per steradian (MJy/sr).
+        type: number
+      good_pixel_fraction:
+        title: Fraction of Good Pixels
+        description: >
+          The fraction of pixels in the output image that
+          are considered good.
+        type: number
+    required: [image_median, image_rms, good_pixel_fraction]
+required:
+  [
+    calibration_software_name,
+    calibration_software_version,
+    filename,
+    file_date,
+    model_type,
+    product_type,
+    origin,
+    telescope,
+  ]

--- a/src/rad/resources/schemas/meta/l3_common-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/l3_common-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/l3_common.yaml

--- a/src/rad/resources/schemas/meta/program-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/program-2.0.0.yaml
@@ -1,1 +1,128 @@
-../../../../../latest/meta/program.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+
+title: Program Information
+type: object
+properties:
+  title:
+    title: Proposal Title
+    description: |
+      The submitted proposal title of the program.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_visit.template
+    maxLength: 200
+    archive_catalog:
+      datatype: nvarchar(200)
+      destination:
+        [
+          WFIExposure.program_title,
+          SourceCatalog.program_title,
+          SegmentationMap.program_title,
+        ]
+  investigator_name:
+    title: Principal Investigator Name
+    description: |
+      The name of the principle investigator (PI) of the
+      program.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 100
+    archive_catalog:
+      datatype: nvarchar(100)
+      destination:
+        [
+          WFIExposure.investigator_name,
+          SourceCatalog.investigator_name,
+          SegmentationMap.investigator_name,
+        ]
+  category:
+    title: Program Category
+    description: |
+      The submitted proposal category of the program. The
+      categories include calibration (CAL), core community survey
+      (CCS), coronagraph technology demonstration (CGI), observatory
+      commissioning (COM), engineering (ENG), general astrophysics
+      survey (GAS), general investigator (GI), and observing conducted
+      at the direction of the National Aeronautics and Space
+      Administration (NASA).
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_program.category
+    maxLength: 6
+    archive_catalog:
+      datatype: nvarchar(6)
+      destination:
+        [
+          WFIExposure.program_category,
+          SourceCatalog.program_category,
+          SegmentationMap.program_category,
+        ]
+  subcategory:
+    title: Program Subcategory
+    description: |
+      The submitted proposal subcategory of the program. The
+      subcategories include calibration (CAL), coronagraph technology
+      demonstration (CGI), community research programs (CR),
+      discretionary research programs (DR), Galactic Bulge Time Domain
+      Survey (GBTD), High-Latitude Time Domain Survey (HLTD),
+      High-Latitude Wide-Area Survey (HLWA), observational research
+      program (OR), Wide Field Instrument (WFI), and Wavefront Sensing
+      and Control (WFSC). All subcategories belong to only a subset of
+      the meta.program.category values.
+    type: string
+    enum:
+      [
+        "CAL",
+        "CGI",
+        "CR",
+        "DR",
+        "GBTD",
+        "HLTD",
+        "HLWA",
+        "OR",
+        "WFI",
+        "WFSC",
+        "None",
+      ]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_program.subcategory
+    archive_catalog:
+      datatype: nvarchar(15)
+      destination:
+        [
+          WFIExposure.program_subcategory,
+          SourceCatalog.program_subcategory,
+          SegmentationMap.program_subcategory,
+        ]
+  science_category:
+    title: Science Category
+    description: |
+      The science category assigned during the Time
+      Allocation Committee (TAC) review process.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: PSS:dms_program.science_category
+    maxLength: 50
+    archive_catalog:
+      datatype: nvarchar(50)
+      destination:
+        [
+          WFIExposure.science_category,
+          SourceCatalog.science_category,
+          SegmentationMap.science_category,
+        ]
+required: [title, investigator_name, category, subcategory, science_category]

--- a/src/rad/resources/schemas/meta/program-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/program-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/program.yaml

--- a/src/rad/resources/schemas/mosaic_segmentation_map-2.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_segmentation_map-2.0.0.yaml
@@ -1,1 +1,35 @@
-../../../../latest/mosaic_segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.0.0
+
+title: Segmentation map generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: MosaicSegmentationMapModel
+
+archive_meta: Science WFI Level 4 Segmentation Map L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-2.0.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-2.0.0
+        required: [association, cal_step, resample]
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/mosaic_segmentation_map-2.1.0.yaml
+++ b/src/rad/resources/schemas/mosaic_segmentation_map-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_segmentation_map.yaml

--- a/src/rad/resources/schemas/mosaic_source_catalog-2.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-2.0.0.yaml
@@ -1,1 +1,34 @@
-../../../../latest/mosaic_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.0.0
+
+title: Source catalog generated from a Level 3 file by the Source Catalog Step.
+
+datamodel_name: MosaicSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-2.0.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-2.0.0
+        required: [association, cal_step, resample]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/prompt_catalog_table-2.0.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/mosaic_source_catalog-2.1.0.yaml
+++ b/src/rad/resources/schemas/mosaic_source_catalog-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/mosaic_source_catalog.yaml

--- a/src/rad/resources/schemas/msos_stack-2.0.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-2.0.0.yaml
@@ -1,1 +1,62 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          image_list:
+            type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  psf:
+    title: Point Spread Function
+    description: |
+      PSF array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage, psf]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage, psf]

--- a/src/rad/resources/schemas/msos_stack-2.1.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/multiband_segmentation_map-2.0.0.yaml
+++ b/src/rad/resources/schemas/multiband_segmentation_map-2.0.0.yaml
@@ -1,1 +1,39 @@
-../../../../latest/multiband_segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.0.0
+
+title: Segmentation map generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSegmentationMapModel
+
+archive_meta: Science WFI Level 4 Multiband Segmentation Map L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+          psf_match_reference_filter:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-2.0.0
+            title: PSF-matched photometric filter
+            description: |
+              Reference band used to compute PSF-matched photometry.
+        required: [image_metas, psf_match_reference_filter]
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/multiband_segmentation_map-2.1.0.yaml
+++ b/src/rad/resources/schemas/multiband_segmentation_map-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_segmentation_map.yaml

--- a/src/rad/resources/schemas/multiband_source_catalog-2.0.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-2.0.0.yaml
@@ -1,1 +1,38 @@
-../../../../latest/multiband_source_catalog.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0
+
+title: Multiband source catalog generated from a Level 3 file by the Multiband Catalog Step.
+
+datamodel_name: MultibandSourceCatalogModel
+
+archive_meta: Science WFI Level 4 Multiband Source Catalog L3 Product
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0
+      - properties:
+          image_metas:
+            type: array
+            items:
+              $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+          psf_match_reference_filter:
+            allOf:
+              - $ref: asdf://stsci.edu/datamodels/roman/schemas/enums/wfi_optical_element-2.0.0
+            title: PSF-matched photometric filter
+            description: |
+              Reference band used to compute PSF-matched photometry.
+        required: [image_metas, psf_match_reference_filter]
+  source_catalog:
+    title: Source Catalog
+    description: |
+      Photometry and astrometry computed in the Source Catalog Step.
+    allOf:
+      - tag: tag:astropy.org:astropy/table/table-1.*
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/tables/multiband_catalog_table-2.0.0
+
+required: [meta, source_catalog]
+flowStyle: block
+propertyOrder: [meta, source_catalog]

--- a/src/rad/resources/schemas/multiband_source_catalog-2.1.0.yaml
+++ b/src/rad/resources/schemas/multiband_source_catalog-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/multiband_source_catalog.yaml

--- a/src/rad/resources/schemas/ramp-2.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-2.0.0.yaml
@@ -1,1 +1,187 @@
-../../../../latest/ramp.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+
+title: Ramp Schema
+
+datamodel_name: RampModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-2.0.0
+        required: [cal_step]
+  data:
+    title: Science Data Including Border Reference Pixels (DN, electrons)
+    description: |
+      Science Data Including Border Reference Pixels in units of DN or
+      electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
+  pixeldq:
+    title: Two Dimensional Data Quality Flags Array for Each Pixel
+    description: |
+      Two dimensional data quality flags array applying to all resultants in a
+      given pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+  groupdq:
+    title: Three-dimensional Data Quality Array For Each Resultant in Each Pixel
+    description: |
+      Three-dimensional data quality array indicating quality of each individual
+      resultant for each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+  amp33:
+    title: Amp 33 Reference Pixel Data (DN)
+    description: |
+      Amplifier 33 Reference Pixel Data in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_left:
+    title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Left of the Detector, from the instrument's
+      perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_right:
+    title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Right of the Detector, from the
+      instrument's perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Top of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_bottom:
+    title: Border Reference Pixels on the Bottom of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Bottom of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  dq_border_ref_pix_left:
+    title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Left Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Data Quality Flag for Border Reference Pixels, on the Right Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Right Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Data Quality Flag for Border Reference Pixels, on Top.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Data Quality Flag for Border Reference Pixels, on Bottom.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+    reset_read,
+    reset_amp33,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/ramp-2.1.0.yaml
+++ b/src/rad/resources/schemas/ramp-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp.yaml

--- a/src/rad/resources/schemas/segmentation_map-2.0.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-2.0.0.yaml
@@ -1,1 +1,25 @@
-../../../../latest/segmentation_map.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.0.0
+
+title: Segmentation map generated from a Level 2 file by the Source Catalog Step.
+
+datamodel_name: SegmentationMapModel
+
+archive_meta: Science WFI Level 4 Segmentation Map L2 Product
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_catalog_common-2.0.0
+  data:
+    title: Segmentation map
+    description: |
+      Segmentation map of an image model, zeros correspond to background.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+required: [meta, data]
+flowStyle: block
+propertyOrder: [meta, data]

--- a/src/rad/resources/schemas/segmentation_map-2.1.0.yaml
+++ b/src/rad/resources/schemas/segmentation_map-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/segmentation_map.yaml

--- a/src/rad/resources/schemas/wfi_image-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-2.0.0.yaml
@@ -1,1 +1,265 @@
-../../../../latest/wfi_image.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+
+title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: ImageModel
+archive_meta: Science WFI Level 2
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          background:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/sky_background-2.0.0
+          cal_logs:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-2.0.0
+          outlier_detection:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/outlier_detection-2.0.0
+          photometry:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-2.0.0
+          source_catalog:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/source_catalog-2.0.0
+          statistics:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/statistics-2.0.0
+          wcs:
+            title: WCS object
+            anyOf:
+              - tag: tag:stsci.edu:gwcs/wcs-*
+              - type: "null"
+
+        required: [photometry, wcs]
+  data:
+    title: Science Data (DN/s) or (MJy/sr)
+    description: |
+      Calibrated science rate image in units of data numbers
+      per second (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  dq:
+    title: Data Quality
+    description: |
+      Bitwise sum of data quality flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Error (DN / s) or (MJy / sr)
+    description: |
+      Total error array in units of data numbers per second
+      (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  var_poisson:
+    title: Poisson Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to Poisson
+      noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_rnoise:
+    title: Read Noise Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to detector
+      read noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_flat:
+    title: Flat Field Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to the flat
+      field in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  chisq:
+    title: Chi-squared of Ramp Fit
+    description: |
+      Chi-squared statistic of the ramp fit (unitless).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+  dumo:
+    title: Difference Uniform Minus Optimal (DN / s) or (MJy / sr)
+    description: |
+      Ramp fit with uniform weights minus ramp fit with optimal weights
+      in units of data numbers per second (DN/s) or megaJanskys per
+      steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DN).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_left:
+    title: Left-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the left-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, :4] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_right:
+    title: Right-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the right-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, 4092:] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border reference pixels on the top of the detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the bottom-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :4, :] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  dq_border_ref_pix_left:
+    title: Left-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the left-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, :4] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Right-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the right-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, 4092:] in a
+      zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Border Reference Pixel Data Quality on the Top of the Detector (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the top-edge of the detector in
+      the science frame orientation. In the L1 uncal file data array,
+      these are pixels (z, y, x) = [:, 4092:, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the bottom-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :4, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+propertyOrder:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    var_rnoise,
+    var_flat,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/wfi_image-2.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_image.yaml

--- a/src/rad/resources/schemas/wfi_mosaic-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-2.0.0.yaml
@@ -1,1 +1,100 @@
-../../../../latest/wfi_mosaic.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0
+
+title: The schema for WFI Level 3 mosaics.
+
+datamodel_name: MosaicModel
+archive_meta: Science WFI Level 3
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0
+      - required:
+          [
+            cal_logs,
+            coadd_info,
+            coordinates,
+            individual_image_meta,
+            instrument,
+            observation,
+            program,
+            statistics,
+          ]
+      - properties:
+          association:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_association-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_cal_step-2.0.0
+          resample:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_resample-2.0.0
+          wcs:
+            title: World Coordinate System (WCS)
+            tag: tag:stsci.edu:gwcs/wcs-*
+          wcsinfo:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l3_wcsinfo-2.0.0
+        required: [association, cal_step, resample, wcs, wcsinfo]
+  data:
+    title: Science Data (MJy / steradian)
+    description: |
+      The science data array, excluding the border reference pixels in units of
+      MJy / steradian.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy.sr**-1"
+  err:
+    title: Error Data (MJy / steradian)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy.sr**-1"
+  context:
+    title: Context Data
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 3
+  weight:
+    title: Weight Data
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+  var_poisson:
+    title: Poisson Variability (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_rnoise:
+    title: Read Noise Variance (MJy^2 / steradian^2
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_flat:
+    title: Flat Field Variance (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+  var_sky:
+    title: Sky Variance (MJy^2 / steradian^2)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: "MJy**2.sr**-2"
+propertyOrder:
+  [meta, data, context, err, weight, var_poisson, var_rnoise, var_flat, var_sky]
+flowStyle: block
+required: [meta, data, context, err, weight, var_poisson, var_rnoise]

--- a/src/rad/resources/schemas/wfi_mosaic-2.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_mosaic.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-2.0.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: Science WFI Level 1
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+  reference_read:
+    title: Reference Read (DN)
+    description: |
+      Reference read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reference read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reference_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reference Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reference read. This array is only present if a reference
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reference_read, reference_amp33]
+flowStyle: block
+required: [meta, data, amp33]

--- a/src/rad/resources/schemas/wfi_science_raw-2.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/src/rad/resources/schemas/wfi_wcs-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-2.0.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_wcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-2.0.0
+      - type: object
+        properties:
+          coordinates:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
+          ephemeris:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+          exposure:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
+          instrument:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-2.0.0
+          observation:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-2.0.0
+          pointing:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
+          program:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+          velocity_aberration:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-2.0.0
+          visit:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-2.0.0
+          wcsinfo:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-2.0.0
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
+        required:
+          [
+            coordinates,
+            ephemeris,
+            exposure,
+            instrument,
+            observation,
+            pointing,
+            program,
+            velocity_aberration,
+            visit,
+            wcsinfo,
+          ]
+  wcs_l2:
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta]

--- a/src/rad/resources/schemas/wfi_wcs-2.1.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_wcs.yaml

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,6 +20,7 @@ METADATA_FORCE_XFAILS = (
 VARCHAR_XFAILS = (
     # <resource uri>
     "asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0",
 )
 
 REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-2.0.0",)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -21,6 +21,7 @@ VARCHAR_XFAILS = (
     # <resource uri>
     "asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0",
     "asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.1.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0",
 )
 
 REF_COMMON_XFAILS = ("asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-2.0.0",)
@@ -32,10 +33,13 @@ ARRAY_TAG_XFAILS = (
 REQUIRED_SKIPS = (
     "asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-1.7.0",
     "asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-1.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.0.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_catalog_common-2.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-1.2.0",
     "asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/CCSP/EXAMPLE/example_custom_product-1.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/CCSP/EXAMPLE/example_custom_product-2.0.0",
 )
@@ -43,6 +47,7 @@ REQUIRED_SKIPS = (
 NESTED_REQUIRED_SKIPS = (
     "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-1.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.0.0",
+    "asdf://stsci.edu/datamodels/roman/schemas/meta/l3_common-2.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/CCSP/ccsp_custom_product-1.1.0",
     "asdf://stsci.edu/datamodels/roman/schemas/CCSP/ccsp_custom_product-2.0.0",
 )


### PR DESCRIPTION
Closes #889

Removes the subcategory enums in program and l3_common.

Regression tests:
https://github.com/spacetelescope/RegressionTests/actions/runs/28548621560
show 2 expected differences for tvac data where subcategory is `?` with this PR instead of `CAL` on main (both from the use of `create_fake_data` in processing tvac data).

## Tasks

- [ ] Update or add relevant `rad` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [ ] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
