### PR TITLE
Add DEFAULT to ephemeris.type schema

### DIFF
--- a/changes/900.feature.rst
+++ b/changes/900.feature.rst
@@ -1,0 +1,1 @@
+Add DEFAULT as an allowed value of the ephemeris type.

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -14,7 +14,7 @@ allOf:
       coordinates:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
       ephemeris:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.1.0
       exposure:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
       guide_star:

--- a/latest/meta/ephemeris.yaml
+++ b/latest/meta/ephemeris.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.1.0
 
 title: Ephemeris Data Information
 type: object
@@ -22,9 +22,9 @@ properties:
   type:
     title: Ephemeris Type
     description: |
-      Type of ephemeris (either DEFINITIVE or PREDICTED).
+      Type of ephemeris (DEFINITIVE, PREDICTED, or DEFAULT).
     type: string
-    enum: [DEFINITIVE, PREDICTED]
+    enum: [DEFINITIVE, PREDICTED, DEFAULT]
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -17,7 +17,7 @@ properties:
           coordinates:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
           ephemeris:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.1.0
           exposure:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
           instrument:

--- a/src/rad/resources/schemas/meta/ephemeris-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/ephemeris-2.0.0.yaml
@@ -1,1 +1,140 @@
-../../../../../latest/meta/ephemeris.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+
+title: Ephemeris Data Information
+type: object
+properties:
+  ephemeris_reference_frame:
+    title: Ephemeris Reference Frame
+    description: |
+      Reference frame of the ephemeris information.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.ephemeris_reference_frame]
+  type:
+    title: Ephemeris Type
+    description: |
+      Type of ephemeris (either DEFINITIVE or PREDICTED).
+    type: string
+    enum: [DEFINITIVE, PREDICTED]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.ephemeris_type]
+  time:
+    title: UTC Time of Ephemeris Information (MJD)
+    description: |
+      UTC time of the position and velocity vectors in the
+      ephemeris. The time is provided in modified Julian date (MJD).
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.ephemeris_time]
+  spatial_x:
+    title: X Spatial Coordinate of Roman (km)
+    description: |
+      X barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_x]
+  spatial_y:
+    title: Y Spatial Coordinate of Roman (km)
+    description: |
+      Y barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_y]
+  spatial_z:
+    title: Z Spatial Coordinate of Roman (km)
+    description: |
+      Z barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_z]
+  velocity_x:
+    title: X Component of Roman Velocity (km/s)
+    description: |
+      X component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_x]
+  velocity_y:
+    title: Y Component of Roman Velocity (km/s)
+    description: |
+      Y component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_y]
+  velocity_z:
+    title: Z Component of Roman Velocity (km/s)
+    description: |
+      Y component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_z]
+required:
+  [
+    type,
+    time,
+    ephemeris_reference_frame,
+    spatial_x,
+    spatial_y,
+    spatial_z,
+    velocity_x,
+    velocity_y,
+    velocity_z,
+  ]

--- a/src/rad/resources/schemas/meta/ephemeris-2.1.0.yaml
+++ b/src/rad/resources/schemas/meta/ephemeris-2.1.0.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/ephemeris.yaml


### PR DESCRIPTION
Mark Kyprianou and @tddesjardins have requested that we add DEFAULT to the allowed values for ephemeris.type, alongside DEFINITIVE and PREDICTED.  This PR addresses that.  It also bumps the relevant schemas.

This is the minimal patch needed to support this feature for B22.2.  #899 is a more complete attempt to eliminate some potentially overly strict enums, but we should not include it in a patch release, and it will need some merging work in order to accommodate this PR.

Regression test here is all green: https://github.com/spacetelescope/RegressionTests/actions/runs/30565362485

## Tasks

- [X] Update relevant docstrings and / or `docs/` page.
- [X] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [X] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [X] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [X] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [x] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change

</details
