### PR TITLE
Add DEFAULT to ephemeris.type to release 1.0 as a patch release

### DIFF
--- a/changes/901.feature.rst
+++ b/changes/901.feature.rst
@@ -1,0 +1,1 @@
+Add DEFAULT as an allowed value of the ephemeris type.

--- a/latest/manifests/datamodels.yaml
+++ b/latest/manifests/datamodels.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.0.0
-extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.0.0
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.0.1
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.0.1
 title: Datamodels extension
 description: |-
   A set of tags for serializing STScI Roman datamodels.
@@ -19,18 +19,18 @@ tags:
     title: Level 1 Detector Guide Star Window Information schema
     description: |-
       Level 1 Detector Guide Star Window Information schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.0.1
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.1
     title: Ramp schema
     description: |-
       Ramp schema
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.0.1
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.1
     title: Roman WFI Raw Science Data datamodel
     description: |-
       Basic Roman Raw Science
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.0.1
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.1
     title: Wfi level 2 image information
     description: |-
       Wfi level 2 image information
@@ -39,8 +39,8 @@ tags:
     title: Wfi level 3 mosaic information
     description: |-
       Wfi level 3 mosaic information
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.0.1
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.1
     title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
     description: |-
       Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
@@ -204,8 +204,8 @@ tags:
     description: |-
       Photometry and astrometry computed by the Source Catalog Step
   # SSC data models
-  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.0.0
-    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.0.1
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.1
     title: MSOS Stack Level 3 Schema
     description: |-
       Level 3 schema for SSC's MSOS stack products

--- a/latest/meta/common.yaml
+++ b/latest/meta/common.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.1
 
 title: Common metadata properties
 
@@ -14,7 +14,7 @@ allOf:
       coordinates:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
       ephemeris:
-        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.1
       exposure:
         $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
       guide_star:

--- a/latest/meta/ephemeris.yaml
+++ b/latest/meta/ephemeris.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.1
 
 title: Ephemeris Data Information
 type: object
@@ -22,9 +22,9 @@ properties:
   type:
     title: Ephemeris Type
     description: |
-      Type of ephemeris (either DEFINITIVE or PREDICTED).
+      Type of ephemeris (DEFINITIVE, PREDICTED, or DEFAULT).
     type: string
-    enum: [DEFINITIVE, PREDICTED]
+    enum: [DEFINITIVE, PREDICTED, DEFAULT]
     sdf:
       special_processing: VALUE_REQUIRED
       source:

--- a/latest/msos_stack.yaml
+++ b/latest/msos_stack.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.1
 
 title: |
   MSOS Stack Level 3 Schema
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.1
       - type: object
         properties:
           image_list:

--- a/latest/ramp.yaml
+++ b/latest/ramp.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.1
 
 title: Ramp Schema
 
@@ -11,7 +11,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.1
       - type: object
         properties:
           cal_step:

--- a/latest/wfi_image.yaml
+++ b/latest/wfi_image.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.1
 
 title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -12,7 +12,7 @@ type: object
 properties:
   meta:
     allOf:
-      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.1
       - type: object
         properties:
           background:

--- a/latest/wfi_science_raw.yaml
+++ b/latest/wfi_science_raw.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.1
 
 title: |
   Level 1 (L1) Uncalibrated Roman Wide Field
@@ -14,7 +14,7 @@ archive_meta: Science WFI Level 1
 type: object
 properties:
   meta:
-    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.1
   data:
     title: Science Data (DN)
     description: |

--- a/latest/wfi_wcs.yaml
+++ b/latest/wfi_wcs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
-id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.1
 
 title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
 
@@ -17,7 +17,7 @@ properties:
           coordinates:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
           ephemeris:
-            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.1
           exposure:
             $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
           instrument:

--- a/src/rad/resources/manifests/datamodels-2.0.0.yaml
+++ b/src/rad/resources/manifests/datamodels-2.0.0.yaml
@@ -1,1 +1,211 @@
-../../../../latest/manifests/datamodels.yaml
+%YAML 1.1
+---
+id: asdf://stsci.edu/datamodels/roman/manifests/datamodels-2.0.0
+extension_uri: asdf://stsci.edu/datamodels/roman/extensions/datamodels-2.0.0
+title: Datamodels extension
+description: |-
+  A set of tags for serializing STScI Roman datamodels.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+  # Object Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_face_guidewindow-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_face_guidewindow-2.0.0
+    title: Level 1 FACE Guide Star Window Information schema
+    description: |-
+      Level 1 FACE Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/l1_detector_guidewindow-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/l1_detector_guidewindow-2.0.0
+    title: Level 1 Detector Guide Star Window Information schema
+    description: |-
+      Level 1 Detector Guide Star Window Information schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/ramp-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+    title: Ramp schema
+    description: |-
+      Ramp schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_science_raw-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+    title: Roman WFI Raw Science Data datamodel
+    description: |-
+      Basic Roman Raw Science
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_image-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+    title: Wfi level 2 image information
+    description: |-
+      Wfi level 2 image information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_mosaic-2.0.0
+    title: Wfi level 3 mosaic information
+    description: |-
+      Wfi level 3 mosaic information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/wfi_wcs-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+    title: Roman Wide Field Instrument (WFI) Level 2 (L2) WCS
+    description: |-
+      Roman Wide Field Instrument (WFI) Level 2 (L2) WCS and
+      modified WCS applicable for Science Raw (L1).
+  # Reference Modules
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/abvegaoffset-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/abvegaoffset-2.0.0
+    title: AB Vega Offset reference schema
+    description: |-
+      AB Vega Offset reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/apcorr-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/apcorr-2.0.0
+    title: Aperture correction reference schema
+    description: |-
+      Aperture correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/dark-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/dark-2.0.0
+    title: Dark reference schema
+    description: |-
+      Dark reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/detectorstatus-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/detectorstatus-2.0.0
+    title: Detector Status reference schema
+    description: |-
+      Reference file that is a summary for the current status of each WFI detector to support prompt processing.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/darkdecaysignal-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/darkdecaysignal-2.0.0
+    title: Dark Decay Signal Reference File Schema
+    description: |-
+      Dark decay reference file contains the residual signal properties for each WFI detector
+      that can be removed by an exponentially decreasing signal of DN with respect to time.
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/distortion-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/distortion-2.0.0
+    title: Distortion reference schema
+    description: |-
+      Distortion reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/epsf-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/epsf-2.0.0
+    title: ePSF reference schema
+    description: |-
+      ePSF reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/etc-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/etc-2.0.0
+    title: Exposure Time Calculator Reference File Schema
+    description: |-
+      Exposure Time Calculator Reference File Schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/flat-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/flat-2.0.0
+    title: Flat reference schema
+    description: |-
+      Flat field information
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/gain-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/gain-2.0.0
+    title: Gain reference schema
+    description: |-
+      Gain reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/integralnonlinearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/integralnonlinearity-2.0.0
+    title: Integral nonlinearity correction reference schema
+    description: |-
+      Integral nonlinearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/inverselinearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/inverselinearity-2.0.0
+    title: Inverse linearity correction reference schema
+    description: |-
+      Inverse linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/ipc-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/ipc-2.0.0
+    title: IPC kernel reference schema
+    description: |-
+      IPC kernel reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/linearity-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/linearity-2.0.0
+    title: Linearity correction reference schema
+    description: |-
+      Linearity correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/mask-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/mask-2.0.0
+    title: DQ Mask reference schema
+    description: |-
+      DQ Mask reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/pixelarea-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/pixelarea-2.0.0
+    title: Pixel area reference schema
+    description: |-
+      Pixel area reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/readnoise-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/readnoise-2.0.0
+    title: Read noise reference schema
+    description: |-
+      Read noise reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/refpix-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/refpix-2.0.0
+    title: Reference pixel correction reference schema
+    description: |-
+      Reference pixel correction reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/saturation-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/saturation-2.0.0
+    title: Saturation reference schema
+    description: |-
+      Saturation reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/superbias-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/superbias-2.0.0
+    title: Super-bias reference schema
+    description: |-
+      Super-bias reference schema
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/wfi_img_photom-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/wfi_img_photom-2.0.0
+    title: WFI imaging photometric flux conversion data model
+    description: |-
+      WFI imaging photometric flux conversion data model
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/skycells-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/skycells-2.0.0
+    title: Skycells Reference File Schema
+    description: |-
+      This file contains definitions for all the skycells that cover the entire celestial sphere
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/reference_files/matable-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/reference_files/matable-2.0.0
+    title: Multiple Accumulation Table Reference File Schema
+    description: |-
+      Multiple Accumulation Table Reference File Schema
+  # Misc
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/image_source_catalog-2.0.0
+    title: Image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/segmentation_map-2.0.0
+    title: Segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_source_catalog-2.0.0
+    title: Mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_source_catalog-2.0.0
+    title: Multiband source catalog
+    description: |-
+      Photometry and astrometry computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/mosaic_segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-2.0.0
+    title: Mosaic segmentation map
+    description: |-
+      Segmentation map computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/multiband_segmentation_map-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-2.0.0
+    title: Multiband segmentation map
+    description: |-
+      Segmentation map computed by the Multiband Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_image_source_catalog-2.0.0
+    title: Forced image source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/forced_mosaic_source_catalog-2.0.0
+    title: Forced mosaic source catalog
+    description: |-
+      Photometry and astrometry computed by the Source Catalog Step
+  # SSC data models
+  - tag_uri: asdf://stsci.edu/datamodels/roman/tags/msos_stack-2.0.0
+    schema_uri: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+    title: MSOS Stack Level 3 Schema
+    description: |-
+      Level 3 schema for SSC's MSOS stack products

--- a/src/rad/resources/manifests/datamodels-2.0.1.yaml
+++ b/src/rad/resources/manifests/datamodels-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/manifests/datamodels.yaml

--- a/src/rad/resources/schemas/meta/common-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/common-2.0.0.yaml
@@ -1,1 +1,55 @@
-../../../../../latest/meta/common.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+
+title: Common metadata properties
+
+allOf:
+  # Meta Variables
+  - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-2.0.0
+  - type: object
+    properties:
+      # Meta Objects
+      coordinates:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
+      ephemeris:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+      exposure:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
+      guide_star:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/guidestar-2.0.0
+      instrument:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-2.0.0
+      observation:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-2.0.0
+      pointing:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
+      program:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+      ref_file:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ref_file-2.0.0
+      rcs:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/rcs-2.0.0
+      velocity_aberration:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-2.0.0
+      visit:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-2.0.0
+      wcsinfo:
+        $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-2.0.0
+    required:
+      [
+        coordinates,
+        ephemeris,
+        exposure,
+        guide_star,
+        instrument,
+        observation,
+        pointing,
+        program,
+        ref_file,
+        rcs,
+        velocity_aberration,
+        visit,
+        wcsinfo,
+      ]

--- a/src/rad/resources/schemas/meta/common-2.0.1.yaml
+++ b/src/rad/resources/schemas/meta/common-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/common.yaml

--- a/src/rad/resources/schemas/meta/ephemeris-2.0.0.yaml
+++ b/src/rad/resources/schemas/meta/ephemeris-2.0.0.yaml
@@ -1,1 +1,140 @@
-../../../../../latest/meta/ephemeris.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+
+title: Ephemeris Data Information
+type: object
+properties:
+  ephemeris_reference_frame:
+    title: Ephemeris Reference Frame
+    description: |
+      Reference frame of the ephemeris information.
+    type: string
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    maxLength: 10
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.ephemeris_reference_frame]
+  type:
+    title: Ephemeris Type
+    description: |
+      Type of ephemeris (either DEFINITIVE or PREDICTED).
+    type: string
+    enum: [DEFINITIVE, PREDICTED]
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: TBD
+    archive_catalog:
+      datatype: nvarchar(10)
+      destination: [WFIExposure.ephemeris_type]
+  time:
+    title: UTC Time of Ephemeris Information (MJD)
+    description: |
+      UTC time of the position and velocity vectors in the
+      ephemeris. The time is provided in modified Julian date (MJD).
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.ephemeris_time]
+  spatial_x:
+    title: X Spatial Coordinate of Roman (km)
+    description: |
+      X barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_x]
+  spatial_y:
+    title: Y Spatial Coordinate of Roman (km)
+    description: |
+      Y barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_y]
+  spatial_z:
+    title: Z Spatial Coordinate of Roman (km)
+    description: |
+      Z barycentric coordinate of the Roman observatory at
+      the MJD described by meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.spatial_z]
+  velocity_x:
+    title: X Component of Roman Velocity (km/s)
+    description: |
+      X component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_x]
+  velocity_y:
+    title: Y Component of Roman Velocity (km/s)
+    description: |
+      Y component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_y]
+  velocity_z:
+    title: Z Component of Roman Velocity (km/s)
+    description: |
+      Y component of the Roman velocity in a barycentric
+      system in units of km/s at the MJD described by
+      meta.ephemeris.time.
+    type: number
+    sdf:
+      special_processing: VALUE_REQUIRED
+      source:
+        origin: Roman Science Data Processing (RSDP)
+    archive_catalog:
+      datatype: float
+      destination: [WFIExposure.velocity_z]
+required:
+  [
+    type,
+    time,
+    ephemeris_reference_frame,
+    spatial_x,
+    spatial_y,
+    spatial_z,
+    velocity_x,
+    velocity_y,
+    velocity_z,
+  ]

--- a/src/rad/resources/schemas/meta/ephemeris-2.0.1.yaml
+++ b/src/rad/resources/schemas/meta/ephemeris-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../../latest/meta/ephemeris.yaml

--- a/src/rad/resources/schemas/msos_stack-2.0.0.yaml
+++ b/src/rad/resources/schemas/msos_stack-2.0.0.yaml
@@ -1,1 +1,62 @@
-../../../../latest/msos_stack.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/msos_stack-2.0.0
+
+title: |
+  MSOS Stack Level 3 Schema
+
+datamodel_name: MsosStackModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          image_list:
+            type: string
+  data:
+    title: Flux Data
+    description: |
+      Flux array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  uncertainty:
+    title: Uncertainty Data
+    description: |
+      Uncertainty array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+  mask:
+    title: Mask Data
+    description: |
+      Mask array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  coverage:
+    title: Coverage Data
+    description: |
+      Coverage array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint8
+    exact_datatype: true
+    ndim: 2
+  psf:
+    title: Point Spread Function
+    description: |
+      PSF array of stacked image data.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float64
+    exact_datatype: true
+    ndim: 2
+propertyOrder: [meta, data, uncertainty, mask, coverage, psf]
+flowStyle: block
+required: [meta, data, uncertainty, mask, coverage, psf]

--- a/src/rad/resources/schemas/msos_stack-2.0.1.yaml
+++ b/src/rad/resources/schemas/msos_stack-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/msos_stack.yaml

--- a/src/rad/resources/schemas/ramp-2.0.0.yaml
+++ b/src/rad/resources/schemas/ramp-2.0.0.yaml
@@ -1,1 +1,187 @@
-../../../../latest/ramp.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/ramp-2.0.0
+
+title: Ramp Schema
+
+datamodel_name: RampModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-2.0.0
+        required: [cal_step]
+  data:
+    title: Science Data Including Border Reference Pixels (DN, electrons)
+    description: |
+      Science Data Including Border Reference Pixels in units of DN or
+      electrons.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: ["DN", "electron"]
+    exact_datatype: true
+
+  pixeldq:
+    title: Two Dimensional Data Quality Flags Array for Each Pixel
+    description: |
+      Two dimensional data quality flags array applying to all resultants in a
+      given pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint32
+    exact_datatype: true
+  groupdq:
+    title: Three-dimensional Data Quality Array For Each Resultant in Each Pixel
+    description: |
+      Three-dimensional data quality array indicating quality of each individual
+      resultant for each pixel.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+  amp33:
+    title: Amp 33 Reference Pixel Data (DN)
+    description: |
+      Amplifier 33 Reference Pixel Data in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_left:
+    title: Border Reference Pixels on the Left of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Left of the Detector, from the instrument's
+      perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_right:
+    title: Border Reference Pixels on the Right of the Detector, from the Instrument's Perspective (DN)
+    description: |
+      Border Reference Pixels on the Right of the Detector, from the
+      instrument's perspective in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Top of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  border_ref_pix_bottom:
+    title: Border Reference Pixels on the Bottom of the Detector (DN)
+    description: |
+      Border Reference Pixels on the Bottom of the Detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: float32
+    unit: "DN"
+    exact_datatype: true
+  dq_border_ref_pix_left:
+    title: Data Quality Flag for Border Reference Pixels, on the Left Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Left Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Data Quality Flag for Border Reference Pixels, on the Right Edge of the Detector from the Instrument Perspective
+    description: |
+      Data Quality Flag for Border Reference Pixels, on the Right Edge of the
+      Detector from the Instrument Perspective.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Data Quality Flag for Border Reference Pixels, on Top.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Top.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Data Quality Flag for Border Reference Pixels, on Bottom.
+    description: |
+      Data Quality Flag for Border Reference Pixels, on Bottom.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+
+  reset_read:
+    title: Reset Read (DN)
+    description: |
+      Reset read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reset read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reset_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reset Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reset read. This array is only present if a reset
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+    reset_read,
+    reset_amp33,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    pixeldq,
+    groupdq,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/ramp-2.0.1.yaml
+++ b/src/rad/resources/schemas/ramp-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/ramp.yaml

--- a/src/rad/resources/schemas/wfi_image-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_image-2.0.0.yaml
@@ -1,1 +1,265 @@
-../../../../latest/wfi_image.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_image-2.0.0
+
+title: Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: ImageModel
+archive_meta: Science WFI Level 2
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+      - type: object
+        properties:
+          background:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/sky_background-2.0.0
+          cal_logs:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/cal_logs-2.0.0
+          cal_step:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/l2_cal_step-2.0.0
+          outlier_detection:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/outlier_detection-2.0.0
+          photometry:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/photometry-2.0.0
+          source_catalog:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/source_catalog-2.0.0
+          statistics:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/statistics-2.0.0
+          wcs:
+            title: WCS object
+            anyOf:
+              - tag: tag:stsci.edu:gwcs/wcs-*
+              - type: "null"
+
+        required: [photometry, wcs]
+  data:
+    title: Science Data (DN/s) or (MJy/sr)
+    description: |
+      Calibrated science rate image in units of data numbers
+      per second (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  dq:
+    title: Data Quality
+    description: |
+      Bitwise sum of data quality flags.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  err:
+    title: Error (DN / s) or (MJy / sr)
+    description: |
+      Total error array in units of data numbers per second
+      (DN/s) or megaJanskys per steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  var_poisson:
+    title: Poisson Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to Poisson
+      noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_rnoise:
+    title: Read Noise Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to detector
+      read noise in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  var_flat:
+    title: Flat Field Variance (DN^2/s^2) or (MJy^2/sr^2)
+    description: |
+      Component of the per pixel variance due to the flat
+      field in units of data numbers squared per second squared
+      (DN^2/s^2) or megaJanskys squared per square steradian
+      (MJy^2/sr^2).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN2 / s2", "MJy**2.sr**-2"]
+  chisq:
+    title: Chi-squared of Ramp Fit
+    description: |
+      Chi-squared statistic of the ramp fit (unitless).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+  dumo:
+    title: Difference Uniform Minus Optimal (DN / s) or (MJy / sr)
+    description: |
+      Ramp fit with uniform weights minus ramp fit with optimal weights
+      in units of data numbers per second (DN/s) or megaJanskys per
+      steradian (MJy/sr).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float16
+    exact_datatype: true
+    ndim: 2
+    unit: ["DN / s", "MJy.sr**-1"]
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DN).
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint16
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_left:
+    title: Left-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the left-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, :4] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_right:
+    title: Right-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the right-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :, 4092:] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_top:
+    title: Border Reference Pixels on the Top of the Detector (DN)
+    description: |
+      Border reference pixels on the top of the detector in units of DN.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixels (DN)
+    description: |
+      Uncalibrated, four-pixel border reference pixel cube
+      from the bottom-edge of the detector in the science frame
+      orientation. In the L1 uncal file data array, these are pixels
+      (z, y, x) = [:, :4, :] in a zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: float32
+    exact_datatype: true
+    ndim: 3
+    unit: "DN"
+  dq_border_ref_pix_left:
+    title: Left-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the left-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, :4] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_right:
+    title: Right-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the right-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :, 4092:] in a
+      zero-indexed system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_top:
+    title: Border Reference Pixel Data Quality on the Top of the Detector (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the top-edge of the detector in
+      the science frame orientation. In the L1 uncal file data array,
+      these are pixels (z, y, x) = [:, 4092:, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+  dq_border_ref_pix_bottom:
+    title: Bottom-Edge Border Reference Pixel Data Quality (DN)
+    description: |
+      Bitwise sum of data quality flags for the four-pixel
+      border reference pixel cube from the bottom-edge of the detector
+      in the science frame orientation. In the L1 uncal file data
+      array, these are pixels (z, y, x) = [:, :4, :] in a zero-indexed
+      system.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    datatype: uint32
+    exact_datatype: true
+    ndim: 2
+propertyOrder:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    var_rnoise,
+    var_flat,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]
+flowStyle: block
+required:
+  [
+    meta,
+    data,
+    dq,
+    err,
+    var_poisson,
+    chisq,
+    dumo,
+    amp33,
+    border_ref_pix_left,
+    border_ref_pix_right,
+    border_ref_pix_top,
+    border_ref_pix_bottom,
+    dq_border_ref_pix_left,
+    dq_border_ref_pix_right,
+    dq_border_ref_pix_top,
+    dq_border_ref_pix_bottom,
+  ]

--- a/src/rad/resources/schemas/wfi_image-2.0.1.yaml
+++ b/src/rad/resources/schemas/wfi_image-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_image.yaml

--- a/src/rad/resources/schemas/wfi_science_raw-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-2.0.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_science_raw.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_science_raw-2.0.0
+
+title: |
+  Level 1 (L1) Uncalibrated Roman Wide Field
+  Instrument (WFI) Ramp Cube
+
+datamodel_name: ScienceRawModel
+
+archive_meta: Science WFI Level 1
+
+type: object
+properties:
+  meta:
+    $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/common-2.0.0
+  data:
+    title: Science Data (DN)
+    description: |
+      Uncalibrated science ramp cube in units of data
+      numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  amp33:
+    title: Amplifier 33 Reference Pixel Data (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of
+      data numbers (DNs)
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  resultantdq:
+    title: Resultant Data Quality Array
+    description: |
+      Optional, 3-D data quality array with a plane for each
+      resultant.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 3
+    datatype: uint8
+    exact_datatype: true
+
+  reference_read:
+    title: Reference Read (DN)
+    description: |
+      Reference read in units of data numbers (DNs) subtracted
+      from subsequent reads up-the-ramp. This array is only present
+      if a reference read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+  reference_amp33:
+    title: Amplifier 33 Reference Pixel Data for the Reference Read (DN)
+    description: |
+      Reference pixel data from amplifier 33 in units of data numbers (DNs)
+      for the reference read. This array is only present if a reference
+      read was used and downlinked.
+    tag: tag:stsci.edu:asdf/core/ndarray-1.*
+    ndim: 2
+    datatype: uint16
+    unit: "DN"
+    exact_datatype: true
+propertyOrder: [meta, data, amp33, resultantdq, reference_read, reference_amp33]
+flowStyle: block
+required: [meta, data, amp33]

--- a/src/rad/resources/schemas/wfi_science_raw-2.0.1.yaml
+++ b/src/rad/resources/schemas/wfi_science_raw-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_science_raw.yaml

--- a/src/rad/resources/schemas/wfi_wcs-2.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-2.0.0.yaml
@@ -1,1 +1,72 @@
-../../../../latest/wfi_wcs.yaml
+%YAML 1.1
+---
+$schema: asdf://stsci.edu/datamodels/roman/schemas/rad_schema-2.0.0
+id: asdf://stsci.edu/datamodels/roman/schemas/wfi_wcs-2.0.0
+
+title: Level 2 (L2) WCS information for Roman Wide Field Instrument (WFI) Rate Image.
+
+datamodel_name: WfiWcsModel
+
+type: object
+properties:
+  meta:
+    allOf:
+      - $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/basic-2.0.0
+      - type: object
+        properties:
+          coordinates:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/coordinates-2.0.0
+          ephemeris:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/ephemeris-2.0.0
+          exposure:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/exposure-2.0.0
+          instrument:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wfi_mode-2.0.0
+          observation:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/observation-2.0.0
+          pointing:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/pointing-2.0.0
+          program:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/program-2.0.0
+          velocity_aberration:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/velocity_aberration-2.0.0
+          visit:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/visit-2.0.0
+          wcsinfo:
+            $ref: asdf://stsci.edu/datamodels/roman/schemas/meta/wcsinfo-2.0.0
+          wcs_fit_results:
+            title: tweakreg/GAIA fit results
+            description: |
+              Results from the tweakreg result when aligning to GAIA.
+              If missing or None, GAIA alignment was not done or failed.
+            type: object
+        required:
+          [
+            coordinates,
+            ephemeris,
+            exposure,
+            instrument,
+            observation,
+            pointing,
+            program,
+            velocity_aberration,
+            visit,
+            wcsinfo,
+          ]
+  wcs_l2:
+    title: L2 GWCS
+    description: |
+      The GWCS object for the Level 2 product that generated it.
+      If the `tweakreg` step is successfully done, this will be the
+      GAIA-aligned wcs.
+    tag: tag:stsci.edu:gwcs/wcs-*
+  wcs_l1:
+    title: L1 GWCS
+    description: |
+      The GWCS object derived from the Level 2 GWCS but with an extra shift
+      and expanded bounding box to account for the larger data array size of
+      the Level 1 product.
+    tag: tag:stsci.edu:gwcs/wcs-*
+propertyOrder: [meta, wcs_l2, wcs_l1]
+flowStyle: block
+required: [meta]

--- a/src/rad/resources/schemas/wfi_wcs-2.0.1.yaml
+++ b/src/rad/resources/schemas/wfi_wcs-2.0.1.yaml
@@ -1,0 +1,1 @@
+../../../../latest/wfi_wcs.yaml


### PR DESCRIPTION
Adds DEFAULT as an allowed value of meta.ephemeris.type.  This is the 'patch release' version of #900 , enabling us to do a release only including the needed schema and nothing else.

Regression test using romancal/1.0.x and this PR: https://github.com/spacetelescope/RegressionTests/actions/runs/30575596848

## Tasks

- [X] Update relevant docstrings and / or `docs/` page.
- [X] Does this PR change any schema files?
  - [ ] Schema changes were discussed at RAD Review Board meeting.
- [X] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [X] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).
  - [X] Update relevant `roman_datamodels` utilities and tests.

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.removal.rst`: deprecation or removal of public API
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change

</details
